### PR TITLE
Add support for tagging LXCs

### DIFF
--- a/proxmox/resource_lxc.go
+++ b/proxmox/resource_lxc.go
@@ -112,6 +112,10 @@ func resourceLxc() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
+			"tags": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
 			"memory": {
 				Type:     schema.TypeInt,
 				Optional: true,
@@ -421,6 +425,7 @@ func resourceLxcCreate(d *schema.ResourceData, meta interface{}) error {
 	config.Start = d.Get("start").(bool)
 	config.Startup = d.Get("startup").(string)
 	config.Swap = d.Get("swap").(int)
+	config.Tags = d.Get("tags").(string)
 	config.Template = d.Get("template").(bool)
 	config.Tty = d.Get("tty").(int)
 	config.Unique = d.Get("unique").(bool)
@@ -530,6 +535,7 @@ func resourceLxcUpdate(d *schema.ResourceData, meta interface{}) error {
 	config.Start = d.Get("start").(bool)
 	config.Startup = d.Get("startup").(string)
 	config.Swap = d.Get("swap").(int)
+	config.Tags = d.Get("tags").(string)
 	config.Template = d.Get("template").(bool)
 	config.Tty = d.Get("tty").(int)
 	config.Unique = d.Get("unique").(bool)
@@ -686,6 +692,7 @@ func _resourceLxcRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("searchdomain", config.SearchDomain)
 	d.Set("startup", config.Startup)
 	d.Set("swap", config.Swap)
+	d.Set("tags", config.Tags)
 	d.Set("template", config.Template)
 	d.Set("tty", config.Tty)
 	d.Set("unique", config.Unique)


### PR DESCRIPTION
This PR makes it possible to set and retrieve tags on LXCs in the same way as for the QEMU instances. I have built the provider from this code and tested that it succesfully sets the tags and verified in the relevant config file in Proxmox that the tags are present. Doing a `terraform state show $resource` also shows the configured tags. 

This fixes compatibility with the Ansible dynamic inventory plugin for Proxmox, which supports tags for both LXCs and VMs:

https://github.com/ansible-collections/community.general/blob/48ef05def340588393075341c3b0b4e44f5fdab8/plugins/inventory/proxmox.py#L295