### PR TITLE
change some QEMU resouce parameters from BOOL to INT

### DIFF
--- a/proxmox/resource_vm_qemu.go
+++ b/proxmox/resource_vm_qemu.go
@@ -378,24 +378,25 @@ func resourceVmQemu() *schema.Resource {
 							Default:  "none",
 						},
 						"backup": &schema.Schema{
-							Type:     schema.TypeBool,
+							Type:     schema.TypeInt,
 							Optional: true,
-							Default:  false,
+							Default:  0,
 						},
 						"iothread": &schema.Schema{
-							Type:     schema.TypeBool,
+							Type:     schema.TypeInt,
 							Optional: true,
-							Default:  false,
+							Default:  0,
 						},
 						"replicate": &schema.Schema{
-							Type:     schema.TypeBool,
+							Type:     schema.TypeInt,
 							Optional: true,
-							Default:  false,
+							Default:  0,
 						},
 						//SSD emulation
 						"ssd": &schema.Schema{
-							Type:     schema.TypeBool,
+							Type:     schema.TypeInt,
 							Optional: true,
+							Default: 0,
 						},
 						"discard": &schema.Schema{
 							Type:     schema.TypeString,


### PR DESCRIPTION
Change the type of some parameter relative to diskt to INT since proxmox api expects 1|0 instead of True|False and casting the values into the provider seems a dirty hack

API Docs for reference:
![api parameters](https://user-images.githubusercontent.com/807457/104034728-9123f680-51d1-11eb-9a85-b6ae619e0778.png)