### PR TITLE
Set id when updateconfig fail

### DIFF
--- a/proxmox/resource_vm_qemu.go
+++ b/proxmox/resource_vm_qemu.go
@@ -388,9 +388,9 @@ func resourceVmQemu() *schema.Resource {
 				Optional: true,
 			},
 			"ipconfig2": {
-                                Type:     schema.TypeString,
-                                Optional: true,
-                        },
+				Type:     schema.TypeString,
+				Optional: true,
+			},
 			"preprovision": {
 				Type:          schema.TypeBool,
 				Optional:      true,
@@ -512,6 +512,8 @@ func resourceVmQemuCreate(d *schema.ResourceData, meta interface{}) error {
 			log.Print("[DEBUG] cloning VM")
 			err = config.CloneVm(sourceVmr, vmr, client)
 			if err != nil {
+				// Set the id because when update config fail the vm is still created
+				d.SetId(resourceId(targetNode, "qemu", vmr.VmId()))
 				pmParallelEnd(pconf)
 				return err
 			}
@@ -542,6 +544,8 @@ func resourceVmQemuCreate(d *schema.ResourceData, meta interface{}) error {
 
 		err := config.UpdateConfig(vmr, client)
 		if err != nil {
+			// Set the id because when update config fail the vm is still created
+			d.SetId(resourceId(targetNode, "qemu", vmr.VmId()))
 			pmParallelEnd(pconf)
 			return err
 		}


### PR DESCRIPTION
When the method [``UpdateConfig``](https://github.com/Telmate/proxmox-api-go/blob/dd1ec5917265ff7e35723684968818a3fce51334/proxmox/config_qemu.go#L182) fail for an http 400 response the VM is created on the cluster but the Terraform's state doesn't persist the vm id.

If we set the id and return an error terraform create the resource state but tainted this resource. 

:warning: This PR required the merge of PR [Telmate/proxmox-api-go#60](https://github.com/Telmate/proxmox-api-go/pull/60) to update the go.mod. 