### PR TITLE
Adding support for tags with qemu resources

### DIFF
--- a/docs/resources/vm_qemu.md
+++ b/docs/resources/vm_qemu.md
@@ -103,6 +103,7 @@ The following arguments are supported in the top level resource block.
 |`hotplug`|`str`|`"network,disk,usb"`|Comma delimited list of hotplug features to enable. Options: `network`, `disk`, `cpu`, `memory`, `usb`. Set to `0` to disable hotplug.|
 |`scsihw`|`str`|`"lsi"`|The SCSI controller to emulate. Options: `lsi`, `lsi53c810`, `megasas`, `pvscsi`, `virtio-scsi-pci`, `virtio-scsi-single`.|
 |`pool`|`str`||The resource pool to which the VM will be added.|
+|`tags`|`str`||Tags of the VM. This is only meta information.|
 |`force_create`|`bool`|`false`|If `false`, and a vm of the same name, on the same node exists, terraform will attempt to reconfigure that VM with these settings. Set to true to always create a new VM (note, the name of the VM must still be unique, otherwise an error will be produced.)|
 |`clone_wait`|`int`|`15`|Provider will wait `clone_wait`/2 seconds after a clone operation and `clone_wait` seconds after an UpdateConfig operation.|
 |`additional_wait`|`int`|`15`|The amount of time in seconds to wait between creating the VM and powering it up.|

--- a/proxmox/resource_vm_qemu.go
+++ b/proxmox/resource_vm_qemu.go
@@ -208,6 +208,10 @@ func resourceVmQemu() *schema.Resource {
 					return strings.TrimSpace(old) == strings.TrimSpace(new)
 				},
 			},
+			"tags": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
 			"memory": {
 				Type:     schema.TypeInt,
 				Optional: true,
@@ -734,6 +738,7 @@ func resourceVmQemuCreate(d *schema.ResourceData, meta interface{}) error {
 		Scsihw:       d.Get("scsihw").(string),
 		HaState:      d.Get("hastate").(string),
 		QemuOs:       d.Get("qemu_os").(string),
+		Tags:         d.Get("tags").(string),
 		QemuNetworks: qemuNetworks,
 		QemuDisks:    qemuDisks,
 		QemuSerials:  qemuSerials,
@@ -987,6 +992,7 @@ func resourceVmQemuUpdate(d *schema.ResourceData, meta interface{}) error {
 		Scsihw:       d.Get("scsihw").(string),
 		HaState:      d.Get("hastate").(string),
 		QemuOs:       d.Get("qemu_os").(string),
+		Tags:         d.Get("tags").(string),
 		QemuNetworks: qemuNetworks,
 		QemuDisks:    qemuDisks,
 		QemuSerials:  qemuSerials,
@@ -1218,6 +1224,7 @@ func _resourceVmQemuRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("scsihw", config.Scsihw)
 	d.Set("hastate", vmr.HaState())
 	d.Set("qemu_os", config.QemuOs)
+	d.Set("tags", config.Tags)
 	// Cloud-init.
 	d.Set("ciuser", config.CIuser)
 	// we purposely use the password from the terraform config here


### PR DESCRIPTION
The proxmox API supports tagging resources with a string of undefined format which is accessible via the configs endpoint.

I am adding this config field in the create, update, and read methods for qemu resources in an attempt to make PVE more usable with ansible dynamic inventory.

PVE will throw 400 errors if the supplied tag string contains unallowed characters which they do not list, but I have found to include ":", "|", "=", and "." precluding standard notation for key/value pairs. (PVE will accept a period if surrounded by alphanumerics)

Otherwise create, update, and delete function as expected and removing the tag field from an existing qemu resource will set the tag field back to null in PVE.

I attempted to update lxc in the same manner, but the PVE API itself throws 400 errors whenever lxc tags are null (including in the initial container state), but will update the tags value as expected anyway which confuses terraform.