### PR TITLE
Improve LXC Resource

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,9 +3,10 @@ module github.com/Telmate/terraform-provider-proxmox
 go 1.13
 
 require (
-	github.com/Telmate/proxmox-api-go v0.0.0-20201028151401-4d5b964c889e
-	github.com/hashicorp/terraform v0.13.4
-	github.com/hashicorp/terraform-plugin-sdk v1.13.0
+	github.com/Telmate/proxmox-api-go v0.0.0-20201105165554-3bcfb8aa1ba3
+	github.com/aws/aws-sdk-go v1.31.9
+	github.com/hashicorp/terraform v0.13.4 // indirect
+	github.com/hashicorp/terraform-plugin-sdk v1.13.0 // indirect
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.1.0
 	github.com/rs/zerolog v1.19.0
 )

--- a/go.sum
+++ b/go.sum
@@ -60,6 +60,8 @@ github.com/Telmate/proxmox-api-go v0.0.0-20201026220046-7dd278a1bfee h1:FoRvorXq
 github.com/Telmate/proxmox-api-go v0.0.0-20201026220046-7dd278a1bfee/go.mod h1:ayPkdmEKnlssqLQ9K1BE1jlsaYhXVwkoduXI30oQF0I=
 github.com/Telmate/proxmox-api-go v0.0.0-20201028151401-4d5b964c889e h1:b5bJwYbuIBN03pMnBsZAbQf+KzJdwitzPFjJ+wD8CJo=
 github.com/Telmate/proxmox-api-go v0.0.0-20201028151401-4d5b964c889e/go.mod h1:ayPkdmEKnlssqLQ9K1BE1jlsaYhXVwkoduXI30oQF0I=
+github.com/Telmate/proxmox-api-go v0.0.0-20201105165554-3bcfb8aa1ba3 h1:SmEY0tZNeyhNKBA6pgpIElFME4jf26ek889oI8RBTn0=
+github.com/Telmate/proxmox-api-go v0.0.0-20201105165554-3bcfb8aa1ba3/go.mod h1:ayPkdmEKnlssqLQ9K1BE1jlsaYhXVwkoduXI30oQF0I=
 github.com/abdullin/seq v0.0.0-20160510034733-d5467c17e7af/go.mod h1:5Jv4cbFiHJMsVxt52+i0Ha45fjshj6wxYr1r19tB9bw=
 github.com/agext/levenshtein v1.2.1/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
 github.com/agext/levenshtein v1.2.2 h1:0S/Yg6LYmFJ5stwQeRp6EeOcCbj7xiqQSdNelsXvaqE=
@@ -356,6 +358,7 @@ github.com/json-iterator/go v0.0.0-20180612202835-f2b4162afba3/go.mod h1:+SdeFBv
 github.com/json-iterator/go v0.0.0-20180701071628-ab8a2e0c74be/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/json-iterator/go v1.1.7/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
+github.com/jstemmer/go-junit-report v0.9.1 h1:6QPYqodiu3GuPL+7mfx+NwDdp2eTkp9IfEUpgAwUN0o=
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
 github.com/jtolds/gls v4.2.1+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
@@ -570,6 +573,7 @@ golang.org/x/lint v0.0.0-20190909230951-414d861bb4ac/go.mod h1:6SW0HCj/g11FgYtHl
 golang.org/x/lint v0.0.0-20190930215403-16217165b5de/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
 golang.org/x/lint v0.0.0-20191125180803-fdd1cda4f05f/go.mod h1:5qLYkcX4OjUUV8bRuDixDT3tpyyb+LUpUlRWLxfhWrs=
 golang.org/x/lint v0.0.0-20200130185559-910be7a94367/go.mod h1:3xt1FjdF8hUf6vQPIChWIBhFzV8gjjsPE/fR3IyQdNY=
+golang.org/x/lint v0.0.0-20200302205851-738671d3881b h1:Wh+f8QHJXR411sJR8/vRBTZ7YapZaRvUcLFFJhusH0k=
 golang.org/x/lint v0.0.0-20200302205851-738671d3881b/go.mod h1:3xt1FjdF8hUf6vQPIChWIBhFzV8gjjsPE/fR3IyQdNY=
 golang.org/x/mobile v0.0.0-20190312151609-d3739f865fa6/go.mod h1:z+o9i4GpDbdi3rU15maQ/Ox0txvL9dWGYEHz965HBQE=
 golang.org/x/mobile v0.0.0-20190719004257-d2bd2a29d028/go.mod h1:E/iHnbuqvinMTCcRqshq8CkpyQDoeVncDDYHnLhea+o=
@@ -579,6 +583,7 @@ golang.org/x/mod v0.1.1-0.20191105210325-c90efee705ee/go.mod h1:QqPTAvyqsEbceGzB
 golang.org/x/mod v0.1.1-0.20191107180719-034126e5016b/go.mod h1:QqPTAvyqsEbceGzBzNggFXnrqF1CaUcvgkdR5Ot7KZg=
 golang.org/x/mod v0.2.0 h1:KU7oHjnv3XNWfa5COkzUifxZmxp1TyI7ImMXqFxLwvQ=
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
+golang.org/x/mod v0.3.0 h1:RM4zey1++hCTbCVQfnWeKs9/IEsaBLA8vTkd0WVtmH4=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/net v0.0.0-20170114055629-f2499483f923/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180530234432-1e491301e022/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -728,9 +733,11 @@ golang.org/x/tools v0.0.0-20200501065659-ab2804fb9c9d/go.mod h1:EkVYQZoAsY45+roY
 golang.org/x/tools v0.0.0-20200512131952-2bc93b1c0c88/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20200515010526-7d3b6ebf133d/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20200618134242-20370b0cb4b2/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
+golang.org/x/tools v0.0.0-20200713011307-fd294ab11aed h1:+qzWo37K31KxduIYaBeMqJ8MUOyTayOQKpH9aDPLMSY=
 golang.org/x/tools v0.0.0-20200713011307-fd294ab11aed/go.mod h1:njjCfa9FT2d7l9Bc6FUM5FLjQPp3cFF28FI3qnDFljA=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/api v0.4.0/go.mod h1:8k5glujaEP+g9n7WNsDg8QP6cUVNI86fCNMcbazEtwE=
 google.golang.org/api v0.7.0/go.mod h1:WtwebWUNSVBH/HAw79HIFXZNqEvBhG+Ra+ax0hx3E3M=
@@ -754,6 +761,7 @@ google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7
 google.golang.org/appengine v1.5.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
 google.golang.org/appengine v1.6.1/go.mod h1:i06prIuMbXzDqacNJfV5OdTW448YApPu5ww/cMBSeb0=
 google.golang.org/appengine v1.6.5/go.mod h1:8WjMMxjGQR8xUklV/ARdw2HLXBOI7O7uCIDZVag1xfc=
+google.golang.org/appengine v1.6.6 h1:lMO5rYAqUxkmaj76jAkRUvt5JZgFymx/+Q5Mzfivuhc=
 google.golang.org/appengine v1.6.6/go.mod h1:8WjMMxjGQR8xUklV/ARdw2HLXBOI7O7uCIDZVag1xfc=
 google.golang.org/genproto v0.0.0-20170818010345-ee236bd376b0/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
 google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=

--- a/go.sum
+++ b/go.sum
@@ -495,6 +495,7 @@ github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/svanharmelen/jsonapi v0.0.0-20180618144545-0c0828c3f16d/go.mod h1:BSTlc8jOjh0niykqEGVXOLXdi9o0r0kR8tCYiMvjFgw=
 github.com/tencentcloud/tencentcloud-sdk-go v3.0.82+incompatible/go.mod h1:0PfYow01SHPMhKY31xa+EFz2RStxIqj6JFAJS+IkCi4=
 github.com/tencentyun/cos-go-sdk-v5 v0.0.0-20190808065407-f07404cefc8c/go.mod h1:wk2XFUg6egk4tSDNZtXeKfe2G6690UVyt163PuUxBZk=
+github.com/terraform-providers/terraform-provider-aws v1.60.0 h1:uJw42EpO/1L8tk5P8hpio0mN9+hIdq8ubteidQjfk7Q=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20171017195756-830351dc03c6/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tombuildsstuff/giovanni v0.12.0/go.mod h1:qJ5dpiYWkRsuOSXO8wHbee7+wElkLNfWVolcf59N84E=
 github.com/ugorji/go v0.0.0-20180813092308-00b869d2f4a5/go.mod h1:hnLbHMwcvSihnDhEfx2/BzKp2xb0Y+ErdfYcrs9tkJQ=

--- a/proxmox/provider.go
+++ b/proxmox/provider.go
@@ -95,8 +95,9 @@ func Provider() *schema.Provider {
 		},
 
 		ResourcesMap: map[string]*schema.Resource{
-			"proxmox_vm_qemu": resourceVmQemu(),
-			"proxmox_lxc":     resourceLxc(),
+			"proxmox_vm_qemu":  resourceVmQemu(),
+			"proxmox_lxc":      resourceLxc(),
+			"proxmox_lxc_disk": resourceLxcDisk(),
 			// TODO - storage_iso
 			// TODO - bridge
 			// TODO - vm_qemu_template

--- a/proxmox/resource_lxc.go
+++ b/proxmox/resource_lxc.go
@@ -807,7 +807,7 @@ func processDiskResize(
 	newSize, ok := newDisk["size"]
 	if ok && newSize != prevDisk["size"] {
 		log.Print("[DEBUG] resizing disk " + diskName)
-		_, err := pconf.Client.ResizeDisk(vmr, diskName, newDisk["size"].(string))
+		_, err := pconf.Client.ResizeQemuDiskRaw(vmr, diskName, newDisk["size"].(string))
 		if err != nil {
 			return err
 		}

--- a/proxmox/resource_lxc.go
+++ b/proxmox/resource_lxc.go
@@ -671,8 +671,6 @@ func _resourceLxcRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("protection", config.Protection)
 	d.Set("restore", config.Restore)
 	d.Set("searchdomain", config.SearchDomain)
-	d.Set("ssh_public_keys", config.SSHPublicKeys)
-	d.Set("start", config.Start)
 	d.Set("startup", config.Startup)
 	d.Set("swap", config.Swap)
 	d.Set("template", config.Template)
@@ -682,8 +680,10 @@ func _resourceLxcRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("unused", config.Unused)
 
 	// Only applicable on create and not readable
+	// d.Set("start", config.Start)
 	// d.Set("ostemplate", config.Ostemplate)
 	// d.Set("password", config.Password)
+	// d.Set("ssh_public_keys", config.SSHPublicKeys)
 
 	return nil
 }

--- a/proxmox/resource_lxc_disk.go
+++ b/proxmox/resource_lxc_disk.go
@@ -1,0 +1,258 @@
+package proxmox
+
+import (
+	"fmt"
+	"strings"
+
+	pxapi "github.com/Telmate/proxmox-api-go/proxmox"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func resourceLxcDisk() *schema.Resource {
+	*pxapi.Debug = true
+	return &schema.Resource{
+		Create: resourceLxcDiskCreate,
+		Read:   resourceLxcDiskRead,
+		Update: resourceLxcDiskUpdate,
+		Delete: resourceLxcDiskDelete,
+
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"container": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"slot": {
+				Type:     schema.TypeInt,
+				Required: true,
+			},
+			"storage": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"mp": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"acl": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+			"backup": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+			"quota": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+			"replicate": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+			"shared": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+			"size": {
+				Type:     schema.TypeString,
+				Required: true,
+				ValidateFunc: func(val interface{}, key string) (warns []string, errs []error) {
+					v := val.(string)
+					if !(strings.Contains(v, "G") || strings.Contains(v, "M") || strings.Contains(v, "n")) {
+						errs = append(errs, fmt.Errorf("Disk size must end in G, M, or K, got %s", v))
+					}
+					return
+				},
+			},
+			"mountoptions": {
+				Type:     schema.TypeList,
+				MaxItems: 1,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"noatime": {
+							Type:     schema.TypeBool,
+							Optional: true,
+						},
+						"nodev": {
+							Type:     schema.TypeBool,
+							Optional: true,
+						},
+						"noexec": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"nosuid": {
+							Type:     schema.TypeBool,
+							Optional: true,
+						},
+					},
+				},
+			},
+			"volume": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceLxcDiskCreate(d *schema.ResourceData, meta interface{}) error {
+	pconf := meta.(*providerConfiguration)
+
+	lock := pmParallelBegin(pconf)
+	defer lock.unlock()
+
+	_, _, vmID, err := parseResourceId(d.Get("container").(string))
+	if err != nil {
+		return err
+	}
+
+	client := pconf.Client
+	vmr := pxapi.NewVmRef(vmID)
+	vmr.SetVmType("lxc")
+	_, err = client.GetVmInfo(vmr)
+	if err != nil {
+		return err
+	}
+
+	disk := d.Get("").(map[string]interface{})
+
+	if mountoptions, ok := disk["mountoptions"]; ok {
+		if len(mountoptions.([]interface{})) > 0 {
+			disk["mountoptions"] = mountoptions.([]interface{})[0]
+		} else {
+			delete(disk, "mountoptions")
+		}
+	}
+
+	params := map[string]interface{}{}
+	mpName := fmt.Sprintf("mp%v", d.Get("slot").(int))
+	params[mpName] = pxapi.FormatDiskParam(disk)
+	exitStatus, err := pconf.Client.SetLxcConfig(vmr, params)
+	if err != nil {
+		return fmt.Errorf("Error updating LXC Mountpoint: %v, error status: %s (params: %v)", err, exitStatus, params)
+	}
+
+	d.Partial(true)
+	if err = _resourceLxcDiskRead(d, meta); err != nil {
+		return err
+	}
+
+	d.Partial(false)
+
+	return nil
+}
+
+func resourceLxcDiskUpdate(d *schema.ResourceData, meta interface{}) error {
+	pconf := meta.(*providerConfiguration)
+	lock := pmParallelBegin(pconf)
+	defer lock.unlock()
+
+	client := pconf.Client
+
+	_, _, vmID, err := parseResourceId(d.Get("container").(string))
+	if err != nil {
+		return err
+	}
+
+	vmr := pxapi.NewVmRef(vmID)
+	_, err = client.GetVmInfo(vmr)
+	if err != nil {
+		return err
+	}
+
+	oldValue, newValue := d.GetChange("")
+	oldDisk := oldValue.(map[string]interface{})
+	newDisk := newValue.(map[string]interface{})
+
+	if mountoptions, ok := newDisk["mountoptions"]; ok && len(mountoptions.([]interface{})) > 0 {
+		newDisk["mountoptions"] = mountoptions.([]interface{})[0]
+	}
+
+	// Apply Changes
+	err = processLxcDiskChanges(DeviceToMap(oldDisk, 0), DeviceToMap(newDisk, 0), pconf, vmr)
+	if err != nil {
+		return fmt.Errorf("Error updating LXC Mountpoint: %v", err)
+	}
+
+	return _resourceLxcDiskRead(d, meta)
+}
+
+func resourceLxcDiskRead(d *schema.ResourceData, meta interface{}) error {
+	pconf := meta.(*providerConfiguration)
+	lock := pmParallelBegin(pconf)
+	defer lock.unlock()
+	return _resourceLxcDiskRead(d, meta)
+}
+
+func _resourceLxcDiskRead(d *schema.ResourceData, meta interface{}) error {
+	pconf := meta.(*providerConfiguration)
+	client := pconf.Client
+
+	_, _, vmID, err := parseResourceId(d.Get("container").(string))
+	if err != nil {
+		return err
+	}
+
+	vmr := pxapi.NewVmRef(vmID)
+	_, err = client.GetVmInfo(vmr)
+	if err != nil {
+		return err
+	}
+
+	apiResult, err := client.GetVmConfig(vmr)
+	if err != nil {
+		return err
+	}
+
+	diskName := fmt.Sprintf("mp%v", d.Get("slot").(int))
+	diskString := apiResult[diskName].(string)
+	disk := pxapi.ParsePMConf(diskString, "volume")
+
+	if mountoptions, ok := disk["mountoptions"]; ok && len(mountoptions.([]interface{})) > 0 {
+		disk["mountoptions"] = []interface{}{mountoptions}
+	}
+
+	d.SetId(disk["volume"].(string))
+	d.Set("", disk)
+
+	return nil
+}
+
+func resourceLxcDiskDelete(d *schema.ResourceData, meta interface{}) error {
+	pconf := meta.(*providerConfiguration)
+	lock := pmParallelBegin(pconf)
+	defer lock.unlock()
+
+	_, _, vmID, err := parseResourceId(d.Get("container").(string))
+	if err != nil {
+		return err
+	}
+
+	client := pconf.Client
+	vmr := pxapi.NewVmRef(vmID)
+	_, err = client.GetVmInfo(vmr)
+	if err != nil {
+		return err
+	}
+
+	params := map[string]interface{}{}
+	params["delete"] = fmt.Sprintf("mp%v", d.Get("slot").(int))
+	if exitStatus, err := pconf.Client.SetLxcConfig(vmr, params); err != nil {
+		return fmt.Errorf("Error deleting LXC Mountpoint: %v, error status: %s (params: %v)", err, exitStatus, params)
+	}
+
+	return nil
+}

--- a/proxmox/resource_vm_qemu.go
+++ b/proxmox/resource_vm_qemu.go
@@ -1310,39 +1310,6 @@ func UpdateDevicesSet(
 	return devicesSet
 }
 
-func adaptDeviceToConf(
-	conf map[string]interface{},
-	device pxapi.QemuDevice,
-) map[string]interface{} {
-	// Value type should be one of types allowed by Terraform schema types.
-	for key, value := range device {
-		// This nested switch is used for nested config like in `net[n]`,
-		// where Proxmox uses `key=<0|1>` in string" at the same time
-		// a boolean could be used in ".tf" files.
-		switch conf[key].(type) {
-		case bool:
-			switch value.(type) {
-			// If the key is bool and value is int (which comes from Proxmox API),
-			// should be converted to bool (as in ".tf" conf).
-			case int:
-				sValue := strconv.Itoa(value.(int))
-				bValue, err := strconv.ParseBool(sValue)
-				if err == nil {
-					conf[key] = bValue
-				}
-			// If value is bool, which comes from Terraform conf, add it directly.
-			case bool:
-				conf[key] = value
-			}
-		// Anything else will be added as it is.
-		default:
-			conf[key] = value
-		}
-	}
-
-	return conf
-}
-
 // Because default values are not stored in Proxmox, so the API returns only active values.
 // So to prevent Terraform doing unnecessary diffs, this function reads default values
 // from Terraform itself, and fill empty fields.

--- a/proxmox/util.go
+++ b/proxmox/util.go
@@ -2,15 +2,15 @@ package proxmox
 
 import (
 	"fmt"
-	pxapi "github.com/Telmate/proxmox-api-go/proxmox"
-	//pxapi "github.com/doransmestad/proxmox-api-go/proxmox"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/rs/zerolog"
 	"io"
 	"log"
 	"os"
 	"strconv"
 	"time"
+
+	pxapi "github.com/Telmate/proxmox-api-go/proxmox"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/rs/zerolog"
 )
 
 // given a string, return the appropriate zerolog level
@@ -231,7 +231,6 @@ func UpdateDeviceConfDefaults(
 }
 
 func DevicesSetToMapWithoutId(devicesSet *schema.Set) pxapi.QemuDevices {
-
 	devicesMap := pxapi.QemuDevices{}
 	i := 1
 	for _, set := range devicesSet.List() {
@@ -241,6 +240,37 @@ func DevicesSetToMapWithoutId(devicesSet *schema.Set) pxapi.QemuDevices {
 			devicesMap[i] = setMap
 			i += 1
 		}
+	}
+	return devicesMap
+}
+
+type KeyedDeviceMap map[interface{}]pxapi.QemuDevice
+
+func DevicesSetToMapByKey(devicesSet *schema.Set, key string) KeyedDeviceMap {
+	devicesMap := KeyedDeviceMap{}
+	for i, set := range devicesSet.List() {
+		setMap, isMap := set.(map[string]interface{})
+		if isMap {
+			if key != "" {
+				devicesMap[setMap[key]] = setMap
+			} else {
+				devicesMap[i] = setMap
+			}
+		}
+	}
+	return devicesMap
+}
+
+func DeviceToMap(device pxapi.QemuDevice, key interface{}) KeyedDeviceMap {
+	kdm := KeyedDeviceMap{}
+	kdm[key] = device
+	return kdm
+}
+
+func DevicesSetToDevices(devicesSet *schema.Set, key string) pxapi.QemuDevices {
+	devicesMap := pxapi.QemuDevices{}
+	for key, set := range DevicesSetToMapByKey(devicesSet, key) {
+		devicesMap[key.(int)] = set
 	}
 	return devicesMap
 }


### PR DESCRIPTION
A number of improvements to the LXC Resource.
- LXC `rootfs` property now expects a resource instead of a string.
- `mountpoints` has improved idempotency
- Added `resource_lxc_disk`

Additionally fixes some potential issues with my earlier Locking fix, #230.

Depends on changes made to `proxmox-api-go` here: https://github.com/Telmate/proxmox-api-go/pull/96