### PR TITLE
Remove storage argument from lxc_example.tf and documentation

### DIFF
--- a/docs/resources/lxc.md
+++ b/docs/resources/lxc.md
@@ -21,7 +21,6 @@ resource "proxmox_lxc" "lxc-test" {
     ostemplate = "shared:vztmpl/centos-7-default_20171212_amd64.tar.xz"
     password = "rootroot"
     pool = "terraform"
-    storage = "local-lvm"
     target_node = "node-01"
     unprivileged = true
 }

--- a/examples/lxc_example.tf
+++ b/examples/lxc_example.tf
@@ -20,7 +20,6 @@ resource "proxmox_lxc" "lxc-test" {
     ostemplate = "shared:vztmpl/centos-7-default_20171212_amd64.tar.xz"
     password = "rootroot"
     pool = "terraform"
-    storage = "local-lvm"
     target_node = "node-01"
     unprivileged = true
 }


### PR DESCRIPTION
This fixes #250 where "storage" is stated in the wrong section in the tf-file