### PR TITLE
Fixes #313 Fix link to resources

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,7 +1,7 @@
 # Proxmox Provider
 
 A Terraform provider is responsible for understanding API interactions and exposing resources. The Proxmox provider
-uses the Proxmox API. This provider exposes two resources: [proxmox_vm_qemu](docs/resources/vm_qemu.md) and [proxmox_lxc](docs/resources/lxc.md).
+uses the Proxmox API. This provider exposes two resources: [proxmox_vm_qemu](resources/vm_qemu.md) and [proxmox_lxc](resources/lxc.md).
 
 ## Creating the connection
 

--- a/docs/resources/vm_qemu.md
+++ b/docs/resources/vm_qemu.md
@@ -66,7 +66,7 @@ EOF
 
 Cloud-init VMs must be cloned from a [cloud-init ready template](https://pve.proxmox.com/wiki/Cloud-Init_Support). When creating a resource that is using Cloud-Init, there are multi configurations possible. You can use either the `ciconfig` parameter to create based on [a Cloud-init configuration file](https://cloudinit.readthedocs.io/en/latest/topics/examples.html) or use the Proxmox variable `ciuser`, `cipassword`, `ipconfig0`, `ipconfig1`, `searchdomain`, `nameserver` and `sshkeys`.
 
-For more information, see the [Cloud-init guide](docs/guides/cloud_init.md).
+For more information, see the [Cloud-init guide](guides/cloud_init.md).
 
 ## Argument reference
 


### PR DESCRIPTION
This PR fixes the issue highlighted by @mjbright in https://github.com/Telmate/terraform-provider-proxmox/issues/313

Reading the link structure is immediately obvious, to test this change works, go to https://github.com/Darrenmeehan/terraform-provider-proxmox/blob/bugfix/gh-313-fix-links-in-docs/docs/index.md and open the two link mentioned.