### PR TITLE
Changed agent type to mirror the type from the proxmox api

### DIFF
--- a/proxmox/resource_vm_qemu.go
+++ b/proxmox/resource_vm_qemu.go
@@ -48,9 +48,9 @@ func resourceVmQemu() *schema.Resource {
 				Default:  true,
 			},
 			"agent": {
-				Type:     schema.TypeString,
+				Type:     schema.TypeInt,
 				Optional: true,
-				Default:  "1",
+				Default:  1,
 			},
 			"iso": {
 				Type:     schema.TypeString,

--- a/proxmox/resource_vm_qemu.go
+++ b/proxmox/resource_vm_qemu.go
@@ -353,7 +353,7 @@ func resourceVmQemuCreate(d *schema.ResourceData, meta interface{}) error {
 		Name:         vmName,
 		Description:  d.Get("desc").(string),
 		Onboot:       d.Get("onboot").(bool),
-		Agent:        d.Get("agent").(string),
+		Agent:        d.Get("agent").(int),
 		Memory:       d.Get("memory").(int),
 		QemuCores:    d.Get("cores").(int),
 		QemuSockets:  d.Get("sockets").(int),


### PR DESCRIPTION
The agent value from the api is received as an integer instead of an string. Therefore applying terraform changes fails when the agent was active within the base image.

Fixes https://github.com/Telmate/terraform-provider-proxmox/issues/46