### PR TITLE
Fix macaddr, optional + computed is problematic

### DIFF
--- a/docs/resource_vm_qemu.md
+++ b/docs/resource_vm_qemu.md
@@ -109,7 +109,8 @@ The following arguments are supported in the resource block:
 * `network` - (Optional)
     * `id` (Required)
     * `model` (Required)
-    * `macaddr` (Optional)
+    * `mac_manual` (Optional) Use if you to pass a manual mac address.
+    * `macaddr` (Computed) Will be either the automatic assigned address by Proxmox or the manual value of `mac_manual`.
     * `bridge` (Optional; defaults to nat)
     * `tag` (Optional; defaults to -1)
     * `firewall` (Optional; defaults to false)

--- a/proxmox/resource_vm_qemu.go
+++ b/proxmox/resource_vm_qemu.go
@@ -175,7 +175,7 @@ func resourceVmQemu() *schema.Resource {
 						"mac_manual": &schema.Schema{
 						    Type:     schema.TypeString,
 						    Optional: true,
-						}
+						},
 						"macaddr": &schema.Schema{
 							Type:     schema.TypeString,
 							Computed: true,

--- a/proxmox/resource_vm_qemu.go
+++ b/proxmox/resource_vm_qemu.go
@@ -494,8 +494,9 @@ func resourceVmQemuCreate(d *schema.ResourceData, meta interface{}) error {
 	qemuDisks := DevicesSetToMap(disks)
 	serials := d.Get("serial").(*schema.Set)
 	qemuSerials := DevicesSetToMap(serials)
-	if d.Get("mac_manual").(string) != "" {
-		d.Set("macaddr", d.Get("mac_manual").(string))
+	mac_manual := d.Get("mac_manual")
+	if mac_manual != nil && mac_manual.(string) != "" {
+		d.Set("macaddr", mac_manual.(string))
 	}
 
 	config := pxapi.ConfigQemu{
@@ -691,8 +692,9 @@ func resourceVmQemuUpdate(d *schema.ResourceData, meta interface{}) error {
 	qemuNetworks := DevicesSetToMap(configNetworksSet)
 	serials := d.Get("serial").(*schema.Set)
 	qemuSerials := DevicesSetToMap(serials)
-	if d.Get("mac_manual").(string) != "" {
-		d.Set("macaddr", d.Get("mac_manual").(string))
+	mac_manual := d.Get("mac_manual")
+	if mac_manual != nil && mac_manual.(string) != "" {
+		d.Set("macaddr", mac_manual.(string))
 	}
 
 	d.Partial(true)

--- a/proxmox/resource_vm_qemu.go
+++ b/proxmox/resource_vm_qemu.go
@@ -172,10 +172,12 @@ func resourceVmQemu() *schema.Resource {
 							Type:     schema.TypeString,
 							Required: true,
 						},
+						"mac_manual": &schema.Schema{
+						    Type:     schema.TypeString,
+						    Optional: true,
+						}
 						"macaddr": &schema.Schema{
-							// TODO: Find a way to set MAC address in .tf config.
 							Type:     schema.TypeString,
-							Optional: true,
 							Computed: true,
 						},
 						"bridge": &schema.Schema{
@@ -492,6 +494,9 @@ func resourceVmQemuCreate(d *schema.ResourceData, meta interface{}) error {
 	qemuDisks := DevicesSetToMap(disks)
 	serials := d.Get("serial").(*schema.Set)
 	qemuSerials := DevicesSetToMap(serials)
+	if d.Get("mac_manual").(string) != "" {
+		d.Set("macaddr", d.Get("mac_manual").(string))
+	}
 
 	config := pxapi.ConfigQemu{
 		Name:         vmName,
@@ -686,6 +691,9 @@ func resourceVmQemuUpdate(d *schema.ResourceData, meta interface{}) error {
 	qemuNetworks := DevicesSetToMap(configNetworksSet)
 	serials := d.Get("serial").(*schema.Set)
 	qemuSerials := DevicesSetToMap(serials)
+	if d.Get("mac_manual").(string) != "" {
+		d.Set("macaddr", d.Get("mac_manual").(string))
+	}
 
 	d.Partial(true)
 	if d.HasChange("target_node") {

--- a/proxmox/resource_vm_qemu.go
+++ b/proxmox/resource_vm_qemu.go
@@ -343,7 +343,7 @@ func resourceVmQemu() *schema.Resource {
 			},
 			"mac": {
 				Type:       schema.TypeString,
-				Deprecated: "Use `network.macaddr` to access the auto generated MAC address",
+				Deprecated: "Use `network.macaddr` to access the auto generated MAC address, or `mac_manual` to set it manually",
 				Optional:   true,
 				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
 					if new == "" {
@@ -490,14 +490,15 @@ func resourceVmQemuCreate(d *schema.ResourceData, meta interface{}) error {
 	qemuVgaList := vga.List()
 	networks := d.Get("network").(*schema.Set)
 	qemuNetworks := DevicesSetToMap(networks)
+	mac_manual := networks.Get("mac_manual")
+	if mac_manual != nil && mac_manual.(string) != "" {
+		qemuNetworks["macaddr"] = mac_manual.(string))
+	}
+    delete(qemuNetworks, "mac_manual")
 	disks := d.Get("disk").(*schema.Set)
 	qemuDisks := DevicesSetToMap(disks)
 	serials := d.Get("serial").(*schema.Set)
 	qemuSerials := DevicesSetToMap(serials)
-	mac_manual := d.Get("mac_manual")
-	if mac_manual != nil && mac_manual.(string) != "" {
-		d.Set("macaddr", mac_manual.(string))
-	}
 
 	config := pxapi.ConfigQemu{
 		Name:         vmName,
@@ -690,12 +691,13 @@ func resourceVmQemuUpdate(d *schema.ResourceData, meta interface{}) error {
 	qemuVgaList := vga.List()
 	configNetworksSet := d.Get("network").(*schema.Set)
 	qemuNetworks := DevicesSetToMap(configNetworksSet)
+	mac_manual := configNetworksSet.Get("mac_manual")
+	if mac_manual != nil && mac_manual.(string) != "" {
+        qemuNetworks["macaddr"] = mac_manual.(string))
+    }
+    delete(qemuNetworks, "mac_manual")
 	serials := d.Get("serial").(*schema.Set)
 	qemuSerials := DevicesSetToMap(serials)
-	mac_manual := d.Get("mac_manual")
-	if mac_manual != nil && mac_manual.(string) != "" {
-		d.Set("macaddr", mac_manual.(string))
-	}
 
 	d.Partial(true)
 	if d.HasChange("target_node") {


### PR DESCRIPTION
We have had several fixes already for this problem. The key issue is that `macaddr` is calculated by Proxmox automatically in the majority of cases, but some might want to pass a specific mac address. When using a computed + optional property you have a remaining limitation. 

Suppose a resource was created without supplying the mac address manually. The mac address is thus computed. Then an update is executed. Now the mac address is missing. Because we are using an optional + computed property, Terraform sees this as a missing value, and wants to update the resource. However, there is no update, because macaddr was never set, and is still not set.

What is the solution? To include the intent in the code. Use `mac_manual` if you want a manual address, or have it automatically calculated.