### PR TITLE
Do not create resource when clone fail

### DIFF
--- a/proxmox/resource_vm_qemu.go
+++ b/proxmox/resource_vm_qemu.go
@@ -520,6 +520,13 @@ func resourceVmQemuCreate(d *schema.ResourceData, meta interface{}) error {
 			}
 			log.Print("[DEBUG] cloning VM")
 			err = config.CloneVm(sourceVmr, vmr, client)
+
+			if err != nil {
+				pmParallelEnd(pconf)
+				return err
+			}
+
+			err = config.UpdateConfig(vmr, client)
 			if err != nil {
 				// Set the id because when update config fail the vm is still created
 				d.SetId(resourceId(targetNode, "qemu", vmr.VmId()))


### PR DESCRIPTION
This PR required the PR 63 on [proxmox-api-go](https://github.com/Telmate/proxmox-api-go/pull/63).

On a previous PR #108 i set the id when I clone VM. 

But when  cloning fail on Proxmox the resource is not created.

But the method cloning method on the promox-api-go clone and configure the vm in the same method.

So i split the cloning and the configuration to set the id only if clone success. 

