### PR TITLE
LXC: Remove Device IDs

### DIFF
--- a/examples/lxc_example.tf
+++ b/examples/lxc_example.tf
@@ -12,7 +12,6 @@ resource "proxmox_lxc" "lxc-test" {
     }
     hostname = "terraform-new-container"
     network {
-        id = 0
         name = "eth0"
         bridge = "vmbr0"
         ip = "dhcp"

--- a/proxmox/util.go
+++ b/proxmox/util.go
@@ -31,3 +31,41 @@ func UpdateDeviceConfDefaults(
 	return defaultDeviceConf
 }
 
+func DevicesSetToMapWithoutId(devicesSet *schema.Set) pxapi.QemuDevices {
+
+	devicesMap := pxapi.QemuDevices{}
+	i := 1
+	for _, set := range devicesSet.List() {
+		setMap, isMap := set.(map[string]interface{})
+		if isMap {
+			// setMap["id"] = i
+			devicesMap[i] = setMap
+			i += 1
+		}
+	}
+	return devicesMap
+}
+
+func AddIds(configSet *schema.Set) *schema.Set {
+	// add device config ids
+	var i = 1
+	for _, setConf := range configSet.List() {
+		configSet.Remove(setConf)
+		setConfMap := setConf.(map[string]interface{})
+		setConfMap["id"] = i
+		i += 1
+		configSet.Add(setConfMap)
+	}
+	return configSet
+}
+
+func RemoveIds(configSet *schema.Set) *schema.Set {
+	// remove device config ids
+	for _, setConf := range configSet.List() {
+		configSet.Remove(setConf)
+		setConfMap := setConf.(map[string]interface{})
+		delete(setConfMap, "id")
+		configSet.Add(setConfMap)
+	}
+	return configSet
+}


### PR DESCRIPTION
It is impossible to create LXC containers with more than one network interface, because the code of the Terraform provider includes the [device id](https://github.com/Telmate/terraform-provider-proxmox/blob/master/examples/lxc_example.tf#L15) in the request to the [PVE API](https://pve.proxmox.com/pve-docs/api-viewer/). The API, however, does not accept such a parameter (`id`).

This change fixes that issue, such that containers with multiple network devices can be created.

This change removes the device ids as discussed in #98.

The question remains, why ids for devices (network, disk, etc) need to be specified by Terraform users in the first place. Since I relied on [`DevicesSetToMap`](https://github.com/Telmate/terraform-provider-proxmox/blob/master/proxmox/resource_vm_qemu.go#L833) to parse the device configuration, this fix pursues the following approach:
* remove device IDs from the Terraform `schema.Set`
* add the IDs whenever needed to use `DevicesSetToMap` (`AddIds`)
* for API requests, make sure the the device configuration does not contain the ID (`DevicesSetToMapWithoutId`, `RemoveIds`)