### PR TITLE
Feature/lxc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .idea
+examples/*_override.tf
 
 *~*
 *.bak

--- a/examples/lxc_example.tf
+++ b/examples/lxc_example.tf
@@ -6,18 +6,18 @@ provider "proxmox" {
 }
 
 resource "proxmox_lxc" "lxc-test" {
+    force = true
     hostname = "terraform-new-container"
-    ostemplate = "shared:vztmpl/centos-7-default_20171212_amd64.tar.xz"
-    target_node = "node-01"
-    network = {
+    network {
         id = 0
         name = "eth0"
         bridge = "vmbr0"
         ip = "dhcp"
         ip6 = "dhcp"
     }
-    storage = "local-lvm"
-    pool = "terraform"
+    ostemplate = "shared:vztmpl/centos-7-default_20171212_amd64.tar.xz"
     password = "rootroot"
-    force = true
+    pool = "terraform"
+    storage = "local-lvm"
+    target_node = "node-01"
 }

--- a/examples/lxc_example.tf
+++ b/examples/lxc_example.tf
@@ -1,0 +1,23 @@
+provider "proxmox" {
+    pm_tls_insecure = true
+    pm_api_url = "https://proxmox.org/api2/json"
+    pm_password = "supersecret"
+    pm_user = "terraform-user@pve"
+}
+
+resource "proxmox_lxc" "lxc-test" {
+    hostname = "terraform-test-container"
+    ostemplate = "shared:vztmpl/centos-7-default_20171212_amd64.tar.xz"
+    target_node = "node-01"
+    networks = [
+        {
+            name = "eth0"
+            bridge = "vmbr0"
+            ip = "dhcp"
+            ip6 = "dhcp"
+        }
+    ]
+    storage = "local-lvm"
+    pool = "terraform"
+    passsword = "rootroot"
+}

--- a/examples/lxc_example.tf
+++ b/examples/lxc_example.tf
@@ -6,7 +6,9 @@ provider "proxmox" {
 }
 
 resource "proxmox_lxc" "lxc-test" {
-    force = true
+    features {
+        nesting = true
+    }
     hostname = "terraform-new-container"
     network {
         id = 0
@@ -20,4 +22,5 @@ resource "proxmox_lxc" "lxc-test" {
     pool = "terraform"
     storage = "local-lvm"
     target_node = "node-01"
+    unprivileged = true
 }

--- a/examples/lxc_example.tf
+++ b/examples/lxc_example.tf
@@ -19,5 +19,5 @@ resource "proxmox_lxc" "lxc-test" {
     ]
     storage = "local-lvm"
     pool = "terraform"
-    passsword = "rootroot"
+    password = "rootroot"
 }

--- a/examples/lxc_example.tf
+++ b/examples/lxc_example.tf
@@ -6,18 +6,18 @@ provider "proxmox" {
 }
 
 resource "proxmox_lxc" "lxc-test" {
-    hostname = "terraform-test-container"
+    hostname = "terraform-new-container"
     ostemplate = "shared:vztmpl/centos-7-default_20171212_amd64.tar.xz"
     target_node = "node-01"
-    networks = [
-        {
-            name = "eth0"
-            bridge = "vmbr0"
-            ip = "dhcp"
-            ip6 = "dhcp"
-        }
-    ]
+    network = {
+        id = 0
+        name = "eth0"
+        bridge = "vmbr0"
+        ip = "dhcp"
+        ip6 = "dhcp"
+    }
     storage = "local-lvm"
     pool = "terraform"
     password = "rootroot"
+    force = true
 }

--- a/examples/lxc_example_override.tf
+++ b/examples/lxc_example_override.tf
@@ -1,0 +1,9 @@
+provider "proxmox" {
+    pm_api_url = "https://proxmox.wolke4.org/api2/json"
+    pm_password = "^U)kV+^Yv}9_KiXN6QY,3;NZO"
+    pm_user = "terraform@pve"
+}
+
+resource "proxmox_lxc" "lxc-test" {
+    target_node = "wolke4"
+}

--- a/examples/lxc_example_override.tf
+++ b/examples/lxc_example_override.tf
@@ -1,9 +1,0 @@
-provider "proxmox" {
-    pm_api_url = "https://proxmox.wolke4.org/api2/json"
-    pm_password = "^U)kV+^Yv}9_KiXN6QY,3;NZO"
-    pm_user = "terraform@pve"
-}
-
-resource "proxmox_lxc" "lxc-test" {
-    target_node = "wolke4"
-}

--- a/proxmox/provider.go
+++ b/proxmox/provider.go
@@ -58,6 +58,7 @@ func Provider() *schema.Provider {
 
 		ResourcesMap: map[string]*schema.Resource{
 			"proxmox_vm_qemu": resourceVmQemu(),
+			"proxmox_lxc": resourceLxc(),
 			// TODO - storage_iso
 			// TODO - bridge
 			// TODO - vm_qemu_template

--- a/proxmox/resource_lxc.go
+++ b/proxmox/resource_lxc.go
@@ -1,0 +1,142 @@
+package proxmox
+
+import (
+	pxapi "github.com/Telmate/proxmox-api-go/proxmox"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceLxc() *schema.Resource {
+	*pxapi.Debug = true
+	return &schema.Resource{
+		Create: resourceLxcCreate,
+		Read:   resourceLxcRead,
+		Update: resourceLxcUpdate,
+		Delete: resourceLxcDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"hostname": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"target_node": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"ostemplate": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"networks": &schema.Schema{
+				Type:          schema.TypeSet,
+				Optional:      true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": &schema.Schema{
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"bridge": &schema.Schema{
+							Type:     schema.TypeString,
+							Optional: true,
+							Default:  "vmbr0",
+						},
+						"ip": &schema.Schema{
+							Type:     schema.TypeString,
+							Optional: true,
+							Default:  "dhcp",
+						},
+						"ip6": &schema.Schema{
+							Type:     schema.TypeString,
+							Optional: true,
+							Default:  "dhcp",
+						},
+					},
+				},
+			},
+			"storage": {
+				Type:       schema.TypeString,
+				Optional:   true,
+				Default:    "local-lvm",
+			},
+			"pool": {
+				Type:       schema.TypeString,
+				Optional:   true,
+			},
+			"password": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+		},
+	}
+}
+
+func resourceLxcCreate(d *schema.ResourceData, meta interface{}) error {
+	pconf := meta.(*providerConfiguration)
+	pmParallelBegin(pconf)
+	client := pconf.Client
+	vmName := d.Get("hostname").(string)
+	networks := d.Get("networks").(*schema.Set)
+	lxcNetworks := lxcDevicesSetToMap(networks)
+
+	config := pxapi.ConfigLxc{
+                Ostemplate: d.Get("ostemplate").(string),
+		Storage:    d.Get("storage").(string),
+		Pool:       d.Get("pool").(string),
+                Password:   d.Get("password").(string),
+		Hostname:   vmName,
+		Networks:   lxcNetworks,
+	}
+
+	targetNode := d.Get("target_node").(string)
+	//vmr, _ := client.GetVmRefByName(vmName)
+
+	// get unique id
+	nextid, err := nextVmId(pconf)
+	if err != nil {
+		pmParallelEnd(pconf)
+		return err
+	}
+	vmr := pxapi.NewVmRef(nextid)
+	vmr.SetNode(targetNode)
+	err = config.CreateLxc(vmr, client)
+	if err != nil {
+		pmParallelEnd(pconf)
+		return err
+	}
+
+        // The existence of a non-blank ID is what tells Terraform that a resource was created
+	d.SetId(resourceId(targetNode, "lxc", vmr.VmId()))
+
+	return resourceLxcRead(d, meta)
+}
+
+func resourceLxcUpdate(d *schema.ResourceData, meta interface{}) error {
+	return resourceLxcRead(d, meta)
+}
+
+func resourceLxcRead(d *schema.ResourceData, meta interface{}) error {
+	return nil
+}
+
+func resourceLxcDelete(d *schema.ResourceData, meta interface{}) error {
+	return nil
+}
+
+func lxcDevicesSetToMap(devicesSet *schema.Set) pxapi.LxcDevices {
+
+	devicesMap := pxapi.LxcDevices{}
+
+	for _, set := range devicesSet.List() {
+		setMap, isMap := set.(map[string]interface{})
+		if isMap {
+			setID := setMap["id"].(int)
+			devicesMap[setID] = setMap
+		}
+	}
+	return devicesMap
+}

--- a/proxmox/resource_lxc.go
+++ b/proxmox/resource_lxc.go
@@ -24,7 +24,7 @@ func resourceLxc() *schema.Resource {
 			"arch": {
 				Type:     schema.TypeString,
 				Optional: true,
-                                Default:  "amd64",
+				Default:  "amd64",
 			},
 			"bwlimit": {
 				Type:     schema.TypeInt,
@@ -33,12 +33,12 @@ func resourceLxc() *schema.Resource {
 			"cmode": {
 				Type:     schema.TypeString,
 				Optional: true,
-                                Default:  "tty",
+				Default:  "tty",
 			},
 			"console": {
 				Type:     schema.TypeBool,
 				Optional: true,
-                                Default:  true,
+				Default:  true,
 			},
 			"cores": {
 				Type:     schema.TypeInt,
@@ -47,12 +47,12 @@ func resourceLxc() *schema.Resource {
 			"cpulimit": {
 				Type:     schema.TypeInt,
 				Optional: true,
-                                Default:  0,
+				Default:  0,
 			},
 			"cpuunits": {
 				Type:     schema.TypeInt,
 				Optional: true,
-                                Default:  1024,
+				Default:  1024,
 			},
 			"description": {
 				Type:     schema.TypeString,
@@ -105,7 +105,7 @@ func resourceLxc() *schema.Resource {
 			"memory": {
 				Type:     schema.TypeInt,
 				Optional: true,
-                                Default:  512,
+				Default:  512,
 			},
 			"mountpoint": {
 				Type:     schema.TypeSet,
@@ -222,7 +222,7 @@ func resourceLxc() *schema.Resource {
 			"onboot": {
 				Type:     schema.TypeBool,
 				Optional: true,
-                                Default:  false,
+				Default:  false,
 			},
 			"ostype": {
 				Type:     schema.TypeString,
@@ -239,7 +239,7 @@ func resourceLxc() *schema.Resource {
 			"protection": {
 				Type:     schema.TypeBool,
 				Optional: true,
-                                Default:  false,
+				Default:  false,
 			},
 			"restore": {
 				Type:     schema.TypeBool,
@@ -260,7 +260,7 @@ func resourceLxc() *schema.Resource {
 			"start": {
 				Type:     schema.TypeBool,
 				Optional: true,
-                                Default:  false,
+				Default:  false,
 			},
 			"startup": {
 				Type:     schema.TypeString,
@@ -274,7 +274,7 @@ func resourceLxc() *schema.Resource {
 			"swap": {
 				Type:     schema.TypeInt,
 				Optional: true,
-                                Default:  512,
+				Default:  512,
 			},
 			"template": {
 				Type:     schema.TypeBool,
@@ -283,7 +283,7 @@ func resourceLxc() *schema.Resource {
 			"tty": {
 				Type:     schema.TypeInt,
 				Optional: true,
-                                Default:  2,
+				Default:  2,
 			},
 			"unique": {
 				Type:     schema.TypeBool,
@@ -292,14 +292,14 @@ func resourceLxc() *schema.Resource {
 			"unprivileged": {
 				Type:     schema.TypeBool,
 				Optional: true,
-                                Default:  false,
+				Default:  false,
 			},
 			"unused": {
 				Type:     schema.TypeList,
 				Optional: true,
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
-                                },
+				},
 			},
 			"target_node": {
 				Type:     schema.TypeString,
@@ -316,7 +316,7 @@ func resourceLxcCreate(d *schema.ResourceData, meta interface{}) error {
 	client := pconf.Client
 	vmName := d.Get("hostname").(string)
 
-        config := pxapi.NewConfigLxc()
+	config := pxapi.NewConfigLxc()
 	config.Ostemplate = d.Get("ostemplate").(string)
 	config.Arch = d.Get("arch").(string)
 	config.BWLimit = d.Get("bwlimit").(int)
@@ -326,33 +326,33 @@ func resourceLxcCreate(d *schema.ResourceData, meta interface{}) error {
 	config.CPULimit = d.Get("cpulimit").(int)
 	config.CPUUnits = d.Get("cpuunits").(int)
 	config.Description = d.Get("description").(string)
-        features := d.Get("features").(*schema.Set)
+	features := d.Get("features").(*schema.Set)
 	featureSetList := features.List()
 	if len(featureSetList) > 0 {
-                // only apply the first feature set,
-                // because proxmox api only allows one feature set
+		// only apply the first feature set,
+		// because proxmox api only allows one feature set
 		config.Features = featureSetList[0].(map[string]interface{})
-        }
+	}
 	config.Force = d.Get("force").(bool)
 	config.Hookscript = d.Get("hookscript").(string)
 	config.Hostname = vmName
-        config.IgnoreUnpackErrors = d.Get("ignore_unpack_errors").(bool)
+	config.IgnoreUnpackErrors = d.Get("ignore_unpack_errors").(bool)
 	config.Lock = d.Get("lock").(string)
 	config.Memory = d.Get("memory").(int)
-        // proxmox api allows multiple mountpoint sets,
-        // having a unique 'id' parameter foreach set
+	// proxmox api allows multiple mountpoint sets,
+	// having a unique 'id' parameter foreach set
 	mountpoints := d.Get("mountpoint").(*schema.Set)
 	lxcMountpoints := DevicesSetToMap(mountpoints)
 	config.Mountpoints = lxcMountpoints
-        config.Nameserver = d.Get("nameserver").(string)
-        // proxmox api allows multiple network sets,
-        // having a unique 'id' parameter foreach set
+	config.Nameserver = d.Get("nameserver").(string)
+	// proxmox api allows multiple network sets,
+	// having a unique 'id' parameter foreach set
 	networks := d.Get("network").(*schema.Set)
 	lxcNetworks := DevicesSetToMap(networks)
-        config.Networks = lxcNetworks
+	config.Networks = lxcNetworks
 	config.OnBoot = d.Get("onboot").(bool)
-        config.OsType = d.Get("ostype").(string)
-        config.Password = d.Get("password").(string)
+	config.OsType = d.Get("ostype").(string)
+	config.Password = d.Get("password").(string)
 	config.Pool = d.Get("pool").(string)
 	config.Protection = d.Get("protection").(bool)
 	config.Restore = d.Get("restore").(bool)
@@ -367,13 +367,13 @@ func resourceLxcCreate(d *schema.ResourceData, meta interface{}) error {
 	config.Tty = d.Get("tty").(int)
 	config.Unique = d.Get("unique").(bool)
 	config.Unprivileged = d.Get("unprivileged").(bool)
-        // proxmox api allows to specify unused volumes
-        // even if it is recommended not to change them manually
+	// proxmox api allows to specify unused volumes
+	// even if it is recommended not to change them manually
 	unusedVolumes := d.Get("unused").([]interface{})
-        var volumes []string
-        for _, v := range unusedVolumes {
-            volumes = append(volumes, v.(string))
-        }
+	var volumes []string
+	for _, v := range unusedVolumes {
+		volumes = append(volumes, v.(string))
+	}
 	config.Unused = volumes
 
 	targetNode := d.Get("target_node").(string)
@@ -393,7 +393,7 @@ func resourceLxcCreate(d *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 
-        // The existence of a non-blank ID is what tells Terraform that a resource was created
+	// The existence of a non-blank ID is what tells Terraform that a resource was created
 	d.SetId(resourceId(targetNode, "lxc", vmr.VmId()))
 
 	return resourceLxcRead(d, meta)
@@ -416,7 +416,7 @@ func resourceLxcUpdate(d *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 
-        config := pxapi.NewConfigLxc()
+	config := pxapi.NewConfigLxc()
 	config.Ostemplate = d.Get("ostemplate").(string)
 	config.Arch = d.Get("arch").(string)
 	config.BWLimit = d.Get("bwlimit").(int)
@@ -426,33 +426,33 @@ func resourceLxcUpdate(d *schema.ResourceData, meta interface{}) error {
 	config.CPULimit = d.Get("cpulimit").(int)
 	config.CPUUnits = d.Get("cpuunits").(int)
 	config.Description = d.Get("description").(string)
-        features := d.Get("features").(*schema.Set)
+	features := d.Get("features").(*schema.Set)
 	featureSetList := features.List()
 	if len(featureSetList) > 0 {
-                // only apply the first feature set,
-                // because proxmox api only allows one feature set
+		// only apply the first feature set,
+		// because proxmox api only allows one feature set
 		config.Features = featureSetList[0].(map[string]interface{})
-        }
+	}
 	config.Force = d.Get("force").(bool)
 	config.Hookscript = d.Get("hookscript").(string)
 	config.Hostname = d.Get("hostname").(string)
-        config.IgnoreUnpackErrors = d.Get("ignore_unpack_errors").(bool)
+	config.IgnoreUnpackErrors = d.Get("ignore_unpack_errors").(bool)
 	config.Lock = d.Get("lock").(string)
 	config.Memory = d.Get("memory").(int)
-        // proxmox api allows multiple mountpoint sets,
-        // having a unique 'id' parameter foreach set
+	// proxmox api allows multiple mountpoint sets,
+	// having a unique 'id' parameter foreach set
 	mountpoints := d.Get("mountpoint").(*schema.Set)
 	lxcMountpoints := DevicesSetToMap(mountpoints)
 	config.Mountpoints = lxcMountpoints
-        config.Nameserver = d.Get("nameserver").(string)
-        // proxmox api allows multiple network sets,
-        // having a unique 'id' parameter foreach set
+	config.Nameserver = d.Get("nameserver").(string)
+	// proxmox api allows multiple network sets,
+	// having a unique 'id' parameter foreach set
 	networks := d.Get("network").(*schema.Set)
 	lxcNetworks := DevicesSetToMap(networks)
-        config.Networks = lxcNetworks
+	config.Networks = lxcNetworks
 	config.OnBoot = d.Get("onboot").(bool)
-        config.OsType = d.Get("ostype").(string)
-        config.Password = d.Get("password").(string)
+	config.OsType = d.Get("ostype").(string)
+	config.Password = d.Get("password").(string)
 	config.Pool = d.Get("pool").(string)
 	config.Protection = d.Get("protection").(bool)
 	config.Restore = d.Get("restore").(bool)
@@ -467,13 +467,13 @@ func resourceLxcUpdate(d *schema.ResourceData, meta interface{}) error {
 	config.Tty = d.Get("tty").(int)
 	config.Unique = d.Get("unique").(bool)
 	config.Unprivileged = d.Get("unprivileged").(bool)
-        // proxmox api allows to specify unused volumes
-        // even if it is recommended not to change them manually
+	// proxmox api allows to specify unused volumes
+	// even if it is recommended not to change them manually
 	unusedVolumes := d.Get("unused").([]interface{})
-        var volumes []string
-        for _, v := range unusedVolumes {
-            volumes = append(volumes, v.(string))
-        }
+	var volumes []string
+	for _, v := range unusedVolumes {
+		volumes = append(volumes, v.(string))
+	}
 	config.Unused = volumes
 
 	err = config.UpdateConfig(vmr, client)
@@ -519,7 +519,7 @@ func resourceLxcRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("description", config.Description)
 
 	defaultFeatures := d.Get("features").(*schema.Set)
-        featuresWithDefaults := UpdateDeviceConfDefaults(config.Features, defaultFeatures)
+	featuresWithDefaults := UpdateDeviceConfDefaults(config.Features, defaultFeatures)
 	d.Set("features", featuresWithDefaults)
 
 	d.Set("force", config.Force)

--- a/proxmox/resource_lxc.go
+++ b/proxmox/resource_lxc.go
@@ -17,19 +17,19 @@ func resourceLxc() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
-			"hostname": {
-				Type:     schema.TypeString,
-				Required: true,
-			},
-			"target_node": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
 			"ostemplate": {
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: true,
+			},
+			"force": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+			"hostname": {
+				Type:     schema.TypeString,
+				Required: true,
 			},
 			"networks": &schema.Schema{
 				Type:          schema.TypeSet,
@@ -58,23 +58,23 @@ func resourceLxc() *schema.Resource {
 					},
 				},
 			},
-			"storage": {
-				Type:       schema.TypeString,
-				Optional:   true,
-				Default:    "local-lvm",
+			"password": {
+				Type:     schema.TypeString,
+				Optional: true,
 			},
 			"pool": {
 				Type:       schema.TypeString,
 				Optional:   true,
 			},
-			"password": {
-				Type:     schema.TypeString,
-				Optional: true,
+			"storage": {
+				Type:       schema.TypeString,
+				Optional:   true,
+				Default:    "local-lvm",
 			},
-			"force": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				Default:  false,
+			"target_node": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
 			},
 		},
 	}

--- a/proxmox/resource_lxc.go
+++ b/proxmox/resource_lxc.go
@@ -415,10 +415,6 @@ func resourceLxcUpdate(d *schema.ResourceData, meta interface{}) error {
 		pmParallelEnd(pconf)
 		return err
 	}
-//	configDisksSet := d.Get("disk").(*schema.Set)
-//	qemuDisks := DevicesSetToMap(configDisksSet)
-//	configNetworksSet := d.Get("network").(*schema.Set)
-//	qemuNetworks := DevicesSetToMap(configNetworksSet)
 
         config := pxapi.NewConfigLxc()
 	config.Ostemplate = d.Get("ostemplate").(string)
@@ -480,19 +476,11 @@ func resourceLxcUpdate(d *schema.ResourceData, meta interface{}) error {
         }
 	config.Unused = volumes
 
-//	targetNode := d.Get("target_node").(string)
-
-
-
-
-
-
 	err = config.UpdateConfig(vmr, client)
 	if err != nil {
 		pmParallelEnd(pconf)
 		return err
 	}
-
 
 	return nil
 }

--- a/proxmox/resource_lxc.go
+++ b/proxmox/resource_lxc.go
@@ -22,54 +22,282 @@ func resourceLxc() *schema.Resource {
 				Optional: true,
 				ForceNew: true,
 			},
-			"force": {
+			"arch": {
+				Type:     schema.TypeString,
+				Optional: true,
+                                Default:  "amd64",
+			},
+			"bwlimit": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"cmode": {
+				Type:     schema.TypeString,
+				Optional: true,
+                                Default:  "tty",
+			},
+			"console": {
 				Type:     schema.TypeBool,
 				Optional: true,
-				Default:  false,
+                                Default:  true,
 			},
-			"hostname": {
+			"cores": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"cpulimit": {
+				Type:     schema.TypeInt,
+				Optional: true,
+                                Default:  0,
+			},
+			"cpuunits": {
+				Type:     schema.TypeInt,
+				Optional: true,
+                                Default:  1024,
+			},
+			"description": {
 				Type:     schema.TypeString,
-				Required: true,
+				Optional: true,
 			},
-			"networks": &schema.Schema{
-				Type:          schema.TypeSet,
-				Optional:      true,
+			"features": {
+				Type:     schema.TypeSet,
+				Optional: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"name": &schema.Schema{
-							Type:     schema.TypeString,
+						"fuse": {
+							Type:     schema.TypeBool,
 							Required: true,
 						},
-						"bridge": &schema.Schema{
-							Type:     schema.TypeString,
-							Optional: true,
-							Default:  "vmbr0",
+						"keyctl": {
+							Type:     schema.TypeBool,
+							Required: true,
 						},
-						"ip": &schema.Schema{
+						"mount": {
 							Type:     schema.TypeString,
 							Optional: true,
-							Default:  "dhcp",
 						},
-						"ip6": &schema.Schema{
-							Type:     schema.TypeString,
+						"nesting": {
+							Type:     schema.TypeBool,
 							Optional: true,
-							Default:  "dhcp",
 						},
 					},
 				},
+			},
+			"force": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+			"hookscript": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"hostname": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"ignore_unpack_errors": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+			"lock": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"memory": {
+				Type:     schema.TypeInt,
+				Optional: true,
+                                Default:  512,
+			},
+			"mountpoints": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeInt,
+							Required: true,
+						},
+						"volume": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"mp": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"acl": {
+							Type:     schema.TypeBool,
+							Optional: true,
+						},
+						"backup": {
+							Type:     schema.TypeBool,
+							Optional: true,
+						},
+						"quota": {
+							Type:     schema.TypeBool,
+							Optional: true,
+						},
+						"replicate": {
+							Type:     schema.TypeBool,
+							Optional: true,
+						},
+						"shared": {
+							Type:     schema.TypeBool,
+							Optional: true,
+						},
+						"size": {
+							Type:     schema.TypeInt,
+							Optional: true,
+						},
+					},
+				},
+			},
+			"nameserver": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"network": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeInt,
+							Required: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"bridge": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"firewall": {
+							Type:     schema.TypeBool,
+							Optional: true,
+						},
+						"gw": {
+							Type:     schema.TypeBool,
+							Optional: true,
+						},
+						"gw6": {
+							Type:     schema.TypeBool,
+							Optional: true,
+						},
+						"hwaddr": {
+							Type:     schema.TypeBool,
+							Optional: true,
+						},
+						"ip": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"ip6": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"mtu": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"rate": {
+							Type:     schema.TypeInt,
+							Optional: true,
+						},
+						"tag": {
+							Type:     schema.TypeInt,
+							Optional: true,
+						},
+						"trunks": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"type": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+					},
+				},
+			},
+			"onboot": {
+				Type:     schema.TypeBool,
+				Optional: true,
+                                Default:  false,
+			},
+			"ostype": {
+				Type:     schema.TypeString,
+				Optional: true,
 			},
 			"password": {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
 			"pool": {
-				Type:       schema.TypeString,
-				Optional:   true,
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"protection": {
+				Type:     schema.TypeBool,
+				Optional: true,
+                                Default:  false,
+			},
+			"restore": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+			"rootfs": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"searchdomain": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"ssh_public_keys": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"start": {
+				Type:     schema.TypeBool,
+				Optional: true,
+                                Default:  false,
+			},
+			"startup": {
+				Type:     schema.TypeString,
+				Optional: true,
 			},
 			"storage": {
-				Type:       schema.TypeString,
-				Optional:   true,
-				Default:    "local-lvm",
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "local",
+			},
+			"swap": {
+				Type:     schema.TypeInt,
+				Optional: true,
+                                Default:  512,
+			},
+			"template": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+			"tty": {
+				Type:     schema.TypeInt,
+				Optional: true,
+                                Default:  2,
+			},
+			"unique": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+			"unprivileged": {
+				Type:     schema.TypeBool,
+				Optional: true,
+                                Default:  false,
+			},
+			"unused": {
+				Type:     schema.TypeString,
+				Optional: true,
 			},
 			"target_node": {
 				Type:     schema.TypeString,
@@ -85,7 +313,7 @@ func resourceLxcCreate(d *schema.ResourceData, meta interface{}) error {
 	pmParallelBegin(pconf)
 	client := pconf.Client
 	vmName := d.Get("hostname").(string)
-	networks := d.Get("networks").(*schema.Set)
+	networks := d.Get("network").(*schema.Set)
 	lxcNetworks := DevicesSetToMap(networks)
 
         config := pxapi.NewConfigLxc()

--- a/proxmox/resource_lxc.go
+++ b/proxmox/resource_lxc.go
@@ -71,6 +71,11 @@ func resourceLxc() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
+			"force": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
 		},
 	}
 }
@@ -81,16 +86,15 @@ func resourceLxcCreate(d *schema.ResourceData, meta interface{}) error {
 	client := pconf.Client
 	vmName := d.Get("hostname").(string)
 	networks := d.Get("networks").(*schema.Set)
-	lxcNetworks := lxcDevicesSetToMap(networks)
+	lxcNetworks := DevicesSetToMap(networks)
 
-	config := pxapi.ConfigLxc{
-                Ostemplate: d.Get("ostemplate").(string),
-		Storage:    d.Get("storage").(string),
-		Pool:       d.Get("pool").(string),
-                Password:   d.Get("password").(string),
-		Hostname:   vmName,
-		Networks:   lxcNetworks,
-	}
+        config := pxapi.NewConfigLxc()
+	config.Ostemplate = d.Get("ostemplate").(string)
+	config.Hostname = vmName
+	config.Networks = lxcNetworks
+        config.Password = d.Get("password").(string)
+	config.Pool = d.Get("pool").(string)
+	config.Storage = d.Get("storage").(string)
 
 	targetNode := d.Get("target_node").(string)
 	//vmr, _ := client.GetVmRefByName(vmName)
@@ -125,18 +129,4 @@ func resourceLxcRead(d *schema.ResourceData, meta interface{}) error {
 
 func resourceLxcDelete(d *schema.ResourceData, meta interface{}) error {
 	return nil
-}
-
-func lxcDevicesSetToMap(devicesSet *schema.Set) pxapi.LxcDevices {
-
-	devicesMap := pxapi.LxcDevices{}
-
-	for _, set := range devicesSet.List() {
-		setMap, isMap := set.(map[string]interface{})
-		if isMap {
-			setID := setMap["id"].(int)
-			devicesMap[setID] = setMap
-		}
-	}
-	return devicesMap
 }

--- a/proxmox/resource_lxc.go
+++ b/proxmox/resource_lxc.go
@@ -400,7 +400,101 @@ func resourceLxcCreate(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceLxcUpdate(d *schema.ResourceData, meta interface{}) error {
-	return resourceLxcRead(d, meta)
+	pconf := meta.(*providerConfiguration)
+	pmParallelBegin(pconf)
+	client := pconf.Client
+
+	_, _, vmID, err := parseResourceId(d.Id())
+	if err != nil {
+		pmParallelEnd(pconf)
+		return err
+	}
+	vmr := pxapi.NewVmRef(vmID)
+	_, err = client.GetVmInfo(vmr)
+	if err != nil {
+		pmParallelEnd(pconf)
+		return err
+	}
+//	configDisksSet := d.Get("disk").(*schema.Set)
+//	qemuDisks := DevicesSetToMap(configDisksSet)
+//	configNetworksSet := d.Get("network").(*schema.Set)
+//	qemuNetworks := DevicesSetToMap(configNetworksSet)
+
+        config := pxapi.NewConfigLxc()
+	config.Ostemplate = d.Get("ostemplate").(string)
+	config.Arch = d.Get("arch").(string)
+	config.BWLimit = d.Get("bwlimit").(int)
+	config.CMode = d.Get("cmode").(string)
+	config.Console = d.Get("console").(bool)
+	config.Cores = d.Get("cores").(int)
+	config.CPULimit = d.Get("cpulimit").(int)
+	config.CPUUnits = d.Get("cpuunits").(int)
+	config.Description = d.Get("description").(string)
+        features := d.Get("features").(*schema.Set)
+	featureSetList := features.List()
+	if len(featureSetList) > 0 {
+                // only apply the first feature set,
+                // because proxmox api only allows one feature set
+		config.Features = featureSetList[0].(map[string]interface{})
+        }
+	config.Force = d.Get("force").(bool)
+	config.Hookscript = d.Get("hookscript").(string)
+	config.Hostname = d.Get("hostname").(string)
+        config.IgnoreUnpackErrors = d.Get("ignore_unpack_errors").(bool)
+	config.Lock = d.Get("lock").(string)
+	config.Memory = d.Get("memory").(int)
+        // proxmox api allows multiple mountpoint sets,
+        // having a unique 'id' parameter foreach set
+	mountpoints := d.Get("mountpoint").(*schema.Set)
+	lxcMountpoints := DevicesSetToMap(mountpoints)
+	config.Mountpoints = lxcMountpoints
+        config.Nameserver = d.Get("nameserver").(string)
+        // proxmox api allows multiple network sets,
+        // having a unique 'id' parameter foreach set
+	networks := d.Get("network").(*schema.Set)
+	lxcNetworks := DevicesSetToMap(networks)
+        config.Networks = lxcNetworks
+	config.OnBoot = d.Get("onboot").(bool)
+        config.OsType = d.Get("ostype").(string)
+        config.Password = d.Get("password").(string)
+	config.Pool = d.Get("pool").(string)
+	config.Protection = d.Get("protection").(bool)
+	config.Restore = d.Get("restore").(bool)
+	config.RootFs = d.Get("rootfs").(string)
+	config.SearchDomain = d.Get("searchdomain").(string)
+	config.SSHPublicKeys = d.Get("ssh_public_keys").(string)
+	config.Start = d.Get("start").(bool)
+	config.Startup = d.Get("startup").(string)
+	config.Storage = d.Get("storage").(string)
+	config.Swap = d.Get("swap").(int)
+	config.Template = d.Get("template").(bool)
+	config.Tty = d.Get("tty").(int)
+	config.Unique = d.Get("unique").(bool)
+	config.Unprivileged = d.Get("unprivileged").(bool)
+        // proxmox api allows to specify unused volumes
+        // even if it is recommended not to change them manually
+	unusedVolumes := d.Get("unused").([]interface{})
+        var volumes []string
+        for _, v := range unusedVolumes {
+            volumes = append(volumes, v.(string))
+        }
+	config.Unused = volumes
+
+//	targetNode := d.Get("target_node").(string)
+
+
+
+
+
+
+	err = config.UpdateConfig(vmr, client)
+	if err != nil {
+		pmParallelEnd(pconf)
+		return err
+	}
+
+
+	return nil
 }
 
 func resourceLxcRead(d *schema.ResourceData, meta interface{}) error {

--- a/proxmox/resource_lxc.go
+++ b/proxmox/resource_lxc.go
@@ -11,7 +11,7 @@ func resourceLxc() *schema.Resource {
 		Create: resourceLxcCreate,
 		Read:   resourceLxcRead,
 		Update: resourceLxcUpdate,
-		Delete: resourceLxcDelete,
+		Delete: resourceVmQemuDelete,
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},
@@ -560,9 +560,5 @@ func resourceLxcRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("unused", config.Unused)
 
 	pmParallelEnd(pconf)
-	return nil
-}
-
-func resourceLxcDelete(d *schema.ResourceData, meta interface{}) error {
 	return nil
 }

--- a/proxmox/resource_vm_qemu.go
+++ b/proxmox/resource_vm_qemu.go
@@ -615,11 +615,11 @@ func resourceVmQemuRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("ipconfig1", config.Ipconfig1)
 	// Disks.
 	configDisksSet := d.Get("disk").(*schema.Set)
-	activeDisksSet := updateDevicesSet(configDisksSet, config.QemuDisks)
+	activeDisksSet := UpdateDevicesSet(configDisksSet, config.QemuDisks)
 	d.Set("disk", activeDisksSet)
 	// Networks.
 	configNetworksSet := d.Get("network").(*schema.Set)
-	activeNetworksSet := updateDevicesSet(configNetworksSet, config.QemuNetworks)
+	activeNetworksSet := UpdateDevicesSet(configNetworksSet, config.QemuNetworks)
 	d.Set("network", activeNetworksSet)
 	// Deprecated single disk config.
 	d.Set("storage", config.Storage)
@@ -722,12 +722,13 @@ func DevicesSetToMap(devicesSet *schema.Set) pxapi.QemuDevices {
 
 // Update schema.TypeSet with new values comes from Proxmox API.
 // TODO: Maybe it's better to create a new Set instead add to current one.
-func updateDevicesSet(
+func UpdateDevicesSet(
 	devicesSet *schema.Set,
 	devicesMap pxapi.QemuDevices,
 ) *schema.Set {
 
 	configDevicesMap := DevicesSetToMap(devicesSet)
+
 	activeDevicesMap := updateDevicesDefaults(devicesMap, configDevicesMap)
 
 	for _, setConf := range devicesSet.List() {

--- a/proxmox/resource_vm_qemu.go
+++ b/proxmox/resource_vm_qemu.go
@@ -354,9 +354,9 @@ func resourceVmQemuCreate(d *schema.ResourceData, meta interface{}) error {
 	client := pconf.Client
 	vmName := d.Get("name").(string)
 	networks := d.Get("network").(*schema.Set)
-	qemuNetworks := devicesSetToMap(networks)
+	qemuNetworks := DevicesSetToMap(networks)
 	disks := d.Get("disk").(*schema.Set)
-	qemuDisks := devicesSetToMap(disks)
+	qemuDisks := DevicesSetToMap(disks)
 
 	config := pxapi.ConfigQemu{
 		Name:         vmName,
@@ -504,9 +504,9 @@ func resourceVmQemuUpdate(d *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 	configDisksSet := d.Get("disk").(*schema.Set)
-	qemuDisks := devicesSetToMap(configDisksSet)
+	qemuDisks := DevicesSetToMap(configDisksSet)
 	configNetworksSet := d.Get("network").(*schema.Set)
-	qemuNetworks := devicesSetToMap(configNetworksSet)
+	qemuNetworks := DevicesSetToMap(configNetworksSet)
 
 	config := pxapi.ConfigQemu{
 		Name:         d.Get("name").(string),
@@ -706,7 +706,7 @@ func diskSizeGB(dcSize interface{}) float64 {
 
 // Converting from schema.TypeSet to map of id and conf for each device,
 // which will be sent to Proxmox API.
-func devicesSetToMap(devicesSet *schema.Set) pxapi.QemuDevices {
+func DevicesSetToMap(devicesSet *schema.Set) pxapi.QemuDevices {
 
 	devicesMap := pxapi.QemuDevices{}
 
@@ -727,7 +727,7 @@ func updateDevicesSet(
 	devicesMap pxapi.QemuDevices,
 ) *schema.Set {
 
-	configDevicesMap := devicesSetToMap(devicesSet)
+	configDevicesMap := DevicesSetToMap(devicesSet)
 	activeDevicesMap := updateDevicesDefaults(devicesMap, configDevicesMap)
 
 	for _, setConf := range devicesSet.List() {

--- a/proxmox/util.go
+++ b/proxmox/util.go
@@ -10,7 +10,7 @@ func UpdateDeviceConfDefaults(
 	activeDeviceConf pxapi.QemuDevice,
 	defaultDeviceConf *schema.Set,
 ) *schema.Set {
-        defaultDeviceConfMap := defaultDeviceConf.List()[0].(map[string]interface{})
+	defaultDeviceConfMap := defaultDeviceConf.List()[0].(map[string]interface{})
 	for key, _ := range defaultDeviceConfMap {
 		if deviceConfigValue, ok := activeDeviceConf[key]; ok {
 			defaultDeviceConfMap[key] = deviceConfigValue

--- a/proxmox/util.go
+++ b/proxmox/util.go
@@ -1,0 +1,33 @@
+package proxmox
+
+import (
+	"strconv"
+	pxapi "github.com/Telmate/proxmox-api-go/proxmox"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func UpdateDeviceConfDefaults(
+	activeDeviceConf pxapi.QemuDevice,
+	defaultDeviceConf *schema.Set,
+) *schema.Set {
+        defaultDeviceConfMap := defaultDeviceConf.List()[0].(map[string]interface{})
+	for key, _ := range defaultDeviceConfMap {
+		if deviceConfigValue, ok := activeDeviceConf[key]; ok {
+			defaultDeviceConfMap[key] = deviceConfigValue
+			switch deviceConfigValue.(type) {
+			case int:
+				sValue := strconv.Itoa(deviceConfigValue.(int))
+				bValue, err := strconv.ParseBool(sValue)
+				if err == nil {
+					defaultDeviceConfMap[key] = bValue
+				}
+			default:
+				defaultDeviceConfMap[key] = deviceConfigValue
+			}
+		}
+	}
+	defaultDeviceConf.Remove(defaultDeviceConf.List()[0])
+	defaultDeviceConf.Add(defaultDeviceConfMap)
+	return defaultDeviceConf
+}
+


### PR DESCRIPTION
This change adds CRUD functionality for LXC containers by adding the new resource type `proxmox_lxc`.

* An example is provided in `examples/lxc_example.tf`
* The parameters for `resourceLxc` are derived from the [Proxmox API documentation](https://pve.proxmox.com/pve-docs/api-viewer/index.html)
* I would like to reuse `devicesSetToMap` and `updateDevicesSet`, therefore, I exported these functions in `QemuDevices`.
* Because I feel like there is more functionality that could be potentially shared between the two resource types, I created the utility file `util.go`. Maybe it would be better to place the logic of `DevicesSetToMap` and `UpdateDevicesSet` there as well.
* The changes depend on https://github.com/Telmate/proxmox-api-go/pull/34