### PR TITLE
Fix creating lxc with mountpoints

### DIFF
--- a/proxmox/resource_lxc.go
+++ b/proxmox/resource_lxc.go
@@ -180,6 +180,11 @@ func resourceLxc() *schema.Resource {
 							Optional: true,
 							Computed: true,
 						},
+						"file": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+						},
 					},
 				},
 			},

--- a/proxmox/resource_lxc.go
+++ b/proxmox/resource_lxc.go
@@ -630,7 +630,7 @@ func _resourceLxcRead(d *schema.ResourceData, meta interface{}) error {
 			return err
 		}
 
-		flatMountpoints, _ := FlattenDevicesList(config.Networks)
+		flatMountpoints, _ := FlattenDevicesList(config.Mountpoints)
 		if err = d.Set("mountpoint", flatMountpoints); err != nil {
 			return err
 		}


### PR DESCRIPTION
When using this provider to create an lxc-container that contains one mountpoint, it fails with the following message:
```
Error: Proxmox Provider Error: proxmox API returned new parameter 'file' we cannot process
```

This is most likely caused due to the mountpoint endpoints return a `file` key, which the provider treats as unknown and aborts the entire apply. I could replicate this error in proxmox 6.2 & 6.3 using the following config:

```terraform
resource "proxmox_lxc" "container" {
  target_node  = "pve"
  ostemplate   = "local:vztmpl/ubuntu-20.04-standard_20.04-1_amd64.tar.gz"
  unprivileged = true

  // Terraform will crash without rootfs defined
  rootfs {
    storage = "local-lvm"
    size    = "2G"
  }
  mountpoint {
    key     = "0"
    slot    = 0
    mp      = "/data/container"
    storage = "local-lvm"
    size    = "5G"
  }
}
```