### PR TITLE
Support setting pool for new VMs and clones (cloud-init)

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,10 @@ resource "proxmox_vm_qemu" "cloudinit-test" {
   target_node = "proxmox1-xx"
 
   clone = "ci-ubuntu-template"
+
+  # The destination resource pool for the new VM
+  pool = "pool0"
+
   storage = "local"
   cores = 3
   sockets = 1
@@ -105,6 +109,10 @@ resource "proxmox_vm_qemu" "prepprovision-test" {
   target_node = "proxmox1-xx"
 
   clone = "terraform-ubuntu1404-template"
+
+  # The destination resource pool for the new VM
+  pool = "pool0"
+
   cores = 3
   sockets = 1
   memory = 2560

--- a/examples/cloudinit_example.tf
+++ b/examples/cloudinit_example.tf
@@ -13,6 +13,9 @@ resource "proxmox_vm_qemu" "cloudinit-test" {
     # this might not include the FQDN
     target_node = "proxmox-server02"
 
+    # The destination resource pool for the new VM
+    pool = "pool0"
+
     # The template name to clone this vm from
     clone = "linux-cloudinit-template"
 


### PR DESCRIPTION
This allows to set the resource pool for a new VM. Without this change, the VM creation will fail for non-root users. With this change, the VM can be created in a particular resource group (supports creation by iso image or as clone from an existing template). The example and Readme file are amended accordingly.

This change depends on https://github.com/Telmate/proxmox-api-go/pull/38