### PR TITLE
fix a deadlocking issue

### DIFF
--- a/proxmox/provider.go
+++ b/proxmox/provider.go
@@ -145,6 +145,12 @@ func pmParallelEnd(pconf *providerConfiguration) {
 	pconf.Mutex.Unlock()
 }
 
+func pmParallelTransfer(pconf *providerConfiguration) {
+	pconf.Mutex.Lock()
+	pconf.CurrentParallel--
+	pconf.Mutex.Unlock()
+}
+
 func resourceId(targetNode string, resType string, vmId int) string {
 	return fmt.Sprintf("%s/%s/%d", targetNode, resType, vmId)
 }

--- a/proxmox/resource_lxc.go
+++ b/proxmox/resource_lxc.go
@@ -403,6 +403,8 @@ func resourceLxcCreate(d *schema.ResourceData, meta interface{}) error {
 	// The existence of a non-blank ID is what tells Terraform that a resource was created
 	d.SetId(resourceId(targetNode, "lxc", vmr.VmId()))
 
+	pmParallelTransfer(pconf)
+
 	return resourceLxcRead(d, meta)
 }
 
@@ -493,7 +495,9 @@ func resourceLxcUpdate(d *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 
-	return nil
+	pmParallelTransfer(pconf)
+
+	return resourceLxcRead(d, meta)
 }
 
 func resourceLxcRead(d *schema.ResourceData, meta interface{}) error {

--- a/proxmox/resource_vm_qemu.go
+++ b/proxmox/resource_vm_qemu.go
@@ -692,7 +692,9 @@ func resourceVmQemuCreate(d *schema.ResourceData, meta interface{}) error {
 	// Apply pre-provision if enabled.
 	preprovision(d, pconf, client, vmr, true)
 
-	return nil
+	pmParallelTransfer(pconf)
+
+	return resourceVmQemuRead(d, meta)
 }
 
 func resourceVmQemuUpdate(d *schema.ResourceData, meta interface{}) error {
@@ -823,7 +825,9 @@ func resourceVmQemuUpdate(d *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 
-	return nil
+	pmParallelTransfer(pconf)
+
+	return resourceVmQemuRead(d, meta)
 }
 
 func resourceVmQemuRead(d *schema.ResourceData, meta interface{}) error {


### PR DESCRIPTION
Some LXC and Qemu methods weren't properly decrementing the parallel counter and were thus causing deadlocks.

Fixes #114.