### PR TITLE
Remove obsolete setup commands from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,6 @@ Note: this plugin is both a provider and provisioner in one, which is why it nee
 Requires https://github.com/Telmate/proxmox-api-go
 
 ```
-export GOPATH=`pwd`
-make setup
 make
 make install
 ```


### PR DESCRIPTION
After #106 there's no setup target in the makefile, and $GOPATH should be a non-issue.

Thanks for building and sharing this prototype!