### PR TITLE
QEMU Resource Docs Update

### DIFF
--- a/docs/resources/vm_qemu.md
+++ b/docs/resources/vm_qemu.md
@@ -84,14 +84,12 @@ The following arguments are supported in the resource block.
 |--------|----|---------|-------------|-----------|
 |`name`|`string`|**Yes**||The name of the VM.|
 |`target_node`|`string`|**Yes**||The name of the Proxmox Node on which to place the VM.|
-|`desc`|`string`|**Yes**|``||
-
 |`vmid`|`integer`|No|`0`|The ID of the VM in Proxmox. The default value of `0` indicates it should use the next available ID in the sequence.|
 |`desc`|`string`|No|`""`|The description of the VM. Shows as the 'Notes' field in the Proxmox GUI.|
 |`define_connection_info`|`bool`|No|`true`|Define the (SSH) connection parameters for preprovisioners, see config block below.|
 |`bios`|`string`|No|`"seabios"`|The BIOS to use, options are `seabios` or `ovmf` for UEFI.|
 |`onboot`|`bool`|No|`true`|Whether to have the VM startup after the PVE node starts.|
-|`boot`|`string`|No|`"cdn"`|The boot order for the VM. Ordered string of characters representing: floppy (a), hard disk (c), CD-ROM (d), or network (n).|
+|`boot`|`string`|No|`"cdn"`|The boot order for the VM. Ordered string of characters denoting boot order. Options: floppy (`a`), hard disk (`c`), CD-ROM (`d`), or network (`n`).|
 |`bootdisk`|`string`|No|*Computed*|Enable booting from specified disk. This value is computed by terraform, so you shouldn't need to change it under most circumstances.|
 |`agent`|`integer`|No|`0`|Whether to enable the QEMU Guest Agent. Note, you must still install the [`qemu-guest-agent`](https://pve.proxmox.com/wiki/Qemu-guest-agent) daemon in the quest for this to have any effect.|
 |`iso`|`string`|No|`""`|The name of the ISO image to mount to the VM. Only applies when `clone` is not set.|
@@ -99,18 +97,16 @@ The following arguments are supported in the resource block.
 |`full_clone`|`bool`|No|`true`|Set to `true` to create a full clone, or `false` to create a linked clone. See the [docs about cloning](https://pve.proxmox.com/pve-docs/chapter-qm.html#qm_copy_and_clone) for more info. Only applies when `clone` is set.|
 |`hastate`|`string`|No|`""`|Requested HA state for the resource. One of "started", "stopped", "enabled", "disabled", or "ignored". See the [docs about HA](https://pve.proxmox.com/pve-docs/chapter-ha-manager.html#ha_manager_resource_config) for more info.|
 |`qemu_os`|`string`|No|`"l26"`|The type of OS in the guest. Set properly to allow Proxmox to enable optimizations for the appropriate guest OS.|
-|`memory`|``|No|``||
+|`memory`|`integer`|No|`512`|The amount of memory to allocate to the VM in bytes.|
+|`balloon`|`integer`|No|`0`|Whether to add the ballooning device to the VM. Options are `1` and `0`. See the [docs about memory](https://pve.proxmox.com/pve-docs/chapter-qm.html#qm_memory) for more info.|
+|`sockets`|`integer`|No|`1`|The number of CPU sockets to allocate to the VM.|
+|`cores`|`integer`|No|`1`|The number of CPU cores per CPU socket to allocate to the VM.|
+|`vcpus`|`integer`|No|`0`|The number of vCPUs plugged into the VM when it starts. If 0, this is set automatically by Proxmox to `sockets * cores`.|
+|`cpu`|`string`|No|`"host"`|The type of CPU to emulate in the Guest. See the [docs about CPU Types](https://pve.proxmox.com/pve-docs/chapter-qm.html#qm_cpu) for more info.|
+|`numa`|`bool`|No|`false`|Whether to enable [Non-Uniform Memory Access](https://pve.proxmox.com/pve-docs/chapter-qm.html#qm_cpu) in the guest.|
+|`hotplug`|`string`|No|`"network,disk,usb"`|Comma delimited list of hotplug features to enable. Options: `network`, `disk`, `cpu`, `memory`, `usb`. Set to `0` to disable hotplug.|
+|`scsihw`|`string`|No|*Computed*|The SCSI controller to emulate, if left empty, proxmox default to `lsi`. Options: `lsi`, `lsi53c810`, `megasas`, `pvscsi`, `virtio-scsi-pci`, `virtio-scsi-single`.|
 
-* `` - (Optional; defaults to 512)
-* `balloon` - (Optional; defaults to 0)
-* `cores` - (Optional; defaults to 1)
-* `sockets` - (Optional; defaults to 1)
-* `vcpus` - (Optional; defaults to 0)
-* `vcpus` - (Optional; defaults to 0)
-* `cpu` - (Optional; defaults to host)
-* `numa` - (Optional; defaults to false)
-* `hotplug` - (Optional; defaults to network,disk,usb)
-* `scsihw` - (Optional; defaults to the empty string)
 * `vga` - (Optional)
     * `type` (Optional; defauls to std)
     * `memory` (Optional)

--- a/docs/resources/vm_qemu.md
+++ b/docs/resources/vm_qemu.md
@@ -78,17 +78,17 @@ The following arguments are supported in the top level resource block.
 |`name`|`string`||**Required** The name of the VM within Proxmox.|
 |`target_node`|`string`||**Required** The name of the Proxmox Node on which to place the VM.|
 |`vmid`|`integer`|`0`|The ID of the VM in Proxmox. The default value of `0` indicates it should use the next available ID in the sequence.|
-|`desc`|`string`|`""`|The description of the VM. Shows as the 'Notes' field in the Proxmox GUI.|
+|`desc`|`string`||The description of the VM. Shows as the 'Notes' field in the Proxmox GUI.|
 |`define_connection_info`|`bool`|`true`|Whether to let terraform define the (SSH) connection parameters for preprovisioners, see config block below.|
 |`bios`|`string`|`"seabios"`|The BIOS to use, options are `seabios` or `ovmf` for UEFI.|
 |`onboot`|`bool`|`true`|Whether to have the VM startup after the PVE node starts.|
 |`boot`|`string`|`"cdn"`|The boot order for the VM. Ordered string of characters denoting boot order. Options: floppy (`a`), hard disk (`c`), CD-ROM (`d`), or network (`n`).|
 |`bootdisk`|`string`|*Computed*|Enable booting from specified disk. This value is computed by terraform, so you shouldn't need to change it under most circumstances.|
 |`agent`|`integer`|`0`|Whether to enable the QEMU Guest Agent. Note, you must still install the [`qemu-guest-agent`](https://pve.proxmox.com/wiki/Qemu-guest-agent) daemon in the quest for this to have any effect.|
-|`iso`|`string`|`""`|The name of the ISO image to mount to the VM. Only applies when `clone` is not set.|
-|`clone`|`string`|`""`|The base VM from which to clone to create the new VM.|
+|`iso`|`string`||The name of the ISO image to mount to the VM. Only applies when `clone` is not set.|
+|`clone`|`string`||The base VM from which to clone to create the new VM.|
 |`full_clone`|`bool`|`true`|Set to `true` to create a full clone, or `false` to create a linked clone. See the [docs about cloning](https://pve.proxmox.com/pve-docs/chapter-qm.html#qm_copy_and_clone) for more info. Only applies when `clone` is set.|
-|`hastate`|`string`|`""`|Requested HA state for the resource. One of "started", "stopped", "enabled", "disabled", or "ignored". See the [docs about HA](https://pve.proxmox.com/pve-docs/chapter-ha-manager.html#ha_manager_resource_config) for more info.|
+|`hastate`|`string`||Requested HA state for the resource. One of "started", "stopped", "enabled", "disabled", or "ignored". See the [docs about HA](https://pve.proxmox.com/pve-docs/chapter-ha-manager.html#ha_manager_resource_config) for more info.|
 |`qemu_os`|`string`|`"l26"`|The type of OS in the guest. Set properly to allow Proxmox to enable optimizations for the appropriate guest OS.|
 |`memory`|`integer`|`512`|The amount of memory to allocate to the VM in bytes.|
 |`balloon`|`integer`|`0`|Whether to add the ballooning device to the VM. Options are `1` and `0`. See the [docs about memory](https://pve.proxmox.com/pve-docs/chapter-qm.html#qm_memory) for more info.|
@@ -99,27 +99,27 @@ The following arguments are supported in the top level resource block.
 |`numa`|`bool`|`false`|Whether to enable [Non-Uniform Memory Access](https://pve.proxmox.com/pve-docs/chapter-qm.html#qm_cpu) in the guest.|
 |`hotplug`|`string`|`"network,disk,usb"`|Comma delimited list of hotplug features to enable. Options: `network`, `disk`, `cpu`, `memory`, `usb`. Set to `0` to disable hotplug.|
 |`scsihw`|`string`|*Computed*|The SCSI controller to emulate, if left empty, proxmox default to `lsi`. Options: `lsi`, `lsi53c810`, `megasas`, `pvscsi`, `virtio-scsi-pci`, `virtio-scsi-single`.|
-|`pool`|`string`|`""`|The resource pool to which the VM will be added.|
+|`pool`|`string`||The resource pool to which the VM will be added.|
 |`force_create`|`bool`|`false`|If `false`, and a vm of the same name, on the same node exists, terraform will attempt to reconfigure that VM with these settings. Set to true to always create a new VM (note, the name of the VM must still be unique, otherwise an error will be produced.)|
 |`clone_wait`|`integer`|`15`|The amount of time in seconds to wait between cloning a VM and performing post-clone actions such as updating the VM.|
 |`additional_wait`|`integer`|`15`|Provider will wait `additional_wait`/2 seconds after a clone operation and `additional_wait` seconds after an UpdateConfig operation.|
 |`preprovision`|`bool`|`true`|Whether to preprovision the VM. See [Preprovision](#Preprovision) above for more info.|
-|`os_type`|`string`|`""`|Which provisioning method to use, based on the OS type. Options: `ubuntu`, `centos`, `cloud-init`.|
-|`force_recreate_on_change_of`|`string`|`""`|If the value of this string changes, the VM will be recreated. Useful for allowing this resource to be recreated when arbitrary attributes change. An example where this is useful is a cloudinit configuration (as the `cicustom` attribute points to a file not the content).|
-|`os_network_config`|`string`|`""`|Only applies when `define_connection_info` is true. Network configuration to be copied into the VM when preprovisioning `ubuntu` or `centos` guests. The specified configuration is added to `/etc/network/interfaces` for Ubuntu, or `/etc/sysconfig/network-scripts/ifcfg-eth0` for CentOS. Forces re-creation on change.|
-|`ssh_forward_ip`|`string`|`""`|Only applies when `define_connection_info` is true. The IP (and optional colon separated port), to use to connect to the host for preprovisioning. If using cloud-init, this can be left blank.|
-|`ssh_user`|`string`|`""`|Only applies when `define_connection_info` is true. The user with which to connect to the guest for preprovisioning. Forces re-creation on change.|
-|`ssh_private_key`|`string`|`""`|Only applies when `define_connection_info` is true. The private key to use when connecting to the guest for preprovisioning. Sensitive.|
+|`os_type`|`string`||Which provisioning method to use, based on the OS type. Options: `ubuntu`, `centos`, `cloud-init`.|
+|`force_recreate_on_change_of`|`string`||If the value of this string changes, the VM will be recreated. Useful for allowing this resource to be recreated when arbitrary attributes change. An example where this is useful is a cloudinit configuration (as the `cicustom` attribute points to a file not the content).|
+|`os_network_config`|`string`||Only applies when `define_connection_info` is true. Network configuration to be copied into the VM when preprovisioning `ubuntu` or `centos` guests. The specified configuration is added to `/etc/network/interfaces` for Ubuntu, or `/etc/sysconfig/network-scripts/ifcfg-eth0` for CentOS. Forces re-creation on change.|
+|`ssh_forward_ip`|`string`||Only applies when `define_connection_info` is true. The IP (and optional colon separated port), to use to connect to the host for preprovisioning. If using cloud-init, this can be left blank.|
+|`ssh_user`|`string`||Only applies when `define_connection_info` is true. The user with which to connect to the guest for preprovisioning. Forces re-creation on change.|
+|`ssh_private_key`|`string`||Only applies when `define_connection_info` is true. The private key to use when connecting to the guest for preprovisioning. Sensitive.|
 |`ci_wait`|`integer`|`30`|How to long in seconds to wait for before provisioning.|
-|`ciuser`|`string`|`""`|Override the default cloud-init user for provisioning.|
-|`cipassword`|`string`|`""`|Override the default cloud-init user's password. Sensitive.|
-|`cicustom`|`string`|`""`|Instead specifying ciuser, cipasword, etc... you can specify the path to a custom cloud-init config file here. Grants more flexibility in configuring cloud-init.|
-|`searchdomain`|`string`|`""`|Sets default DNS search domain suffix.|
-|`nameserver`|`string`|`""`|Sets default DNS server for guest.|
-|`sshkeys`|`string`|`""`|Newline delimited list of SSH public keys to add to authorized keys file for the cloud-init user.|
-|`ipconfig0`|`string`|`""`|The first IP address to assign to the guest. Format: `[gw=<GatewayIPv4>] [,gw6=<GatewayIPv6>] [,ip=<IPv4Format/CIDR>] [,ip6=<IPv6Format/CIDR>]`|
-|`ipconfig1`|`string`|`""`|The second IP address to assign to the guest. Same format as `ipconfig0`|
-|`ipconfig2`|`string`|`""`|The third IP address to assign to the guest. Same format as `ipconfig0`|
+|`ciuser`|`string`||Override the default cloud-init user for provisioning.|
+|`cipassword`|`string`||Override the default cloud-init user's password. Sensitive.|
+|`cicustom`|`string`||Instead specifying ciuser, cipasword, etc... you can specify the path to a custom cloud-init config file here. Grants more flexibility in configuring cloud-init.|
+|`searchdomain`|`string`||Sets default DNS search domain suffix.|
+|`nameserver`|`string`||Sets default DNS server for guest.|
+|`sshkeys`|`string`||Newline delimited list of SSH public keys to add to authorized keys file for the cloud-init user.|
+|`ipconfig0`|`string`||The first IP address to assign to the guest. Format: `[gw=<GatewayIPv4>] [,gw6=<GatewayIPv6>] [,ip=<IPv4Format/CIDR>] [,ip6=<IPv6Format/CIDR>]`|
+|`ipconfig1`|`string`||The second IP address to assign to the guest. Same format as `ipconfig0`|
+|`ipconfig2`|`string`||The third IP address to assign to the guest. Same format as `ipconfig0`|
 
 ### VGA Block
 
@@ -140,8 +140,8 @@ See the [docs about network devices](https://pve.proxmox.com/pve-docs/chapter-qm
 
 |Argument|Type|Default Value|Description|
 |--------|----|-------------|-----------|
-|`model`|`string`|`""`|**Required** Network Card Model. The virtio model provides the best performance with very low CPU overhead. If your guest does not support this driver, it is usually best to use e1000. Options: `e1000`, `e1000-82540em`, `e1000-82544gc`, `e1000-82545em`, `i82551`, `i82557b`, `i82559er`, `ne2k_isa`, `ne2k_pci`, `pcnet`, `rtl8139`, `virtio`, `vmxnet3`|
-|`macaddr`|`string`|`""`|Override the randomly generated MAC Address for the VM.|
+|`model`|`string`||**Required** Network Card Model. The virtio model provides the best performance with very low CPU overhead. If your guest does not support this driver, it is usually best to use e1000. Options: `e1000`, `e1000-82540em`, `e1000-82544gc`, `e1000-82545em`, `i82551`, `i82557b`, `i82559er`, `ne2k_isa`, `ne2k_pci`, `pcnet`, `rtl8139`, `virtio`, `vmxnet3`|
+|`macaddr`|`string`||Override the randomly generated MAC Address for the VM.|
 |`bridge`|`string`|`"nat"`|Bridge to which the network device should be attached. The Proxmox VE standard bridge is called `vmbr0`.|
 |`tag`|`integer`|`-1`|The VLAN tag to apply to packets on this device. `-1` disables VLAN tagging.|
 |`firewall`|`boolean`|`false`|Whether to enable the Proxmox firewall on this network device.|
@@ -187,16 +187,16 @@ See the [docs about disks](https://pve.proxmox.com/pve-docs/chapter-qm.html#qm_h
 
 |Argument|Type|Default Value|Description|
 |--------|----|-------------|-----------|
-|`type`|`string`|`""`|**Required** The type of disk device to add. Options: `ide`, `sata`, `scsi`, `virtio`|
-|`storage`|`string`|`""`|**Required** The name of the storage pool on which to store the disk.|
-|`size`|`string`|`""`|**Required** The size of the created disk, format must match the regex `\d+[GMK]`, where G, M, and K represent Gigabytes, Megabytes, and Kilobytes respectively.|
+|`type`|`string`||**Required** The type of disk device to add. Options: `ide`, `sata`, `scsi`, `virtio`|
+|`storage`|`string`||**Required** The name of the storage pool on which to store the disk.|
+|`size`|`string`||**Required** The size of the created disk, format must match the regex `\d+[GMK]`, where G, M, and K represent Gigabytes, Megabytes, and Kilobytes respectively.|
 |`format`|`string`|`"raw"`|The drive’s backing file’s data format.|
 |`cache`|`string`|`"none"`|The drive’s cache mode. Options: `directsync`, `none`, `unsafe`, `writeback`, `writethrough`|
 |`backup`|`boolean`|`false`|Whether the drive should be included when making backups.|
 |`iothread`|`boolean`|`false`|Whether to use iothreads for this drive. Only effective with a disk of type `virtio`, or `scsi` when the the emulated controller type is VirtIO SCSI single.|
 |`replicate`|`boolean`|`false`|Whether the drive should considered for replication jobs.|
 |`ssd`|`boolean`|`false`|Whether to expose this drive as an SSD, rather than a rotational hard disk.|
-|`discard`|`boolean`|``|Controls whether to pass discard/trim requests to the underlying storage. Only effective when the underlying storage supports thin provisioning. There are other caveots too, see the [docs about disks](https://pve.proxmox.com/pve-docs/chapter-qm.html#qm_hard_disk) for more info.|
+|`discard`|`boolean`||Controls whether to pass discard/trim requests to the underlying storage. Only effective when the underlying storage supports thin provisioning. There are other caveots too, see the [docs about disks](https://pve.proxmox.com/pve-docs/chapter-qm.html#qm_hard_disk) for more info.|
 |`mbps`|`integer`|`0`|Maximum r/w speed in megabytes per second. `0` means unlimited.|
 |`mbps_rd`|`integer`|`0`|Maximum read speed in megabytes per second. `0` means unlimited.|
 |`mbps_rd_max`|`integer`|`0`|Maximum read speed in megabytes per second. `0` means unlimited.|
@@ -206,7 +206,7 @@ See the [docs about disks](https://pve.proxmox.com/pve-docs/chapter-qm.html#qm_h
 |`media`|`string`|`"disk"`|The drive’s media type. Options: `cdrom`, `disk`|
 |`volume`|`string`|*Computed*|The full path to the drive’s backing volume including the storage pool name. You shouldn't need to specify this, use the `storage` parameter instead.|
 |`slot`|`integer`|*Computed*|(not sure what this is for, seems to be deprecated, do not use)|
-|`storage_type`|`string`|`""`|The type of pool that `storage` is backed by. You shouldn't need to specify this, use the `storage` parameter instead.|
+|`storage_type`|`string`||The type of pool that `storage` is backed by. You shouldn't need to specify this, use the `storage` parameter instead.|
 
 ### Serial Block
 
@@ -219,7 +219,7 @@ See the [options for serial](https://pve.proxmox.com/pve-docs/chapter-qm.html#qm
 |Argument|Type|Default Value|Description|
 |--------|----|-------------|-----------|
 |`id`|`integer`||**Required** The ID of the serial device. Must be between 0-3.|
-|`type`|`string`|`""`|**Required** The type of serial device to create. Options: `socket`, or the path to a serial device like `/dev/ttyS0`.|
+|`type`|`string`||**Required** The type of serial device to create. Options: `socket`, or the path to a serial device like `/dev/ttyS0`.|
 
 ## Attribute Reference
 

--- a/docs/resources/vm_qemu.md
+++ b/docs/resources/vm_qemu.md
@@ -119,6 +119,15 @@ The following arguments are supported in the resource block.
 |`ipconfig1`|`string`|No|`""`|The second IP address to assign to the guest. Same format as `ipconfig0`|
 |`ipconfig2`|`string`|No|`""`|The third IP address to assign to the guest. Same format as `ipconfig0`|
 
+### VGA Block
+
+The `vga` block is used to configure the display device. It may be specified multiple times, however only the first instance of the block will be used.
+
+|Argument|Type|Required?|Default Value|Description|
+|--------|----|---------|-------------|-----------|
+|`type`|`string`|No|`"std"`|The type of display to virtualize. See the [docs about display](https://pve.proxmox.com/pve-docs/chapter-qm.html#qm_display) for more details. Options: `cirrus`, `none`, `qxl`, `qxl2`, `qxl3`, `qxl4`, `serial0`, `serial1`, `serial2`, `serial3`, `std`, `virtio`, `vmware`|
+|`type`|`integer`|No||Sets the VGA memory (in MiB). Has no effect with serial display type.|
+
 * `vga` - (Optional)
     * `type` (Optional; defauls to std)
     * `memory` (Optional)

--- a/docs/resources/vm_qemu.md
+++ b/docs/resources/vm_qemu.md
@@ -1,17 +1,14 @@
 # VM Qemu Resource
 
-Resources are the most important element in the Terraform language. Each resource block describes one or more 
-infrastructure objects, such as virtual networks, compute instances, or higher-level components such as DNS records.
+Resources are the most important element in the Terraform language. Each resource block describes one or more infrastructure objects, such as virtual networks, compute instances, or higher-level components such as DNS records.
 
 This resource manages a Proxmox VM Qemu container.
 
 ## Create a Qemu VM resource
 
-You can start from either an ISO or clone an existing VM. Optimally, you could create a VM resource you will use a clone 
-base with an ISO, and make the rest of the VM resources depend on that base "template" and clone it.
+You can start from either an ISO or clone an existing VM. Optimally, you could create a VM resource you will use a clone base with an ISO, and make the rest of the VM resources depend on that base "template" and clone it.
 
-When creating a VM Qemu resource, you create a `proxmox_vm_qemu` resource block. The name and target node of the VM are
-the only required parameters.
+When creating a VM Qemu resource, you create a `proxmox_vm_qemu` resource block. The name and target node of the VM are the only required parameters.
 
 ```hcl
 resource "proxmox_vm_qemu" "resource-name" {
@@ -22,8 +19,7 @@ resource "proxmox_vm_qemu" "resource-name" {
 
 ## Preprovision
 
-With preprovision you can provision a VM directly from the resource block. This provisioning method is therefore ran
-**before** provision blocks. When using preprovision, there are three `os_type` options: `ubuntu`, `centos` or `cloud-init`.
+With preprovision you can provision a VM directly from the resource block. This provisioning method is therefore ran **before** provision blocks. When using preprovision, there are three `os_type` options: `ubuntu`, `centos` or `cloud-init`.
 
 ```hcl
 resource "proxmox_vm_qemu" "prepprovision-test" {
@@ -35,9 +31,7 @@ resource "proxmox_vm_qemu" "prepprovision-test" {
 
 ### Preprovision for Linux (Ubuntu / CentOS)
 
-There is a pre-provision phase which is used to set a hostname, intialize eth0, and resize the VM disk to available 
-space. This is done over SSH with the `ssh_forward_ip`, `ssh_user` and `ssh_private_key`. Disk resize is done if the file 
-[/etc/auto_resize_vda.sh](https://github.com/Telmate/terraform-ubuntu-proxmox-iso/blob/master/auto_resize_vda.sh) exists.
+There is a pre-provision phase which is used to set a hostname, intialize eth0, and resize the VM disk to available space. This is done over SSH with the `ssh_forward_ip`, `ssh_user` and `ssh_private_key`. Disk resize is done if the file [/etc/auto_resize_vda.sh](https://github.com/Telmate/terraform-ubuntu-proxmox-iso/blob/master/auto_resize_vda.sh) exists.
 
 ```hcl
 resource "proxmox_vm_qemu" "prepprovision-test" {
@@ -55,7 +49,7 @@ EOF
 auto eth0
 iface eth0 inet dhcp
 EOF
-    
+
     connection {
         type = "ssh"
         user = "${self.ssh_user}"
@@ -69,10 +63,7 @@ EOF
 
 ## Preprovision for Cloud-Init
 
-Cloud-init VMs must be cloned from a [cloud-init ready template](https://pve.proxmox.com/wiki/Cloud-Init_Support). When
-creating a resource that is using Cloud-Init, there are multi configurations possible. You can use either the `ciconfig`
-parameter to create based on [a Cloud-init configuration file](https://cloudinit.readthedocs.io/en/latest/topics/examples.html)
-or use the Proxmox variable `ciuser`, `cipassword`, `ipconfig0`, `ipconfig1`, `searchdomain`, `nameserver` and `sshkeys`.
+Cloud-init VMs must be cloned from a [cloud-init ready template](https://pve.proxmox.com/wiki/Cloud-Init_Support). When creating a resource that is using Cloud-Init, there are multi configurations possible. You can use either the `ciconfig` parameter to create based on [a Cloud-init configuration file](https://cloudinit.readthedocs.io/en/latest/topics/examples.html) or use the Proxmox variable `ciuser`, `cipassword`, `ipconfig0`, `ipconfig1`, `searchdomain`, `nameserver` and `sshkeys`.
 
 For more information, see the [Cloud-init guide](docs/guides/cloud_init.md).
 

--- a/docs/resources/vm_qemu.md
+++ b/docs/resources/vm_qemu.md
@@ -75,51 +75,51 @@ The following arguments are supported in the top level resource block.
 
 |Argument|Type|Default Value|Description|
 |--------|----|-------------|-----------|
-|`name`|`string`||**Required** The name of the VM within Proxmox.|
-|`target_node`|`string`||**Required** The name of the Proxmox Node on which to place the VM.|
-|`vmid`|`integer`|`0`|The ID of the VM in Proxmox. The default value of `0` indicates it should use the next available ID in the sequence.|
-|`desc`|`string`||The description of the VM. Shows as the 'Notes' field in the Proxmox GUI.|
+|`name`|`str`||**Required** The name of the VM within Proxmox.|
+|`target_node`|`str`||**Required** The name of the Proxmox Node on which to place the VM.|
+|`vmid`|`int`|`0`|The ID of the VM in Proxmox. The default value of `0` indicates it should use the next available ID in the sequence.|
+|`desc`|`str`||The description of the VM. Shows as the 'Notes' field in the Proxmox GUI.|
 |`define_connection_info`|`bool`|`true`|Whether to let terraform define the (SSH) connection parameters for preprovisioners, see config block below.|
-|`bios`|`string`|`"seabios"`|The BIOS to use, options are `seabios` or `ovmf` for UEFI.|
+|`bios`|`str`|`"seabios"`|The BIOS to use, options are `seabios` or `ovmf` for UEFI.|
 |`onboot`|`bool`|`true`|Whether to have the VM startup after the PVE node starts.|
-|`boot`|`string`|`"cdn"`|The boot order for the VM. Ordered string of characters denoting boot order. Options: floppy (`a`), hard disk (`c`), CD-ROM (`d`), or network (`n`).|
-|`bootdisk`|`string`||Enable booting from specified disk. You shouldn't need to change it under most circumstances.|
-|`agent`|`integer`|`0`|Set to `1` to enable the QEMU Guest Agent. Note, you must run the [`qemu-guest-agent`](https://pve.proxmox.com/wiki/Qemu-guest-agent) daemon in the quest for this to have any effect.|
-|`iso`|`string`||The name of the ISO image to mount to the VM. Only applies when `clone` is not set.|
-|`clone`|`string`||The base VM from which to clone to create the new VM.|
+|`boot`|`str`|`"cdn"`|The boot order for the VM. Ordered string of characters denoting boot order. Options: floppy (`a`), hard disk (`c`), CD-ROM (`d`), or network (`n`).|
+|`bootdisk`|`str`||Enable booting from specified disk. You shouldn't need to change it under most circumstances.|
+|`agent`|`int`|`0`|Set to `1` to enable the QEMU Guest Agent. Note, you must run the [`qemu-guest-agent`](https://pve.proxmox.com/wiki/Qemu-guest-agent) daemon in the quest for this to have any effect.|
+|`iso`|`str`||The name of the ISO image to mount to the VM. Only applies when `clone` is not set.|
+|`clone`|`str`||The base VM from which to clone to create the new VM.|
 |`full_clone`|`bool`|`true`|Set to `true` to create a full clone, or `false` to create a linked clone. See the [docs about cloning](https://pve.proxmox.com/pve-docs/chapter-qm.html#qm_copy_and_clone) for more info. Only applies when `clone` is set.|
-|`hastate`|`string`||Requested HA state for the resource. One of "started", "stopped", "enabled", "disabled", or "ignored". See the [docs about HA](https://pve.proxmox.com/pve-docs/chapter-ha-manager.html#ha_manager_resource_config) for more info.|
-|`qemu_os`|`string`|`"l26"`|The type of OS in the guest. Set properly to allow Proxmox to enable optimizations for the appropriate guest OS.|
-|`memory`|`integer`|`512`|The amount of memory to allocate to the VM in bytes.|
-|`balloon`|`integer`|`0`|Whether to add the ballooning device to the VM. Options are `1` and `0`. See the [docs about memory](https://pve.proxmox.com/pve-docs/chapter-qm.html#qm_memory) for more info.|
-|`sockets`|`integer`|`1`|The number of CPU sockets to allocate to the VM.|
-|`cores`|`integer`|`1`|The number of CPU cores per CPU socket to allocate to the VM.|
-|`vcpus`|`integer`|`0`|The number of vCPUs plugged into the VM when it starts. If `0`, this is set automatically by Proxmox to `sockets * cores`.|
-|`cpu`|`string`|`"host"`|The type of CPU to emulate in the Guest. See the [docs about CPU Types](https://pve.proxmox.com/pve-docs/chapter-qm.html#qm_cpu) for more info.|
+|`hastate`|`str`||Requested HA state for the resource. One of "started", "stopped", "enabled", "disabled", or "ignored". See the [docs about HA](https://pve.proxmox.com/pve-docs/chapter-ha-manager.html#ha_manager_resource_config) for more info.|
+|`qemu_os`|`str`|`"l26"`|The type of OS in the guest. Set properly to allow Proxmox to enable optimizations for the appropriate guest OS.|
+|`memory`|`int`|`512`|The amount of memory to allocate to the VM in bytes.|
+|`balloon`|`int`|`0`|Whether to add the ballooning device to the VM. Options are `1` and `0`. See the [docs about memory](https://pve.proxmox.com/pve-docs/chapter-qm.html#qm_memory) for more info.|
+|`sockets`|`int`|`1`|The number of CPU sockets to allocate to the VM.|
+|`cores`|`int`|`1`|The number of CPU cores per CPU socket to allocate to the VM.|
+|`vcpus`|`int`|`0`|The number of vCPUs plugged into the VM when it starts. If `0`, this is set automatically by Proxmox to `sockets * cores`.|
+|`cpu`|`str`|`"host"`|The type of CPU to emulate in the Guest. See the [docs about CPU Types](https://pve.proxmox.com/pve-docs/chapter-qm.html#qm_cpu) for more info.|
 |`numa`|`bool`|`false`|Whether to enable [Non-Uniform Memory Access](https://pve.proxmox.com/pve-docs/chapter-qm.html#qm_cpu) in the guest.|
-|`hotplug`|`string`|`"network,disk,usb"`|Comma delimited list of hotplug features to enable. Options: `network`, `disk`, `cpu`, `memory`, `usb`. Set to `0` to disable hotplug.|
-|`scsihw`|`string`|`"lsi"`|The SCSI controller to emulate. Options: `lsi`, `lsi53c810`, `megasas`, `pvscsi`, `virtio-scsi-pci`, `virtio-scsi-single`.|
-|`pool`|`string`||The resource pool to which the VM will be added.|
+|`hotplug`|`str`|`"network,disk,usb"`|Comma delimited list of hotplug features to enable. Options: `network`, `disk`, `cpu`, `memory`, `usb`. Set to `0` to disable hotplug.|
+|`scsihw`|`str`|`"lsi"`|The SCSI controller to emulate. Options: `lsi`, `lsi53c810`, `megasas`, `pvscsi`, `virtio-scsi-pci`, `virtio-scsi-single`.|
+|`pool`|`str`||The resource pool to which the VM will be added.|
 |`force_create`|`bool`|`false`|If `false`, and a vm of the same name, on the same node exists, terraform will attempt to reconfigure that VM with these settings. Set to true to always create a new VM (note, the name of the VM must still be unique, otherwise an error will be produced.)|
-|`clone_wait`|`integer`|`15`|Provider will wait `clone_wait`/2 seconds after a clone operation and `clone_wait` seconds after an UpdateConfig operation.|
-|`additional_wait`|`integer`|`15`|The amount of time in seconds to wait between creating the VM and powering it up.|
+|`clone_wait`|`int`|`15`|Provider will wait `clone_wait`/2 seconds after a clone operation and `clone_wait` seconds after an UpdateConfig operation.|
+|`additional_wait`|`int`|`15`|The amount of time in seconds to wait between creating the VM and powering it up.|
 |`preprovision`|`bool`|`true`|Whether to preprovision the VM. See [Preprovision](#Preprovision) above for more info.|
-|`os_type`|`string`||Which provisioning method to use, based on the OS type. Options: `ubuntu`, `centos`, `cloud-init`.|
-|`force_recreate_on_change_of`|`string`||If the value of this string changes, the VM will be recreated. Useful for allowing this resource to be recreated when arbitrary attributes change. An example where this is useful is a cloudinit configuration (as the `cicustom` attribute points to a file not the content).|
-|`os_network_config`|`string`||Only applies when `define_connection_info` is true. Network configuration to be copied into the VM when preprovisioning `ubuntu` or `centos` guests. The specified configuration is added to `/etc/network/interfaces` for Ubuntu, or `/etc/sysconfig/network-scripts/ifcfg-eth0` for CentOS. Forces re-creation on change.|
-|`ssh_forward_ip`|`string`||Only applies when `define_connection_info` is true. The IP (and optional colon separated port), to use to connect to the host for preprovisioning. If using cloud-init, this can be left blank.|
-|`ssh_user`|`string`||Only applies when `define_connection_info` is true. The user with which to connect to the guest for preprovisioning. Forces re-creation on change.|
-|`ssh_private_key`|`string`||Only applies when `define_connection_info` is true. The private key to use when connecting to the guest for preprovisioning. Sensitive.|
-|`ci_wait`|`integer`|`30`|How to long in seconds to wait for before provisioning.|
-|`ciuser`|`string`||Override the default cloud-init user for provisioning.|
-|`cipassword`|`string`||Override the default cloud-init user's password. Sensitive.|
-|`cicustom`|`string`||Instead specifying ciuser, cipasword, etc... you can specify the path to a custom cloud-init config file here. Grants more flexibility in configuring cloud-init.|
-|`searchdomain`|`string`||Sets default DNS search domain suffix.|
-|`nameserver`|`string`||Sets default DNS server for guest.|
-|`sshkeys`|`string`||Newline delimited list of SSH public keys to add to authorized keys file for the cloud-init user.|
-|`ipconfig0`|`string`||The first IP address to assign to the guest. Format: `[gw=<GatewayIPv4>] [,gw6=<GatewayIPv6>] [,ip=<IPv4Format/CIDR>] [,ip6=<IPv6Format/CIDR>]`.|
-|`ipconfig1`|`string`||The second IP address to assign to the guest. Same format as `ipconfig0`.|
-|`ipconfig2`|`string`||The third IP address to assign to the guest. Same format as `ipconfig0`.|
+|`os_type`|`str`||Which provisioning method to use, based on the OS type. Options: `ubuntu`, `centos`, `cloud-init`.|
+|`force_recreate_on_change_of`|`str`||If the value of this string changes, the VM will be recreated. Useful for allowing this resource to be recreated when arbitrary attributes change. An example where this is useful is a cloudinit configuration (as the `cicustom` attribute points to a file not the content).|
+|`os_network_config`|`str`||Only applies when `define_connection_info` is true. Network configuration to be copied into the VM when preprovisioning `ubuntu` or `centos` guests. The specified configuration is added to `/etc/network/interfaces` for Ubuntu, or `/etc/sysconfig/network-scripts/ifcfg-eth0` for CentOS. Forces re-creation on change.|
+|`ssh_forward_ip`|`str`||Only applies when `define_connection_info` is true. The IP (and optional colon separated port), to use to connect to the host for preprovisioning. If using cloud-init, this can be left blank.|
+|`ssh_user`|`str`||Only applies when `define_connection_info` is true. The user with which to connect to the guest for preprovisioning. Forces re-creation on change.|
+|`ssh_private_key`|`str`||Only applies when `define_connection_info` is true. The private key to use when connecting to the guest for preprovisioning. Sensitive.|
+|`ci_wait`|`int`|`30`|How to long in seconds to wait for before provisioning.|
+|`ciuser`|`str`||Override the default cloud-init user for provisioning.|
+|`cipassword`|`str`||Override the default cloud-init user's password. Sensitive.|
+|`cicustom`|`str`||Instead specifying ciuser, cipasword, etc... you can specify the path to a custom cloud-init config file here. Grants more flexibility in configuring cloud-init.|
+|`searchdomain`|`str`||Sets default DNS search domain suffix.|
+|`nameserver`|`str`||Sets default DNS server for guest.|
+|`sshkeys`|`str`||Newline delimited list of SSH public keys to add to authorized keys file for the cloud-init user.|
+|`ipconfig0`|`str`||The first IP address to assign to the guest. Format: `[gw=<GatewayIPv4>] [,gw6=<GatewayIPv6>] [,ip=<IPv4Format/CIDR>] [,ip6=<IPv6Format/CIDR>]`.|
+|`ipconfig1`|`str`||The second IP address to assign to the guest. Same format as `ipconfig0`.|
+|`ipconfig2`|`str`||The third IP address to assign to the guest. Same format as `ipconfig0`.|
 
 ### VGA Block
 
@@ -129,8 +129,8 @@ See the [docs about display](https://pve.proxmox.com/pve-docs/chapter-qm.html#qm
 
 |Argument|Type|Default Value|Description|
 |--------|----|-------------|-----------|
-|`type`|`string`|`"std"`|The type of display to virtualize. Options: `cirrus`, `none`, `qxl`, `qxl2`, `qxl3`, `qxl4`, `serial0`, `serial1`, `serial2`, `serial3`, `std`, `virtio`, `vmware`.|
-|`type`|`integer`||Sets the VGA memory (in MiB). Has no effect with serial display type.|
+|`type`|`str`|`"std"`|The type of display to virtualize. Options: `cirrus`, `none`, `qxl`, `qxl2`, `qxl3`, `qxl4`, `serial0`, `serial1`, `serial2`, `serial3`, `std`, `virtio`, `vmware`.|
+|`type`|`int`||Sets the VGA memory (in MiB). Has no effect with serial display type.|
 
 ### Network Block
 
@@ -140,14 +140,14 @@ See the [docs about network devices](https://pve.proxmox.com/pve-docs/chapter-qm
 
 |Argument|Type|Default Value|Description|
 |--------|----|-------------|-----------|
-|`model`|`string`||**Required** Network Card Model. The virtio model provides the best performance with very low CPU overhead. If your guest does not support this driver, it is usually best to use e1000. Options: `e1000`, `e1000-82540em`, `e1000-82544gc`, `e1000-82545em`, `i82551`, `i82557b`, `i82559er`, `ne2k_isa`, `ne2k_pci`, `pcnet`, `rtl8139`, `virtio`, `vmxnet3`.|
-|`macaddr`|`string`||Override the randomly generated MAC Address for the VM.|
-|`bridge`|`string`|`"nat"`|Bridge to which the network device should be attached. The Proxmox VE standard bridge is called `vmbr0`.|
-|`tag`|`integer`|`-1`|The VLAN tag to apply to packets on this device. `-1` disables VLAN tagging.|
-|`firewall`|`boolean`|`false`|Whether to enable the Proxmox firewall on this network device.|
-|`rate`|`integer`|`0`|Network device rate limit in mbps (megabytes per second) as floating point number. Set to `0` to disable rate limiting.|
-|`queues`|`integer`|`1`|Number of packet queues to be used on the device. Requires `virtio` model to have an effect.|
-|`link_down`|`boolean`|`false`|Whether this interface should be disconnected (like pulling the plug).|
+|`model`|`str`||**Required** Network Card Model. The virtio model provides the best performance with very low CPU overhead. If your guest does not support this driver, it is usually best to use e1000. Options: `e1000`, `e1000-82540em`, `e1000-82544gc`, `e1000-82545em`, `i82551`, `i82557b`, `i82559er`, `ne2k_isa`, `ne2k_pci`, `pcnet`, `rtl8139`, `virtio`, `vmxnet3`.|
+|`macaddr`|`str`||Override the randomly generated MAC Address for the VM.|
+|`bridge`|`str`|`"nat"`|Bridge to which the network device should be attached. The Proxmox VE standard bridge is called `vmbr0`.|
+|`tag`|`int`|`-1`|The VLAN tag to apply to packets on this device. `-1` disables VLAN tagging.|
+|`firewall`|`bool`|`false`|Whether to enable the Proxmox firewall on this network device.|
+|`rate`|`int`|`0`|Network device rate limit in mbps (megabytes per second) as floating point number. Set to `0` to disable rate limiting.|
+|`queues`|`int`|`1`|Number of packet queues to be used on the device. Requires `virtio` model to have an effect.|
+|`link_down`|`bool`|`false`|Whether this interface should be disconnected (like pulling the plug).|
 
 ### Disk Block
 
@@ -187,26 +187,26 @@ See the [docs about disks](https://pve.proxmox.com/pve-docs/chapter-qm.html#qm_h
 
 |Argument|Type|Default Value|Description|
 |--------|----|-------------|-----------|
-|`type`|`string`||**Required** The type of disk device to add. Options: `ide`, `sata`, `scsi`, `virtio`.|
-|`storage`|`string`||**Required** The name of the storage pool on which to store the disk.|
-|`size`|`string`||**Required** The size of the created disk, format must match the regex `\d+[GMK]`, where G, M, and K represent Gigabytes, Megabytes, and Kilobytes respectively.|
-|`format`|`string`|`"raw"`|The drive’s backing file’s data format.|
-|`cache`|`string`|`"none"`|The drive’s cache mode. Options: `directsync`, `none`, `unsafe`, `writeback`, `writethrough`|
-|`backup`|`boolean`|`false`|Whether the drive should be included when making backups.|
-|`iothread`|`boolean`|`false`|Whether to use iothreads for this drive. Only effective with a disk of type `virtio`, or `scsi` when the the emulated controller type (`scsihw` top level block argument) is `virtio-scsi-single`.|
-|`replicate`|`boolean`|`false`|Whether the drive should considered for replication jobs.|
-|`ssd`|`boolean`|`false`|Whether to expose this drive as an SSD, rather than a rotational hard disk.|
-|`discard`|`boolean`||Controls whether to pass discard/trim requests to the underlying storage. Only effective when the underlying storage supports thin provisioning. There are other caveots too, see the [docs about disks](https://pve.proxmox.com/pve-docs/chapter-qm.html#qm_hard_disk) for more info.|
-|`mbps`|`integer`|`0`|Maximum r/w speed in megabytes per second. `0` means unlimited.|
-|`mbps_rd`|`integer`|`0`|Maximum read speed in megabytes per second. `0` means unlimited.|
-|`mbps_rd_max`|`integer`|`0`|Maximum read speed in megabytes per second. `0` means unlimited.|
-|`mbps_wr`|`integer`|`0`|Maximum write speed in megabytes per second. `0` means unlimited.|
-|`mbps_wr_max`|`integer`|`0`|Maximum unthrottled write pool in megabytes per second. `0` means unlimited.|
-|`file`|`string`||The filename portion of the path to the drive’s backing volume. You shouldn't need to specify this, use the `storage` parameter instead.|
-|`media`|`string`|`"disk"`|The drive’s media type. Options: `cdrom`, `disk`.|
-|`volume`|`string`||The full path to the drive’s backing volume including the storage pool name. You shouldn't need to specify this, use the `storage` parameter instead.|
-|`slot`|`integer`||*(not sure what this is for, seems to be deprecated, do not use)*.|
-|`storage_type`|`string`||The type of pool that `storage` is backed by. You shouldn't need to specify this, use the `storage` parameter instead.|
+|`type`|`str`||**Required** The type of disk device to add. Options: `ide`, `sata`, `scsi`, `virtio`.|
+|`storage`|`str`||**Required** The name of the storage pool on which to store the disk.|
+|`size`|`str`||**Required** The size of the created disk, format must match the regex `\d+[GMK]`, where G, M, and K represent Gigabytes, Megabytes, and Kilobytes respectively.|
+|`format`|`str`|`"raw"`|The drive’s backing file’s data format.|
+|`cache`|`str`|`"none"`|The drive’s cache mode. Options: `directsync`, `none`, `unsafe`, `writeback`, `writethrough`|
+|`backup`|`bool`|`false`|Whether the drive should be included when making backups.|
+|`iothread`|`bool`|`false`|Whether to use iothreads for this drive. Only effective with a disk of type `virtio`, or `scsi` when the the emulated controller type (`scsihw` top level block argument) is `virtio-scsi-single`.|
+|`replicate`|`bool`|`false`|Whether the drive should considered for replication jobs.|
+|`ssd`|`bool`|`false`|Whether to expose this drive as an SSD, rather than a rotational hard disk.|
+|`discard`|`bool`||Controls whether to pass discard/trim requests to the underlying storage. Only effective when the underlying storage supports thin provisioning. There are other caveots too, see the [docs about disks](https://pve.proxmox.com/pve-docs/chapter-qm.html#qm_hard_disk) for more info.|
+|`mbps`|`int`|`0`|Maximum r/w speed in megabytes per second. `0` means unlimited.|
+|`mbps_rd`|`int`|`0`|Maximum read speed in megabytes per second. `0` means unlimited.|
+|`mbps_rd_max`|`int`|`0`|Maximum read speed in megabytes per second. `0` means unlimited.|
+|`mbps_wr`|`int`|`0`|Maximum write speed in megabytes per second. `0` means unlimited.|
+|`mbps_wr_max`|`int`|`0`|Maximum unthrottled write pool in megabytes per second. `0` means unlimited.|
+|`file`|`str`||The filename portion of the path to the drive’s backing volume. You shouldn't need to specify this, use the `storage` parameter instead.|
+|`media`|`str`|`"disk"`|The drive’s media type. Options: `cdrom`, `disk`.|
+|`volume`|`str`||The full path to the drive’s backing volume including the storage pool name. You shouldn't need to specify this, use the `storage` parameter instead.|
+|`slot`|`int`||*(not sure what this is for, seems to be deprecated, do not use)*.|
+|`storage_type`|`str`||The type of pool that `storage` is backed by. You shouldn't need to specify this, use the `storage` parameter instead.|
 
 ### Serial Block
 
@@ -218,8 +218,8 @@ See the [options for serial](https://pve.proxmox.com/pve-docs/chapter-qm.html#qm
 
 |Argument|Type|Default Value|Description|
 |--------|----|-------------|-----------|
-|`id`|`integer`||**Required** The ID of the serial device. Must be unique, and between `0-3`.|
-|`type`|`string`||**Required** The type of serial device to create. Options: `socket`, or the path to a serial device like `/dev/ttyS0`.|
+|`id`|`int`||**Required** The ID of the serial device. Must be unique, and between `0-3`.|
+|`type`|`str`||**Required** The type of serial device to create. Options: `socket`, or the path to a serial device like `/dev/ttyS0`.|
 
 ## Attribute Reference
 
@@ -227,8 +227,8 @@ In addition to  the arguments above, the following attributes can be referenced 
 
 |Attribute|Type|Description|
 |---------|----|-----------|
-|`ssh_host`|`string`|Read-only attribute. Only applies when `define_connection_info` is true. The hostname or IP to use to connect to the VM for preprovisioning. This can be overridden by defining `ssh_forward_ip`, but if you're using cloud-init and `ipconfig0=dhcp`, the IP reported by qemu-guest-agent is used, otherwise the IP defined in `ipconfig0` is used.|
-|`ssh_port`|`string`|Read-only attribute. Only applies when `define_connection_info` is true. The port to connect to the VM over SSH for preprovisioning. If using cloud-init and a port is not specified in `ssh_forward_ip`, then 22 is used. If not using cloud-init, a port on the `target_node` will be forwarded to port 22 in the guest, and this attribute will be set to the forwarded port.|
+|`ssh_host`|`str`|Read-only attribute. Only applies when `define_connection_info` is true. The hostname or IP to use to connect to the VM for preprovisioning. This can be overridden by defining `ssh_forward_ip`, but if you're using cloud-init and `ipconfig0=dhcp`, the IP reported by qemu-guest-agent is used, otherwise the IP defined in `ipconfig0` is used.|
+|`ssh_port`|`str`|Read-only attribute. Only applies when `define_connection_info` is true. The port to connect to the VM over SSH for preprovisioning. If using cloud-init and a port is not specified in `ssh_forward_ip`, then 22 is used. If not using cloud-init, a port on the `target_node` will be forwarded to port 22 in the guest, and this attribute will be set to the forwarded port.|
 
 ## Deprecated Arguments
 

--- a/docs/resources/vm_qemu.md
+++ b/docs/resources/vm_qemu.md
@@ -67,6 +67,8 @@ For more information, see the [Cloud-init guide](docs/guides/cloud_init.md).
 
 ## Argument reference
 
+**Note: Except where explicitly stated in the description, all arguments are assumed to be optional.**
+
 ### Top Level Block
 
 The following arguments are supported in the top level resource block.

--- a/docs/resources/vm_qemu.md
+++ b/docs/resources/vm_qemu.md
@@ -84,7 +84,7 @@ The following arguments are supported in the top level resource block.
 |`onboot`|`bool`|`true`|Whether to have the VM startup after the PVE node starts.|
 |`boot`|`string`|`"cdn"`|The boot order for the VM. Ordered string of characters denoting boot order. Options: floppy (`a`), hard disk (`c`), CD-ROM (`d`), or network (`n`).|
 |`bootdisk`|`string`||Enable booting from specified disk. You shouldn't need to change it under most circumstances.|
-|`agent`|`integer`|`0`|Whether to enable the QEMU Guest Agent. Note, you must still install the [`qemu-guest-agent`](https://pve.proxmox.com/wiki/Qemu-guest-agent) daemon in the quest for this to have any effect.|
+|`agent`|`integer`|`0`|Set to `1` to enable the QEMU Guest Agent. Note, you must run the [`qemu-guest-agent`](https://pve.proxmox.com/wiki/Qemu-guest-agent) daemon in the quest for this to have any effect.|
 |`iso`|`string`||The name of the ISO image to mount to the VM. Only applies when `clone` is not set.|
 |`clone`|`string`||The base VM from which to clone to create the new VM.|
 |`full_clone`|`bool`|`true`|Set to `true` to create a full clone, or `false` to create a linked clone. See the [docs about cloning](https://pve.proxmox.com/pve-docs/chapter-qm.html#qm_copy_and_clone) for more info. Only applies when `clone` is set.|

--- a/docs/resources/vm_qemu.md
+++ b/docs/resources/vm_qemu.md
@@ -94,15 +94,15 @@ The following arguments are supported in the top level resource block.
 |`balloon`|`integer`|`0`|Whether to add the ballooning device to the VM. Options are `1` and `0`. See the [docs about memory](https://pve.proxmox.com/pve-docs/chapter-qm.html#qm_memory) for more info.|
 |`sockets`|`integer`|`1`|The number of CPU sockets to allocate to the VM.|
 |`cores`|`integer`|`1`|The number of CPU cores per CPU socket to allocate to the VM.|
-|`vcpus`|`integer`|`0`|The number of vCPUs plugged into the VM when it starts. If 0, this is set automatically by Proxmox to `sockets * cores`.|
+|`vcpus`|`integer`|`0`|The number of vCPUs plugged into the VM when it starts. If `0`, this is set automatically by Proxmox to `sockets * cores`.|
 |`cpu`|`string`|`"host"`|The type of CPU to emulate in the Guest. See the [docs about CPU Types](https://pve.proxmox.com/pve-docs/chapter-qm.html#qm_cpu) for more info.|
 |`numa`|`bool`|`false`|Whether to enable [Non-Uniform Memory Access](https://pve.proxmox.com/pve-docs/chapter-qm.html#qm_cpu) in the guest.|
 |`hotplug`|`string`|`"network,disk,usb"`|Comma delimited list of hotplug features to enable. Options: `network`, `disk`, `cpu`, `memory`, `usb`. Set to `0` to disable hotplug.|
 |`scsihw`|`string`|`"lsi"`|The SCSI controller to emulate. Options: `lsi`, `lsi53c810`, `megasas`, `pvscsi`, `virtio-scsi-pci`, `virtio-scsi-single`.|
 |`pool`|`string`||The resource pool to which the VM will be added.|
 |`force_create`|`bool`|`false`|If `false`, and a vm of the same name, on the same node exists, terraform will attempt to reconfigure that VM with these settings. Set to true to always create a new VM (note, the name of the VM must still be unique, otherwise an error will be produced.)|
-|`clone_wait`|`integer`|`15`|The amount of time in seconds to wait between cloning a VM and performing post-clone actions such as updating the VM.|
-|`additional_wait`|`integer`|`15`|Provider will wait `additional_wait`/2 seconds after a clone operation and `additional_wait` seconds after an UpdateConfig operation.|
+|`clone_wait`|`integer`|`15`|Provider will wait `clone_wait`/2 seconds after a clone operation and `clone_wait` seconds after an UpdateConfig operation.|
+|`additional_wait`|`integer`|`15`|The amount of time in seconds to wait between creating the VM and powering it up.|
 |`preprovision`|`bool`|`true`|Whether to preprovision the VM. See [Preprovision](#Preprovision) above for more info.|
 |`os_type`|`string`||Which provisioning method to use, based on the OS type. Options: `ubuntu`, `centos`, `cloud-init`.|
 |`force_recreate_on_change_of`|`string`||If the value of this string changes, the VM will be recreated. Useful for allowing this resource to be recreated when arbitrary attributes change. An example where this is useful is a cloudinit configuration (as the `cicustom` attribute points to a file not the content).|
@@ -117,9 +117,9 @@ The following arguments are supported in the top level resource block.
 |`searchdomain`|`string`||Sets default DNS search domain suffix.|
 |`nameserver`|`string`||Sets default DNS server for guest.|
 |`sshkeys`|`string`||Newline delimited list of SSH public keys to add to authorized keys file for the cloud-init user.|
-|`ipconfig0`|`string`||The first IP address to assign to the guest. Format: `[gw=<GatewayIPv4>] [,gw6=<GatewayIPv6>] [,ip=<IPv4Format/CIDR>] [,ip6=<IPv6Format/CIDR>]`|
-|`ipconfig1`|`string`||The second IP address to assign to the guest. Same format as `ipconfig0`|
-|`ipconfig2`|`string`||The third IP address to assign to the guest. Same format as `ipconfig0`|
+|`ipconfig0`|`string`||The first IP address to assign to the guest. Format: `[gw=<GatewayIPv4>] [,gw6=<GatewayIPv6>] [,ip=<IPv4Format/CIDR>] [,ip6=<IPv6Format/CIDR>]`.|
+|`ipconfig1`|`string`||The second IP address to assign to the guest. Same format as `ipconfig0`.|
+|`ipconfig2`|`string`||The third IP address to assign to the guest. Same format as `ipconfig0`.|
 
 ### VGA Block
 
@@ -129,7 +129,7 @@ See the [docs about display](https://pve.proxmox.com/pve-docs/chapter-qm.html#qm
 
 |Argument|Type|Default Value|Description|
 |--------|----|-------------|-----------|
-|`type`|`string`|`"std"`|The type of display to virtualize. Options: `cirrus`, `none`, `qxl`, `qxl2`, `qxl3`, `qxl4`, `serial0`, `serial1`, `serial2`, `serial3`, `std`, `virtio`, `vmware`|
+|`type`|`string`|`"std"`|The type of display to virtualize. Options: `cirrus`, `none`, `qxl`, `qxl2`, `qxl3`, `qxl4`, `serial0`, `serial1`, `serial2`, `serial3`, `std`, `virtio`, `vmware`.|
 |`type`|`integer`||Sets the VGA memory (in MiB). Has no effect with serial display type.|
 
 ### Network Block
@@ -140,7 +140,7 @@ See the [docs about network devices](https://pve.proxmox.com/pve-docs/chapter-qm
 
 |Argument|Type|Default Value|Description|
 |--------|----|-------------|-----------|
-|`model`|`string`||**Required** Network Card Model. The virtio model provides the best performance with very low CPU overhead. If your guest does not support this driver, it is usually best to use e1000. Options: `e1000`, `e1000-82540em`, `e1000-82544gc`, `e1000-82545em`, `i82551`, `i82557b`, `i82559er`, `ne2k_isa`, `ne2k_pci`, `pcnet`, `rtl8139`, `virtio`, `vmxnet3`|
+|`model`|`string`||**Required** Network Card Model. The virtio model provides the best performance with very low CPU overhead. If your guest does not support this driver, it is usually best to use e1000. Options: `e1000`, `e1000-82540em`, `e1000-82544gc`, `e1000-82545em`, `i82551`, `i82557b`, `i82559er`, `ne2k_isa`, `ne2k_pci`, `pcnet`, `rtl8139`, `virtio`, `vmxnet3`.|
 |`macaddr`|`string`||Override the randomly generated MAC Address for the VM.|
 |`bridge`|`string`|`"nat"`|Bridge to which the network device should be attached. The Proxmox VE standard bridge is called `vmbr0`.|
 |`tag`|`integer`|`-1`|The VLAN tag to apply to packets on this device. `-1` disables VLAN tagging.|
@@ -187,13 +187,13 @@ See the [docs about disks](https://pve.proxmox.com/pve-docs/chapter-qm.html#qm_h
 
 |Argument|Type|Default Value|Description|
 |--------|----|-------------|-----------|
-|`type`|`string`||**Required** The type of disk device to add. Options: `ide`, `sata`, `scsi`, `virtio`|
+|`type`|`string`||**Required** The type of disk device to add. Options: `ide`, `sata`, `scsi`, `virtio`.|
 |`storage`|`string`||**Required** The name of the storage pool on which to store the disk.|
 |`size`|`string`||**Required** The size of the created disk, format must match the regex `\d+[GMK]`, where G, M, and K represent Gigabytes, Megabytes, and Kilobytes respectively.|
 |`format`|`string`|`"raw"`|The drive’s backing file’s data format.|
 |`cache`|`string`|`"none"`|The drive’s cache mode. Options: `directsync`, `none`, `unsafe`, `writeback`, `writethrough`|
 |`backup`|`boolean`|`false`|Whether the drive should be included when making backups.|
-|`iothread`|`boolean`|`false`|Whether to use iothreads for this drive. Only effective with a disk of type `virtio`, or `scsi` when the the emulated controller type is VirtIO SCSI single.|
+|`iothread`|`boolean`|`false`|Whether to use iothreads for this drive. Only effective with a disk of type `virtio`, or `scsi` when the the emulated controller type (`scsihw` top level block argument) is `virtio-scsi-single`.|
 |`replicate`|`boolean`|`false`|Whether the drive should considered for replication jobs.|
 |`ssd`|`boolean`|`false`|Whether to expose this drive as an SSD, rather than a rotational hard disk.|
 |`discard`|`boolean`||Controls whether to pass discard/trim requests to the underlying storage. Only effective when the underlying storage supports thin provisioning. There are other caveots too, see the [docs about disks](https://pve.proxmox.com/pve-docs/chapter-qm.html#qm_hard_disk) for more info.|
@@ -203,9 +203,9 @@ See the [docs about disks](https://pve.proxmox.com/pve-docs/chapter-qm.html#qm_h
 |`mbps_wr`|`integer`|`0`|Maximum write speed in megabytes per second. `0` means unlimited.|
 |`mbps_wr_max`|`integer`|`0`|Maximum unthrottled write pool in megabytes per second. `0` means unlimited.|
 |`file`|`string`||The filename portion of the path to the drive’s backing volume. You shouldn't need to specify this, use the `storage` parameter instead.|
-|`media`|`string`|`"disk"`|The drive’s media type. Options: `cdrom`, `disk`|
+|`media`|`string`|`"disk"`|The drive’s media type. Options: `cdrom`, `disk`.|
 |`volume`|`string`||The full path to the drive’s backing volume including the storage pool name. You shouldn't need to specify this, use the `storage` parameter instead.|
-|`slot`|`integer`||*(not sure what this is for, seems to be deprecated, do not use)*|
+|`slot`|`integer`||*(not sure what this is for, seems to be deprecated, do not use)*.|
 |`storage_type`|`string`||The type of pool that `storage` is backed by. You shouldn't need to specify this, use the `storage` parameter instead.|
 
 ### Serial Block
@@ -218,19 +218,21 @@ See the [options for serial](https://pve.proxmox.com/pve-docs/chapter-qm.html#qm
 
 |Argument|Type|Default Value|Description|
 |--------|----|-------------|-----------|
-|`id`|`integer`||**Required** The ID of the serial device. Must be between 0-3.|
+|`id`|`integer`||**Required** The ID of the serial device. Must be unique, and between `0-3`.|
 |`type`|`string`||**Required** The type of serial device to create. Options: `socket`, or the path to a serial device like `/dev/ttyS0`.|
 
 ## Attribute Reference
 
-In addition to all the arguments above, the following attributes can be referenced from this resource.
+In addition to  the arguments above, the following attributes can be referenced from this resource.
 
 |Attribute|Type|Description|
 |---------|----|-----------|
 |`ssh_host`|`string`|Read-only attribute. Only applies when `define_connection_info` is true. The hostname or IP to use to connect to the VM for preprovisioning. This can be overridden by defining `ssh_forward_ip`, but if you're using cloud-init and `ipconfig0=dhcp`, the IP reported by qemu-guest-agent is used, otherwise the IP defined in `ipconfig0` is used.|
 |`ssh_port`|`string`|Read-only attribute. Only applies when `define_connection_info` is true. The port to connect to the VM over SSH for preprovisioning. If using cloud-init and a port is not specified in `ssh_forward_ip`, then 22 is used. If not using cloud-init, a port on the `target_node` will be forwarded to port 22 in the guest, and this attribute will be set to the forwarded port.|
 
-Deprecated arguments.
+## Deprecated Arguments
+
+The following arguments are deprecated, and should no longer be used.
 
 * `disk_gb` - (Optional; use disk.size instead)
 * `storage` - (Optional; use disk.storage instead)

--- a/docs/resources/vm_qemu.md
+++ b/docs/resources/vm_qemu.md
@@ -164,25 +164,14 @@ The following arguments are supported in the resource block.
     * `id` (Required)
     * `type` (Required)
 
-* `os_network_config` - (Optional) Linux provisioning specific, `/etc/network/interfaces` for Ubuntu and `/etc/sysconfig/network-scripts/ifcfg-eth0` for CentOS.
-* `ssh_forward_ip` - (Optional) Address used to connect to the VM
-* `ssh_host` - (Optional)
-* `ssh_port` - (Optional)
-* `ssh_user` - (Optional) Username to login in the VM when preprovisioning.
-* `ssh_private_key` - (Optional; sensitive) Private key to login in the VM when preprovisioning.
+## Attribute Reference
 
-The following arguments are specifically for Cloud-init for preprovisioning.
+In addition to all the arguments above, the following attributes can be referenced from this resource.
 
-* `ci_wait` - (Optional) Cloud-init specific, how to long to wait for preprovisioning.
-* `ciuser` - (Optional) Cloud-init specific, overwrite image default user.
-* `cipassword` - (Optional) Cloud-init specific, password to assign to the user.
-* `cicustom` - (Optional) Cloud-init specific, location of the custom cloud-config files.
-* `searchdomain` - (Optional) Cloud-init specific, sets DNS search domains for a container.
-* `nameserver` - (Optional) Cloud-init specific, sets DNS server IP address for a container.
-* `sshkeys` - (Optional) Cloud-init specific, public ssh keys, one per line
-* `ipconfig0` - (Optional) Cloud-init specific, [gw=<GatewayIPv4>] [,gw6=<GatewayIPv6>] [,ip=<IPv4Format/CIDR>] [,ip6=<IPv6Format/CIDR>]
-* `ipconfig1` - (Optional) Cloud-init specific, see ipconfig0
-* `ipconfig2` - (Optional) Cloud-init specific, see ipconfig0
+|Attribute|Type|Description|
+|---------|----|-----------|
+|`ssh_host`|`string`|Read-only attribute. Only applies when `define_connection_info` is true. The hostname or IP to use to connect to the VM for preprovisioning. This can be overridden by defining `ssh_forward_ip`, but if you're using cloud-init and `ipconfig0=dhcp`, the IP reported by qemu-guest-agent is used, otherwise the IP defined in `ipconfig0` is used.|
+|`ssh_port`|`string`|Read-only attribute. Only applies when `define_connection_info` is true. The port to connect to the VM over SSH for preprovisioning. If using cloud-init and a port is not specified in `ssh_forward_ip`, then 22 is used. If not using cloud-init, a port on the `target_node` will be forwarded to port 22 in the guest, and this attribute will be set to the forwarded port.|
 
 Deprecated arguments.
 

--- a/docs/resources/vm_qemu.md
+++ b/docs/resources/vm_qemu.md
@@ -73,53 +73,53 @@ For more information, see the [Cloud-init guide](docs/guides/cloud_init.md).
 
 The following arguments are supported in the top level resource block.
 
-|Argument|Type|Required?|Default Value|Description|
-|--------|----|---------|-------------|-----------|
-|`name`|`string`|**Yes**||The name of the VM within Proxmox.|
-|`target_node`|`string`|**Yes**||The name of the Proxmox Node on which to place the VM.|
-|`vmid`|`integer`|No|`0`|The ID of the VM in Proxmox. The default value of `0` indicates it should use the next available ID in the sequence.|
-|`desc`|`string`|No|`""`|The description of the VM. Shows as the 'Notes' field in the Proxmox GUI.|
-|`define_connection_info`|`bool`|No|`true`|Whether to let terraform define the (SSH) connection parameters for preprovisioners, see config block below.|
-|`bios`|`string`|No|`"seabios"`|The BIOS to use, options are `seabios` or `ovmf` for UEFI.|
-|`onboot`|`bool`|No|`true`|Whether to have the VM startup after the PVE node starts.|
-|`boot`|`string`|No|`"cdn"`|The boot order for the VM. Ordered string of characters denoting boot order. Options: floppy (`a`), hard disk (`c`), CD-ROM (`d`), or network (`n`).|
-|`bootdisk`|`string`|No|*Computed*|Enable booting from specified disk. This value is computed by terraform, so you shouldn't need to change it under most circumstances.|
-|`agent`|`integer`|No|`0`|Whether to enable the QEMU Guest Agent. Note, you must still install the [`qemu-guest-agent`](https://pve.proxmox.com/wiki/Qemu-guest-agent) daemon in the quest for this to have any effect.|
-|`iso`|`string`|No|`""`|The name of the ISO image to mount to the VM. Only applies when `clone` is not set.|
-|`clone`|`string`|No|`""`|The base VM from which to clone to create the new VM.|
-|`full_clone`|`bool`|No|`true`|Set to `true` to create a full clone, or `false` to create a linked clone. See the [docs about cloning](https://pve.proxmox.com/pve-docs/chapter-qm.html#qm_copy_and_clone) for more info. Only applies when `clone` is set.|
-|`hastate`|`string`|No|`""`|Requested HA state for the resource. One of "started", "stopped", "enabled", "disabled", or "ignored". See the [docs about HA](https://pve.proxmox.com/pve-docs/chapter-ha-manager.html#ha_manager_resource_config) for more info.|
-|`qemu_os`|`string`|No|`"l26"`|The type of OS in the guest. Set properly to allow Proxmox to enable optimizations for the appropriate guest OS.|
-|`memory`|`integer`|No|`512`|The amount of memory to allocate to the VM in bytes.|
-|`balloon`|`integer`|No|`0`|Whether to add the ballooning device to the VM. Options are `1` and `0`. See the [docs about memory](https://pve.proxmox.com/pve-docs/chapter-qm.html#qm_memory) for more info.|
-|`sockets`|`integer`|No|`1`|The number of CPU sockets to allocate to the VM.|
-|`cores`|`integer`|No|`1`|The number of CPU cores per CPU socket to allocate to the VM.|
-|`vcpus`|`integer`|No|`0`|The number of vCPUs plugged into the VM when it starts. If 0, this is set automatically by Proxmox to `sockets * cores`.|
-|`cpu`|`string`|No|`"host"`|The type of CPU to emulate in the Guest. See the [docs about CPU Types](https://pve.proxmox.com/pve-docs/chapter-qm.html#qm_cpu) for more info.|
-|`numa`|`bool`|No|`false`|Whether to enable [Non-Uniform Memory Access](https://pve.proxmox.com/pve-docs/chapter-qm.html#qm_cpu) in the guest.|
-|`hotplug`|`string`|No|`"network,disk,usb"`|Comma delimited list of hotplug features to enable. Options: `network`, `disk`, `cpu`, `memory`, `usb`. Set to `0` to disable hotplug.|
-|`scsihw`|`string`|No|*Computed*|The SCSI controller to emulate, if left empty, proxmox default to `lsi`. Options: `lsi`, `lsi53c810`, `megasas`, `pvscsi`, `virtio-scsi-pci`, `virtio-scsi-single`.|
-|`pool`|`string`|No|`""`|The resource pool to which the VM will be added.|
-|`force_create`|`bool`|No|`false`|If `false`, and a vm of the same name, on the same node exists, terraform will attempt to reconfigure that VM with these settings. Set to true to always create a new VM (note, the name of the VM must still be unique, otherwise an error will be produced.)|
-|`clone_wait`|`integer`|No|`15`|The amount of time in seconds to wait between cloning a VM and performing post-clone actions such as updating the VM.|
-|`additional_wait`|`integer`|No|`15`|Provider will wait `additional_wait`/2 seconds after a clone operation and `additional_wait` seconds after an UpdateConfig operation.|
-|`preprovision`|`bool`|No|`true`|Whether to preprovision the VM. See [Preprovision](#Preprovision) above for more info.|
-|`os_type`|`string`|No|`""`|Which provisioning method to use, based on the OS type. Options: `ubuntu`, `centos`, `cloud-init`.|
-|`force_recreate_on_change_of`|`string`|No|`""`|If the value of this string changes, the VM will be recreated. Useful for allowing this resource to be recreated when arbitrary attributes change. An example where this is useful is a cloudinit configuration (as the `cicustom` attribute points to a file not the content).|
-|`os_network_config`|`string`|No|`""`|Only applies when `define_connection_info` is true. Network configuration to be copied into the VM when preprovisioning `ubuntu` or `centos` guests. The specified configuration is added to `/etc/network/interfaces` for Ubuntu, or `/etc/sysconfig/network-scripts/ifcfg-eth0` for CentOS. Forces re-creation on change.|
-|`ssh_forward_ip`|`string`|No|`""`|Only applies when `define_connection_info` is true. The IP (and optional colon separated port), to use to connect to the host for preprovisioning. If using cloud-init, this can be left blank.|
-|`ssh_user`|`string`|No|`""`|Only applies when `define_connection_info` is true. The user with which to connect to the guest for preprovisioning. Forces re-creation on change.|
-|`ssh_private_key`|`string`|No|`""`|Only applies when `define_connection_info` is true. The private key to use when connecting to the guest for preprovisioning. Sensitive.|
-|`ci_wait`|`integer`|No|`30`|How to long in seconds to wait for before provisioning.|
-|`ciuser`|`string`|No|`""`|Override the default cloud-init user for provisioning.|
-|`cipassword`|`string`|No|`""`|Override the default cloud-init user's password. Sensitive.|
-|`cicustom`|``|No|`""`|Instead specifying ciuser, cipasword, etc... you can specify the path to a custom cloud-init config file here. Grants more flexibility in configuring cloud-init.|
-|`searchdomain`|`string`|No|`""`|Sets default DNS search domain suffix.|
-|`nameserver`|`string`|No|`""`|Sets default DNS server for guest.|
-|`sshkeys`|`string`|No|`""`|Newline delimited list of SSH public keys to add to authorized keys file for the cloud-init user.|
-|`ipconfig0`|`string`|No|`""`|The first IP address to assign to the guest. Format: `[gw=<GatewayIPv4>] [,gw6=<GatewayIPv6>] [,ip=<IPv4Format/CIDR>] [,ip6=<IPv6Format/CIDR>]`|
-|`ipconfig1`|`string`|No|`""`|The second IP address to assign to the guest. Same format as `ipconfig0`|
-|`ipconfig2`|`string`|No|`""`|The third IP address to assign to the guest. Same format as `ipconfig0`|
+|Argument|Type|Default Value|Description|
+|--------|----|-------------|-----------|
+|`name`|`string`||**Required** The name of the VM within Proxmox.|
+|`target_node`|`string`||**Required** The name of the Proxmox Node on which to place the VM.|
+|`vmid`|`integer`|`0`|The ID of the VM in Proxmox. The default value of `0` indicates it should use the next available ID in the sequence.|
+|`desc`|`string`|`""`|The description of the VM. Shows as the 'Notes' field in the Proxmox GUI.|
+|`define_connection_info`|`bool`|`true`|Whether to let terraform define the (SSH) connection parameters for preprovisioners, see config block below.|
+|`bios`|`string`|`"seabios"`|The BIOS to use, options are `seabios` or `ovmf` for UEFI.|
+|`onboot`|`bool`|`true`|Whether to have the VM startup after the PVE node starts.|
+|`boot`|`string`|`"cdn"`|The boot order for the VM. Ordered string of characters denoting boot order. Options: floppy (`a`), hard disk (`c`), CD-ROM (`d`), or network (`n`).|
+|`bootdisk`|`string`|*Computed*|Enable booting from specified disk. This value is computed by terraform, so you shouldn't need to change it under most circumstances.|
+|`agent`|`integer`|`0`|Whether to enable the QEMU Guest Agent. Note, you must still install the [`qemu-guest-agent`](https://pve.proxmox.com/wiki/Qemu-guest-agent) daemon in the quest for this to have any effect.|
+|`iso`|`string`|`""`|The name of the ISO image to mount to the VM. Only applies when `clone` is not set.|
+|`clone`|`string`|`""`|The base VM from which to clone to create the new VM.|
+|`full_clone`|`bool`|`true`|Set to `true` to create a full clone, or `false` to create a linked clone. See the [docs about cloning](https://pve.proxmox.com/pve-docs/chapter-qm.html#qm_copy_and_clone) for more info. Only applies when `clone` is set.|
+|`hastate`|`string`|`""`|Requested HA state for the resource. One of "started", "stopped", "enabled", "disabled", or "ignored". See the [docs about HA](https://pve.proxmox.com/pve-docs/chapter-ha-manager.html#ha_manager_resource_config) for more info.|
+|`qemu_os`|`string`|`"l26"`|The type of OS in the guest. Set properly to allow Proxmox to enable optimizations for the appropriate guest OS.|
+|`memory`|`integer`|`512`|The amount of memory to allocate to the VM in bytes.|
+|`balloon`|`integer`|`0`|Whether to add the ballooning device to the VM. Options are `1` and `0`. See the [docs about memory](https://pve.proxmox.com/pve-docs/chapter-qm.html#qm_memory) for more info.|
+|`sockets`|`integer`|`1`|The number of CPU sockets to allocate to the VM.|
+|`cores`|`integer`|`1`|The number of CPU cores per CPU socket to allocate to the VM.|
+|`vcpus`|`integer`|`0`|The number of vCPUs plugged into the VM when it starts. If 0, this is set automatically by Proxmox to `sockets * cores`.|
+|`cpu`|`string`|`"host"`|The type of CPU to emulate in the Guest. See the [docs about CPU Types](https://pve.proxmox.com/pve-docs/chapter-qm.html#qm_cpu) for more info.|
+|`numa`|`bool`|`false`|Whether to enable [Non-Uniform Memory Access](https://pve.proxmox.com/pve-docs/chapter-qm.html#qm_cpu) in the guest.|
+|`hotplug`|`string`|`"network,disk,usb"`|Comma delimited list of hotplug features to enable. Options: `network`, `disk`, `cpu`, `memory`, `usb`. Set to `0` to disable hotplug.|
+|`scsihw`|`string`|*Computed*|The SCSI controller to emulate, if left empty, proxmox default to `lsi`. Options: `lsi`, `lsi53c810`, `megasas`, `pvscsi`, `virtio-scsi-pci`, `virtio-scsi-single`.|
+|`pool`|`string`|`""`|The resource pool to which the VM will be added.|
+|`force_create`|`bool`|`false`|If `false`, and a vm of the same name, on the same node exists, terraform will attempt to reconfigure that VM with these settings. Set to true to always create a new VM (note, the name of the VM must still be unique, otherwise an error will be produced.)|
+|`clone_wait`|`integer`|`15`|The amount of time in seconds to wait between cloning a VM and performing post-clone actions such as updating the VM.|
+|`additional_wait`|`integer`|`15`|Provider will wait `additional_wait`/2 seconds after a clone operation and `additional_wait` seconds after an UpdateConfig operation.|
+|`preprovision`|`bool`|`true`|Whether to preprovision the VM. See [Preprovision](#Preprovision) above for more info.|
+|`os_type`|`string`|`""`|Which provisioning method to use, based on the OS type. Options: `ubuntu`, `centos`, `cloud-init`.|
+|`force_recreate_on_change_of`|`string`|`""`|If the value of this string changes, the VM will be recreated. Useful for allowing this resource to be recreated when arbitrary attributes change. An example where this is useful is a cloudinit configuration (as the `cicustom` attribute points to a file not the content).|
+|`os_network_config`|`string`|`""`|Only applies when `define_connection_info` is true. Network configuration to be copied into the VM when preprovisioning `ubuntu` or `centos` guests. The specified configuration is added to `/etc/network/interfaces` for Ubuntu, or `/etc/sysconfig/network-scripts/ifcfg-eth0` for CentOS. Forces re-creation on change.|
+|`ssh_forward_ip`|`string`|`""`|Only applies when `define_connection_info` is true. The IP (and optional colon separated port), to use to connect to the host for preprovisioning. If using cloud-init, this can be left blank.|
+|`ssh_user`|`string`|`""`|Only applies when `define_connection_info` is true. The user with which to connect to the guest for preprovisioning. Forces re-creation on change.|
+|`ssh_private_key`|`string`|`""`|Only applies when `define_connection_info` is true. The private key to use when connecting to the guest for preprovisioning. Sensitive.|
+|`ci_wait`|`integer`|`30`|How to long in seconds to wait for before provisioning.|
+|`ciuser`|`string`|`""`|Override the default cloud-init user for provisioning.|
+|`cipassword`|`string`|`""`|Override the default cloud-init user's password. Sensitive.|
+|`cicustom`|`string`|`""`|Instead specifying ciuser, cipasword, etc... you can specify the path to a custom cloud-init config file here. Grants more flexibility in configuring cloud-init.|
+|`searchdomain`|`string`|`""`|Sets default DNS search domain suffix.|
+|`nameserver`|`string`|`""`|Sets default DNS server for guest.|
+|`sshkeys`|`string`|`""`|Newline delimited list of SSH public keys to add to authorized keys file for the cloud-init user.|
+|`ipconfig0`|`string`|`""`|The first IP address to assign to the guest. Format: `[gw=<GatewayIPv4>] [,gw6=<GatewayIPv6>] [,ip=<IPv4Format/CIDR>] [,ip6=<IPv6Format/CIDR>]`|
+|`ipconfig1`|`string`|`""`|The second IP address to assign to the guest. Same format as `ipconfig0`|
+|`ipconfig2`|`string`|`""`|The third IP address to assign to the guest. Same format as `ipconfig0`|
 
 ### VGA Block
 
@@ -127,10 +127,10 @@ The `vga` block is used to configure the display device. It may be specified mul
 
 See the [docs about display](https://pve.proxmox.com/pve-docs/chapter-qm.html#qm_display) for more details.
 
-|Argument|Type|Required?|Default Value|Description|
-|--------|----|---------|-------------|-----------|
-|`type`|`string`|No|`"std"`|The type of display to virtualize. Options: `cirrus`, `none`, `qxl`, `qxl2`, `qxl3`, `qxl4`, `serial0`, `serial1`, `serial2`, `serial3`, `std`, `virtio`, `vmware`|
-|`type`|`integer`|No||Sets the VGA memory (in MiB). Has no effect with serial display type.|
+|Argument|Type|Default Value|Description|
+|--------|----|-------------|-----------|
+|`type`|`string`|`"std"`|The type of display to virtualize. Options: `cirrus`, `none`, `qxl`, `qxl2`, `qxl3`, `qxl4`, `serial0`, `serial1`, `serial2`, `serial3`, `std`, `virtio`, `vmware`|
+|`type`|`integer`||Sets the VGA memory (in MiB). Has no effect with serial display type.|
 
 ### Network Block
 
@@ -138,16 +138,16 @@ The `network` block is used to configure the network devices. It may be specifie
 
 See the [docs about network devices](https://pve.proxmox.com/pve-docs/chapter-qm.html#qm_network_device) for more details.
 
-|Argument|Type|Required?|Default Value|Description|
-|--------|----|---------|-------------|-----------|
-|`model`|`string`|**Yes**|`""`|Network Card Model. The virtio model provides the best performance with very low CPU overhead. If your guest does not support this driver, it is usually best to use e1000. Options: `e1000`, `e1000-82540em`, `e1000-82544gc`, `e1000-82545em`, `i82551`, `i82557b`, `i82559er`, `ne2k_isa`, `ne2k_pci`, `pcnet`, `rtl8139`, `virtio`, `vmxnet3`|
-|`macaddr`|`string`|No|`""`|Override the randomly generated MAC Address for the VM.|
-|`bridge`|`string`|No|`"nat"`|Bridge to which the network device should be attached. The Proxmox VE standard bridge is called `vmbr0`.|
-|`tag`|`integer`|No|`-1`|The VLAN tag to apply to packets on this device. `-1` disables VLAN tagging.|
-|`firewall`|`boolean`|No|`false`|Whether to enable the Proxmox firewall on this network device.|
-|`rate`|`integer`|No|*Computed*|Network device rate limit in mbps (megabytes per second) as floating point number. Leave empty to disable rate limiting.|
-|`queues`|`integer`|No|*Computed*|Number of packet queues to be used on the device.|
-|`link_down`|`boolean`|No|`false`|Whether this interface should be disconnected (like pulling the plug).|
+|Argument|Type|Default Value|Description|
+|--------|----|-------------|-----------|
+|`model`|`string`|`""`|**Required** Network Card Model. The virtio model provides the best performance with very low CPU overhead. If your guest does not support this driver, it is usually best to use e1000. Options: `e1000`, `e1000-82540em`, `e1000-82544gc`, `e1000-82545em`, `i82551`, `i82557b`, `i82559er`, `ne2k_isa`, `ne2k_pci`, `pcnet`, `rtl8139`, `virtio`, `vmxnet3`|
+|`macaddr`|`string`|`""`|Override the randomly generated MAC Address for the VM.|
+|`bridge`|`string`|`"nat"`|Bridge to which the network device should be attached. The Proxmox VE standard bridge is called `vmbr0`.|
+|`tag`|`integer`|`-1`|The VLAN tag to apply to packets on this device. `-1` disables VLAN tagging.|
+|`firewall`|`boolean`|`false`|Whether to enable the Proxmox firewall on this network device.|
+|`rate`|`integer`|*Computed*|Network device rate limit in mbps (megabytes per second) as floating point number. Leave empty to disable rate limiting.|
+|`queues`|`integer`|*Computed*|Number of packet queues to be used on the device.|
+|`link_down`|`boolean`|`false`|Whether this interface should be disconnected (like pulling the plug).|
 
 ### Disk Block
 
@@ -185,28 +185,28 @@ resource "proxmox_vm_qemu" "resource-name" {
 
 See the [docs about disks](https://pve.proxmox.com/pve-docs/chapter-qm.html#qm_hard_disk) for more details.
 
-|Argument|Type|Required?|Default Value|Description|
-|--------|----|---------|-------------|-----------|
-|`type`|`string`|**Yes**|`""`|The type of disk device to add. Options: `ide`, `sata`, `scsi`, `virtio`|
-|`storage`|`string`|**Yes**|`""`|The name of the storage pool on which to store the disk.|
-|`size`|`string`|**Yes**|`""`|The size of the created disk, format must match the regex `\d+[GMK]`, where G, M, and K represent Gigabytes, Megabytes, and Kilobytes respectively.|
-|`format`|`string`|No|`"raw"`|The drive’s backing file’s data format.|
-|`cache`|`string`|No|`"none"`|The drive’s cache mode. Options: `directsync`, `none`, `unsafe`, `writeback`, `writethrough`|
-|`backup`|`boolean`|No|`false`|Whether the drive should be included when making backups.|
-|`iothread`|`boolean`|No|`false`|Whether to use iothreads for this drive. Only effective with a disk of type `virtio`, or `scsi` when the the emulated controller type is VirtIO SCSI single.|
-|`replicate`|`boolean`|No|`false`|Whether the drive should considered for replication jobs.|
-|`ssd`|`boolean`|No|`false`|Whether to expose this drive as an SSD, rather than a rotational hard disk.|
-|`discard`|`boolean`|No|``|Controls whether to pass discard/trim requests to the underlying storage. Only effective when the underlying storage supports thin provisioning. There are other caveots too, see the [docs about disks](https://pve.proxmox.com/pve-docs/chapter-qm.html#qm_hard_disk) for more info.|
-|`mbps`|`integer`|No|`0`|Maximum r/w speed in megabytes per second. `0` means unlimited.|
-|`mbps_rd`|`integer`|No|`0`|Maximum read speed in megabytes per second. `0` means unlimited.|
-|`mbps_rd_max`|`integer`|No|`0`|Maximum read speed in megabytes per second. `0` means unlimited.|
-|`mbps_wr`|`integer`|No|`0`|Maximum write speed in megabytes per second. `0` means unlimited.|
-|`mbps_wr_max`|`integer`|No|`0`|Maximum unthrottled write pool in megabytes per second. `0` means unlimited.|
-|`file`|`string`|No|*Computed*|The filename portion of the path to the drive’s backing volume. You shouldn't need to specify this, use the `storage` parameter instead.|
-|`media`|`string`|No|`"disk"`|The drive’s media type. Options: `cdrom`, `disk`|
-|`volume`|`string`|No|*Computed*|The full path to the drive’s backing volume including the storage pool name. You shouldn't need to specify this, use the `storage` parameter instead.|
-|`slot`|`integer`|No|*Computed*|(not sure what this is for, seems to be deprecated, do not use)|
-|`storage_type`|`string`|No|`""`|The type of pool that `storage` is backed by. You shouldn't need to specify this, use the `storage` parameter instead.|
+|Argument|Type|Default Value|Description|
+|--------|----|-------------|-----------|
+|`type`|`string`|`""`|**Required** The type of disk device to add. Options: `ide`, `sata`, `scsi`, `virtio`|
+|`storage`|`string`|`""`|**Required** The name of the storage pool on which to store the disk.|
+|`size`|`string`|`""`|**Required** The size of the created disk, format must match the regex `\d+[GMK]`, where G, M, and K represent Gigabytes, Megabytes, and Kilobytes respectively.|
+|`format`|`string`|`"raw"`|The drive’s backing file’s data format.|
+|`cache`|`string`|`"none"`|The drive’s cache mode. Options: `directsync`, `none`, `unsafe`, `writeback`, `writethrough`|
+|`backup`|`boolean`|`false`|Whether the drive should be included when making backups.|
+|`iothread`|`boolean`|`false`|Whether to use iothreads for this drive. Only effective with a disk of type `virtio`, or `scsi` when the the emulated controller type is VirtIO SCSI single.|
+|`replicate`|`boolean`|`false`|Whether the drive should considered for replication jobs.|
+|`ssd`|`boolean`|`false`|Whether to expose this drive as an SSD, rather than a rotational hard disk.|
+|`discard`|`boolean`|``|Controls whether to pass discard/trim requests to the underlying storage. Only effective when the underlying storage supports thin provisioning. There are other caveots too, see the [docs about disks](https://pve.proxmox.com/pve-docs/chapter-qm.html#qm_hard_disk) for more info.|
+|`mbps`|`integer`|`0`|Maximum r/w speed in megabytes per second. `0` means unlimited.|
+|`mbps_rd`|`integer`|`0`|Maximum read speed in megabytes per second. `0` means unlimited.|
+|`mbps_rd_max`|`integer`|`0`|Maximum read speed in megabytes per second. `0` means unlimited.|
+|`mbps_wr`|`integer`|`0`|Maximum write speed in megabytes per second. `0` means unlimited.|
+|`mbps_wr_max`|`integer`|`0`|Maximum unthrottled write pool in megabytes per second. `0` means unlimited.|
+|`file`|`string`|*Computed*|The filename portion of the path to the drive’s backing volume. You shouldn't need to specify this, use the `storage` parameter instead.|
+|`media`|`string`|`"disk"`|The drive’s media type. Options: `cdrom`, `disk`|
+|`volume`|`string`|*Computed*|The full path to the drive’s backing volume including the storage pool name. You shouldn't need to specify this, use the `storage` parameter instead.|
+|`slot`|`integer`|*Computed*|(not sure what this is for, seems to be deprecated, do not use)|
+|`storage_type`|`string`|`""`|The type of pool that `storage` is backed by. You shouldn't need to specify this, use the `storage` parameter instead.|
 
 ### Serial Block
 
@@ -216,10 +216,10 @@ Create a serial device inside the VM (up to a maximum of 4 can be specified), an
 
 See the [options for serial](https://pve.proxmox.com/pve-docs/chapter-qm.html#qm_options) in the PVE docs for more details.
 
-|Argument|Type|Required?|Default Value|Description|
-|--------|----|---------|-------------|-----------|
-|`id`|`integer`|**Yes**||The ID of the serial device. Must be between 0-3.|
-|`type`|`string`|**Yes**|`""`|The type of serial device to create. Options: `socket`, or the path to a serial device like `/dev/ttyS0`.|
+|Argument|Type|Default Value|Description|
+|--------|----|-------------|-----------|
+|`id`|`integer`||**Required** The ID of the serial device. Must be between 0-3.|
+|`type`|`string`|`""`|**Required** The type of serial device to create. Options: `socket`, or the path to a serial device like `/dev/ttyS0`.|
 
 ## Attribute Reference
 

--- a/docs/resources/vm_qemu.md
+++ b/docs/resources/vm_qemu.md
@@ -83,7 +83,7 @@ The following arguments are supported in the top level resource block.
 |`bios`|`string`|`"seabios"`|The BIOS to use, options are `seabios` or `ovmf` for UEFI.|
 |`onboot`|`bool`|`true`|Whether to have the VM startup after the PVE node starts.|
 |`boot`|`string`|`"cdn"`|The boot order for the VM. Ordered string of characters denoting boot order. Options: floppy (`a`), hard disk (`c`), CD-ROM (`d`), or network (`n`).|
-|`bootdisk`|`string`|*Computed*|Enable booting from specified disk. This value is computed by terraform, so you shouldn't need to change it under most circumstances.|
+|`bootdisk`|`string`||Enable booting from specified disk. You shouldn't need to change it under most circumstances.|
 |`agent`|`integer`|`0`|Whether to enable the QEMU Guest Agent. Note, you must still install the [`qemu-guest-agent`](https://pve.proxmox.com/wiki/Qemu-guest-agent) daemon in the quest for this to have any effect.|
 |`iso`|`string`||The name of the ISO image to mount to the VM. Only applies when `clone` is not set.|
 |`clone`|`string`||The base VM from which to clone to create the new VM.|
@@ -98,7 +98,7 @@ The following arguments are supported in the top level resource block.
 |`cpu`|`string`|`"host"`|The type of CPU to emulate in the Guest. See the [docs about CPU Types](https://pve.proxmox.com/pve-docs/chapter-qm.html#qm_cpu) for more info.|
 |`numa`|`bool`|`false`|Whether to enable [Non-Uniform Memory Access](https://pve.proxmox.com/pve-docs/chapter-qm.html#qm_cpu) in the guest.|
 |`hotplug`|`string`|`"network,disk,usb"`|Comma delimited list of hotplug features to enable. Options: `network`, `disk`, `cpu`, `memory`, `usb`. Set to `0` to disable hotplug.|
-|`scsihw`|`string`|*Computed*|The SCSI controller to emulate, if left empty, proxmox default to `lsi`. Options: `lsi`, `lsi53c810`, `megasas`, `pvscsi`, `virtio-scsi-pci`, `virtio-scsi-single`.|
+|`scsihw`|`string`|`"lsi"`|The SCSI controller to emulate. Options: `lsi`, `lsi53c810`, `megasas`, `pvscsi`, `virtio-scsi-pci`, `virtio-scsi-single`.|
 |`pool`|`string`||The resource pool to which the VM will be added.|
 |`force_create`|`bool`|`false`|If `false`, and a vm of the same name, on the same node exists, terraform will attempt to reconfigure that VM with these settings. Set to true to always create a new VM (note, the name of the VM must still be unique, otherwise an error will be produced.)|
 |`clone_wait`|`integer`|`15`|The amount of time in seconds to wait between cloning a VM and performing post-clone actions such as updating the VM.|
@@ -145,8 +145,8 @@ See the [docs about network devices](https://pve.proxmox.com/pve-docs/chapter-qm
 |`bridge`|`string`|`"nat"`|Bridge to which the network device should be attached. The Proxmox VE standard bridge is called `vmbr0`.|
 |`tag`|`integer`|`-1`|The VLAN tag to apply to packets on this device. `-1` disables VLAN tagging.|
 |`firewall`|`boolean`|`false`|Whether to enable the Proxmox firewall on this network device.|
-|`rate`|`integer`|*Computed*|Network device rate limit in mbps (megabytes per second) as floating point number. Leave empty to disable rate limiting.|
-|`queues`|`integer`|*Computed*|Number of packet queues to be used on the device.|
+|`rate`|`integer`|`0`|Network device rate limit in mbps (megabytes per second) as floating point number. Set to `0` to disable rate limiting.|
+|`queues`|`integer`|`1`|Number of packet queues to be used on the device. Requires `virtio` model to have an effect.|
 |`link_down`|`boolean`|`false`|Whether this interface should be disconnected (like pulling the plug).|
 
 ### Disk Block
@@ -202,10 +202,10 @@ See the [docs about disks](https://pve.proxmox.com/pve-docs/chapter-qm.html#qm_h
 |`mbps_rd_max`|`integer`|`0`|Maximum read speed in megabytes per second. `0` means unlimited.|
 |`mbps_wr`|`integer`|`0`|Maximum write speed in megabytes per second. `0` means unlimited.|
 |`mbps_wr_max`|`integer`|`0`|Maximum unthrottled write pool in megabytes per second. `0` means unlimited.|
-|`file`|`string`|*Computed*|The filename portion of the path to the drive’s backing volume. You shouldn't need to specify this, use the `storage` parameter instead.|
+|`file`|`string`||The filename portion of the path to the drive’s backing volume. You shouldn't need to specify this, use the `storage` parameter instead.|
 |`media`|`string`|`"disk"`|The drive’s media type. Options: `cdrom`, `disk`|
-|`volume`|`string`|*Computed*|The full path to the drive’s backing volume including the storage pool name. You shouldn't need to specify this, use the `storage` parameter instead.|
-|`slot`|`integer`|*Computed*|(not sure what this is for, seems to be deprecated, do not use)|
+|`volume`|`string`||The full path to the drive’s backing volume including the storage pool name. You shouldn't need to specify this, use the `storage` parameter instead.|
+|`slot`|`integer`||*(not sure what this is for, seems to be deprecated, do not use)*|
 |`storage_type`|`string`||The type of pool that `storage` is backed by. You shouldn't need to specify this, use the `storage` parameter instead.|
 
 ### Serial Block

--- a/docs/resources/vm_qemu.md
+++ b/docs/resources/vm_qemu.md
@@ -78,24 +78,30 @@ For more information, see the [Cloud-init guide](docs/guides/cloud_init.md).
 
 ## Argument reference
 
-The following arguments are supported in the resource block:
+The following arguments are supported in the resource block.
 
-* `name` - (Required) Name of the VM
-* `target_node` - (Required) Node to place the VM on
-* `vmid` - (Optional; integer) ID of the VM in Proxmox, defaults to 0 which indicates it should use the next number in the sequence.
-* `desc` - (Optional) Description of the VM
-* `define_connection_info` - (Optional; defaults to true) define the (SSH) connection parameters for preprovisioners, see config block below.
-* `bios` - (Optional; defaults to seabios)
-* `onboot` - (Optional)
-* `boot` - (Optional; defaults to cdn)
-* `bootdisk` - (Optional; defaults to true)
-* `agent` - (Optional; defaults to 0)
-* `iso` - (Optional)
-* `clone` - (Optional) - The name of the VM to clone into a new VM
-* `full_clone` - (Optional)
-* `hastate` - (Optional) 
-* `qemu_os` - (Optional; defaults to l26)
-* `memory` - (Optional; defaults to 512)
+|Argument|Type|Required?|Default Value|Description|
+|--------|----|---------|-------------|-----------|
+|`name`|`string`|**Yes**||The name of the VM.|
+|`target_node`|`string`|**Yes**||The name of the Proxmox Node on which to place the VM.|
+|`desc`|`string`|**Yes**|``||
+
+|`vmid`|`integer`|No|`0`|The ID of the VM in Proxmox. The default value of `0` indicates it should use the next available ID in the sequence.|
+|`desc`|`string`|No|`""`|The description of the VM. Shows as the 'Notes' field in the Proxmox GUI.|
+|`define_connection_info`|`bool`|No|`true`|Define the (SSH) connection parameters for preprovisioners, see config block below.|
+|`bios`|`string`|No|`"seabios"`|The BIOS to use, options are `seabios` or `ovmf` for UEFI.|
+|`onboot`|`bool`|No|`true`|Whether to have the VM startup after the PVE node starts.|
+|`boot`|`string`|No|`"cdn"`|The boot order for the VM. Ordered string of characters representing: floppy (a), hard disk (c), CD-ROM (d), or network (n).|
+|`bootdisk`|`string`|No|*Computed*|Enable booting from specified disk. This value is computed by terraform, so you shouldn't need to change it under most circumstances.|
+|`agent`|`integer`|No|`0`|Whether to enable the QEMU Guest Agent. Note, you must still install the [`qemu-guest-agent`](https://pve.proxmox.com/wiki/Qemu-guest-agent) daemon in the quest for this to have any effect.|
+|`iso`|`string`|No|`""`|The name of the ISO image to mount to the VM. Only applies when `clone` is not set.|
+|`clone`|`string`|No|`""`|The base VM from which to clone to create the new VM.|
+|`full_clone`|`bool`|No|`true`|Set to `true` to create a full clone, or `false` to create a linked clone. See the [docs about cloning](https://pve.proxmox.com/pve-docs/chapter-qm.html#qm_copy_and_clone) for more info. Only applies when `clone` is set.|
+|`hastate`|`string`|No|`""`|Requested HA state for the resource. One of "started", "stopped", "enabled", "disabled", or "ignored". See the [docs about HA](https://pve.proxmox.com/pve-docs/chapter-ha-manager.html#ha_manager_resource_config) for more info.|
+|`qemu_os`|`string`|No|`"l26"`|The type of OS in the guest. Set properly to allow Proxmox to enable optimizations for the appropriate guest OS.|
+|`memory`|``|No|``||
+
+* `` - (Optional; defaults to 512)
 * `balloon` - (Optional; defaults to 0)
 * `cores` - (Optional; defaults to 1)
 * `sockets` - (Optional; defaults to 1)

--- a/docs/resources/vm_qemu.md
+++ b/docs/resources/vm_qemu.md
@@ -1,7 +1,5 @@
 # VM Qemu Resource
 
-Resources are the most important element in the Terraform language. Each resource block describes one or more infrastructure objects, such as virtual networks, compute instances, or higher-level components such as DNS records.
-
 This resource manages a Proxmox VM Qemu container.
 
 ## Create a Qemu VM resource


### PR DESCRIPTION
This PR updates the QEMU resource documentation with data types, default values, and references to official Proxmox documentation where useful. This also organizes all the arguments and attributes into tables, rather than using bullet points, as (IMHO) it makes it easier to scroll through and view at-a-glance which options are available.

I have done my best to read through the code to determine how the arguments are processed by the provider, the proxmox-api-go lib, and the PVE API, so the descriptions can be as useful as possible. If I missed anything, or any of the descriptions are inaccurate, please feel free to suggest any all changes amendments you feel are necessary.