### PR TITLE
WIP: Create additional disks when template cloning

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,3 +6,4 @@ require (
 	github.com/Telmate/proxmox-api-go v0.0.0-20191217000250-7338ae30b9b0
 	github.com/hashicorp/terraform v0.12.10
 )
+replace github.com/Telmate/proxmox-api-go => github.com/claudusd/proxmox-api-go cloned_update_config

--- a/proxmox/resource_vm_qemu.go
+++ b/proxmox/resource_vm_qemu.go
@@ -596,7 +596,7 @@ func resourceVmQemuCreate(d *schema.ResourceData, meta interface{}) error {
 				return err
 			}
 
-			err = config.UpdateConfig(vmr, client)
+			err = config.UpdateConfig(vmr, client, true)
 			if err != nil {
 				// Set the id because when update config fail the vm is still created
 				d.SetId(resourceId(targetNode, "qemu", vmr.VmId()))
@@ -628,7 +628,7 @@ func resourceVmQemuCreate(d *schema.ResourceData, meta interface{}) error {
 
 		client.StopVm(vmr)
 
-		err := config.UpdateConfig(vmr, client)
+		err := config.UpdateConfig(vmr, client, false)
 		if err != nil {
 			// Set the id because when update config fail the vm is still created
 			d.SetId(resourceId(targetNode, "qemu", vmr.VmId()))
@@ -749,7 +749,7 @@ func resourceVmQemuUpdate(d *schema.ResourceData, meta interface{}) error {
 		config.QemuVga = qemuVgaList[0].(map[string]interface{})
 	}
 
-	err = config.UpdateConfig(vmr, client)
+	err = config.UpdateConfig(vmr, client, false)
 	if err != nil {
 		pmParallelEnd(pconf)
 		return err


### PR DESCRIPTION
Hi, 

VM creation  doesn't create additional disk when template cloning. And creation fail because the provider try ti resize unknown disk.

This PR add the disk creation for template cloning. 