### PR TITLE
Allow specifying cloudinit_cdrom_storage to add a CloudInit Drive

### DIFF
--- a/proxmox/resource_vm_qemu.go
+++ b/proxmox/resource_vm_qemu.go
@@ -183,6 +183,10 @@ func resourceVmQemu() *schema.Resource {
 				Optional: true,
 				ForceNew: true,
 			},
+			"cloudinit_cdrom_storage": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
 			"full_clone": {
 				Type:     schema.TypeBool,
 				Optional: true,
@@ -879,6 +883,17 @@ func resourceVmQemuCreate(d *schema.ResourceData, meta interface{}) error {
 	}
 	d.SetId(resourceId(targetNode, "qemu", vmr.VmId()))
 	logger.Debug().Int("vmid", vmr.VmId()).Msgf("Set this vm (resource Id) to '%v'", d.Id())
+
+	if d.Get("cloudinit_cdrom_storage").(string) != "" {
+		vmParams := map[string]interface{}{
+			"cdrom": fmt.Sprintf("%s:cloudinit", d.Get("cloudinit_cdrom_storage").(string)),
+		}
+
+		_, err := client.SetVmConfig(vmr, vmParams)
+		if err != nil {
+			return err
+		}
+	}
 
 	// give sometime to proxmox to catchup
 	time.Sleep(time.Duration(d.Get("additional_wait").(int)) * time.Second)


### PR DESCRIPTION
If you have a Proxmox QEMU template that supports cloud-init (perhaps you ran 'apt-get install cloud-init' during installation) then you need a "CloudInit Drive" attached to the VM to be able to pass the cloud-init parameters to the guest.  This adds a parameter 'cloudinit_cdrom_storage' that will configure a CloudInit Drive stored on the storage you specify. For example: cloudinit_cdrom_storage = "local-lvm".

Proxmox has an unfortunate "magic syntax" for these devices. Their documentation suggests that you do a 'config set' on a created template for something like 'local-lvm:cloudinit' to make it work.  Using a disk {} clause in the existing proxmox resource hierarchy doesn't work.