### PR TITLE
converting disk backup value to bool

### DIFF
--- a/proxmox/resource_vm_qemu.go
+++ b/proxmox/resource_vm_qemu.go
@@ -1068,6 +1068,11 @@ func _resourceVmQemuRead(d *schema.ResourceData, meta interface{}) error {
 		if qemuDisk["cache"] == "" || qemuDisk["cache"] == nil {
 			qemuDisk["cache"] = "none"
 		}
+		if qemuDisk["backup"] == 0 {
+			qemuDisk["backup"] = false
+		} else if qemuDisk["backup"] == 1 {
+			qemuDisk["backup"] = true
+		}
 	}
 
 	flatDisks, _ := FlattenDevicesList(config.QemuDisks)


### PR DESCRIPTION
This should fix issues when importing disks with backups disabled (0 integer), because terraform will silently discard it since backup has `TypeBool` in schema.