### PR TITLE
Add disk slot attribute, fix disk resize error on no size change, add more tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,8 +21,9 @@ build: clean
 	CGO_ENABLED=0 go build  -o bin/terraform-provider-proxmox_v2.0.0 cmd/terraform-provider-proxmox/* 
 	@echo "Built terraform-provider-proxmox"
 
-acctest:
-	TF_ACC=1 go test ./proxmox
+acctest: build
+	# to run only certain tests, run something of the form:  make acctest TESTARGS='-run=TestAccProxmoxVmQemu_DiskSlot'
+	TF_ACC=1 go test ./proxmox $(TESTARGS)
 
 install: build 
 	cp bin/terraform-provider-proxmox_v2.0.0 $$GOPATH/bin/terraform-provider-proxmox

--- a/proxmox/provider.go
+++ b/proxmox/provider.go
@@ -68,8 +68,8 @@ func Provider() *schema.Provider {
 				Default:  4,
 			},
 			"pm_tls_insecure": {
-				Type:     schema.TypeBool,
-				Optional: true,
+				Type:        schema.TypeBool,
+				Optional:    true,
 				DefaultFunc: schema.EnvDefaultFunc("PM_TLS_INSECURE", false),
 			},
 			"pm_log_enable": {


### PR DESCRIPTION
This PR:

- Fixes a disk resizing bug which would error out when no resize was needed (i.e.  run a clone and no disk size change is needed)  #235 
- Adds the disk `slot` attribute that is now returned by proxmox-api-go.  Unfortunately it seems to be broken?  I can't tell if it is an issue in the provider or in the upstream proxmox-api-go, but the slot specification does not get applied in proxmox. I do not recommend using the `slot` attribute until we can figure out what's going on there.  #237 
- Clean up references to the `storage_type` attribute as that was removed from the qemu resource in the commit here:  https://github.com/Telmate/terraform-provider-proxmox/commit/aafcadd9948adc60c8f31f802fb9dc3c98cc1915

I also added additional test cases.  I did include a test case for the disk slot attribute but it currently fails due to the issue described above.  I left the test in here, but commented out, until someone can take a look at why it isn't working. 