### PR TITLE
Fix relative links to providers

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,7 +1,7 @@
 # Proxmox Provider
 
 A Terraform provider is responsible for understanding API interactions and exposing resources. The Proxmox provider
-uses the Proxmox API. This provider exposes two resources: [proxmox_vm_qemu](docs/resources/vm_qemu.md) and [proxmox_lxc](docs/resources/lxc.md).
+uses the Proxmox API. This provider exposes two resources: [proxmox_vm_qemu](resources/vm_qemu.md) and [proxmox_lxc](resources/lxc.md).
 
 ## Creating the connection
 


### PR DESCRIPTION
These were 404ing from the GitHub view. Looks like they need to be relative to this file's location.