### PR TITLE
Fix unknown attribute disk storage_type provided by api library but not added back to resource

### DIFF
--- a/proxmox/resource_vm_qemu.go
+++ b/proxmox/resource_vm_qemu.go
@@ -455,6 +455,11 @@ func resourceVmQemu() *schema.Resource {
 							Optional: true,
 							Computed: true,
 						},
+						"storage_type": &schema.Schema{
+							Type:     schema.TypeString,
+							Required: false,
+							Computed: true,
+						},
 					},
 				},
 			},

--- a/proxmox/resource_vm_qemu_test.go
+++ b/proxmox/resource_vm_qemu_test.go
@@ -33,7 +33,7 @@ func testAccProxmoxProviderFactory() map[string]*schema.Provider {
 	}
 	// TODO move this log configuration elsewhere, it doesn't make sense here but
 	// it's a short term solution to test the testing out
-	ConfigureLogger(true, "acctest.log", map[string]string{"_default": "debug", "_capturelog": ""})
+	ConfigureLogger(true, "../../acctest.log", map[string]string{"_default": "debug", "_capturelog": ""})
 	return providers
 }
 


### PR DESCRIPTION
@yukron @gentoo9ball  looks like commit 4e62f1042487a539e28e709e49fc0249278a66ba added the storage_type back to the api library but didn't include the storage_type back into the resource.    This is a quick fix to add it back in so master branch works.  Fixes #265

thanks @ameeno for raising the issue 