### PR TITLE
lxc: Change hwaddr type to string

### DIFF
--- a/proxmox/resource_lxc.go
+++ b/proxmox/resource_lxc.go
@@ -177,7 +177,7 @@ func resourceLxc() *schema.Resource {
 							Optional: true,
 						},
 						"hwaddr": {
-							Type:     schema.TypeBool,
+							Type:     schema.TypeString,
 							Optional: true,
 						},
 						"ip": {


### PR DESCRIPTION
Similar to #92, this changes the `hwaddr` field for the lxc resource to a string. Tested with TF 0.12.18 and PVE 5.4-13.