### PR TITLE
Check feature list length

### DIFF
--- a/proxmox/resource_lxc.go
+++ b/proxmox/resource_lxc.go
@@ -519,8 +519,10 @@ func resourceLxcRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("description", config.Description)
 
 	defaultFeatures := d.Get("features").(*schema.Set)
-	featuresWithDefaults := UpdateDeviceConfDefaults(config.Features, defaultFeatures)
-	d.Set("features", featuresWithDefaults)
+	if len(defaultFeatures.List()) > 0 {
+		featuresWithDefaults := UpdateDeviceConfDefaults(config.Features, defaultFeatures)
+		d.Set("features", featuresWithDefaults)
+	}
 
 	d.Set("force", config.Force)
 	d.Set("hookscript", config.Hookscript)


### PR DESCRIPTION
This fixes the following error, when trying to create an lxc container without any features (as non-root user):
```
2019-10-03T06:11:28.596+0200 [DEBUG] plugin.terraform-provider-proxmox: 	/home/andi/gocode/src/github.com/Telmate/terraform-provider-proxmox/proxmox/resource_lxc.go:522 +0x5e9
```

Terraform example:
```
resource "proxmox_lxc" "lxc-test" {
    # features {
    #     nesting = true
    # }
    hostname = "tf1"
    network {
        id = 0
        name = "eth0"
        bridge = "vmbr0"
        ip = "dhcp"
        ip6 = "dhcp"
    }
    ostemplate = "shared:vztmpl/centos-7-default_20171212_amd64.tar.xz"
    password = "rootroot"
    pool = "pool1"
    storage = "local-lvm"
    target_node = "node1"
}