### PR TITLE
Force lxc container recreate when ssh keys are updated

### DIFF
--- a/proxmox/resource_lxc.go
+++ b/proxmox/resource_lxc.go
@@ -522,7 +522,6 @@ func resourceLxcUpdate(d *schema.ResourceData, meta interface{}) error {
 	config.Protection = d.Get("protection").(bool)
 	config.Restore = d.Get("restore").(bool)
 	config.SearchDomain = d.Get("searchdomain").(string)
-	config.SSHPublicKeys = d.Get("ssh_public_keys").(string)
 	config.Start = d.Get("start").(bool)
 	config.Startup = d.Get("startup").(string)
 	config.Swap = d.Get("swap").(int)

--- a/proxmox/resource_lxc.go
+++ b/proxmox/resource_lxc.go
@@ -316,6 +316,7 @@ func resourceLxc() *schema.Resource {
 			"ssh_public_keys": {
 				Type:     schema.TypeString,
 				Optional: true,
+				ForceNew: true,
 			},
 			"start": {
 				Type:     schema.TypeBool,


### PR DESCRIPTION
The only way to update the keys is to recreate the container entirely, as proxmox does not expose any API to do that. 

Fixes #207 

