### PR TITLE
Support setting the BIOS implementation (seabios|ovmf)

### DIFF
--- a/proxmox/resource_vm_qemu.go
+++ b/proxmox/resource_vm_qemu.go
@@ -41,6 +41,11 @@ func resourceVmQemu() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 			},
+			"bios": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "seabios",
+			},
 			"onboot": {
 				Type:     schema.TypeBool,
 				Optional: true,
@@ -498,6 +503,7 @@ func resourceVmQemuCreate(d *schema.ResourceData, meta interface{}) error {
 		Name:         vmName,
 		Description:  d.Get("desc").(string),
 		Pool:         d.Get("pool").(string),
+		Bios:         d.Get("bios").(string),
 		Onboot:       d.Get("onboot").(bool),
 		Boot:         d.Get("boot").(string),
 		BootDisk:     d.Get("bootdisk").(string),
@@ -695,6 +701,7 @@ func resourceVmQemuUpdate(d *schema.ResourceData, meta interface{}) error {
 		Name:         d.Get("name").(string),
 		Description:  d.Get("desc").(string),
 		Pool:         d.Get("pool").(string),
+		Bios:         d.Get("bios").(string),
 		Onboot:       d.Get("onboot").(bool),
 		Boot:         d.Get("boot").(string),
 		BootDisk:     d.Get("bootdisk").(string),
@@ -798,6 +805,7 @@ func resourceVmQemuRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("name", config.Name)
 	d.Set("desc", config.Description)
 	d.Set("pool", config.Pool)
+	d.Set("bios", config.Bios)
 	d.Set("onboot", config.Onboot)
 	d.Set("boot", config.Boot)
 	d.Set("bootdisk", config.BootDisk)


### PR DESCRIPTION
This allows booting UEFI VMs.

This requires: https://github.com/Telmate/proxmox-api-go/pull/69.