### PR TITLE
Fix Cloud-init resizing

### DIFF
--- a/proxmox/resource_vm_qemu.go
+++ b/proxmox/resource_vm_qemu.go
@@ -777,11 +777,24 @@ func prepareDiskSize(
 
 func diskSizeGB(dcSize interface{}) float64 {
 	var diskSize float64
-	// TODO support other units M/G/K
 	switch dcSize.(type) {
 	case string:
-		diskSizeGB := dcSize.(string)
-		diskSize, _ = strconv.ParseFloat(strings.Trim(diskSizeGB, "G"), 64)
+		diskString := strings.ToUpper(dcSize.(string))
+		re := regexp.MustCompile("([0-9]+)([A-Z]*)")
+		diskArray := re.FindStringSubmatch(diskString)
+		
+		diskSize, _ = strconv.ParseFloat(diskArray[1], 64)
+		
+		if len(diskArray) >= 3 {
+			switch diskArray[2] {
+			case "G", "GB":
+				//Nothing to do
+			case "M", "MB":
+				diskSize /= 1000
+			case "K", "KB":
+				diskSize /= 1000000
+			}
+		}
 	case float64:
 		diskSize = dcSize.(float64)
 	}


### PR DESCRIPTION
Cloud init is returning a disk size in MB and the function diskSizeGB was not able to convert it in GB so the new disk size was not the wanted one.
I have also added support for other units, will be useful for the future.