### PR TITLE
Attempting to enable a workaround for #199

### DIFF
--- a/docs/resources/vm_qemu.md
+++ b/docs/resources/vm_qemu.md
@@ -142,7 +142,8 @@ The following arguments are supported in the resource block:
     * `type` (Required)
 * `pool` - (Optional)
 * `force_create` - (Optional; defaults to true)
-* `clone_wait` - (Optional)
+* `clone_wait` - (Optional; defaults to 15 seconds) Amount of time to wait after a clone operation and after an UpdateConfig operation.
+* `additional_wait` - (Optional; defaults to 15 seconds) Provider will wait n/2 seconds after a clone operation and n seconds after an UpdateConfig operation.
 * `preprovision` - (Optional; defaults to true)
 * `os_type` - (Optional) Which provisioning method to use, based on the OS type. Possible values: ubuntu, centos, cloud-init.
 * `force_recreate_on_change_of` (Optional) // Allows this to depend on another resource, that when changed, needs to re-create this vm. An example where this is useful is a cloudinit configuration (as the `cicustom` attribute points to a file not the content).

--- a/proxmox/resource_vm_qemu.go
+++ b/proxmox/resource_vm_qemu.go
@@ -576,6 +576,11 @@ func resourceVmQemu() *schema.Resource {
 				Optional: true,
 				Default:  15,
 			},
+			"additional_wait": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Default:  15,
+			},
 			"ci_wait": { // how long to wait before provision
 				Type:     schema.TypeInt,
 				Optional: true,
@@ -865,7 +870,7 @@ func resourceVmQemuCreate(d *schema.ResourceData, meta interface{}) error {
 	logger.Debug().Int("vmid", vmr.VmId()).Msgf("Set this vm (resource Id) to '%v'", d.Id())
 
 	// give sometime to proxmox to catchup
-	time.Sleep(15 * time.Second)
+	time.Sleep(time.Duration(d.Get("additional_wait").(int)) * time.Second)
 
 	log.Print("[DEBUG] starting VM")
 	_, err := client.StartVm(vmr)
@@ -1100,7 +1105,7 @@ func _resourceVmQemuRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("ipconfig2", config.Ipconfig2)
 
 	// Some dirty hacks to populate undefined keys with default values.
-	checkedKeys := []string{"clone_wait", "force_create", "full_clone", "define_connection_info", "preprovision"}
+	checkedKeys := []string{"clone_wait", "additional_wait", "force_create", "full_clone", "define_connection_info", "preprovision"}
 	for _, key := range checkedKeys {
 		if _, ok := d.GetOk(key); !ok {
 			d.Set(key, thisResource.Schema[key].Default)


### PR DESCRIPTION
This might allow people to work around the issues in ticket #199 and also allow me to address the slow deployment issues that I've been having.

It's important to test this for a number of reasons:
- I did not add a unit test (I did look for clone_wait in there and was going to mimic that for additional_wait if it existed)
- I did not test this myself, as I'm not sure where I'd put the executable so it'd be available to a test VM, but not interfere with the rest of my VMs
- I didn't even compile it on account of not knowing how and not being able to find build instructions.  I tried `make` but it complained I didn't have go.  I installed golang-go and tried `make` again, but it complained about the nighmarish GOROOT and GOPATH environment variables that cause me problems with go 100% of the time
- I don't actually know golang. It seems easy enough to pick up for little changes like this, but it also means testing is vital