### PR TITLE
add cloudinit_cdrom_storage to options list

### DIFF
--- a/docs/guides/cloud_init.md
+++ b/docs/guides/cloud_init.md
@@ -172,6 +172,8 @@ EOF
     the snippets folder in the local storage in the Proxmox VE server.
   */
   cicustom = "user=local:snippets/user_data_vm-${count.index}.yml"
+  /* Create the cloud-init drive on the "local-lvm" storage */
+  cloudinit_cdrom_storage = "local-lvm"
 
   provisioner "remote-exec" {
     inline = [

--- a/docs/resources/vm_qemu.md
+++ b/docs/resources/vm_qemu.md
@@ -118,6 +118,7 @@ The following arguments are supported in the top level resource block.
 |`ciuser`|`str`||Override the default cloud-init user for provisioning.|
 |`cipassword`|`str`||Override the default cloud-init user's password. Sensitive.|
 |`cicustom`|`str`||Instead specifying ciuser, cipasword, etc... you can specify the path to a custom cloud-init config file here. Grants more flexibility in configuring cloud-init.|
+|`cloudinit_cdrom_storage`|`str`||Set the storage location for the cloud-init drive. Required when specifying `cicustom`.|
 |`searchdomain`|`str`||Sets default DNS search domain suffix.|
 |`nameserver`|`str`||Sets default DNS server for guest.|
 |`sshkeys`|`str`||Newline delimited list of SSH public keys to add to authorized keys file for the cloud-init user.|


### PR DESCRIPTION
This PR documents the `cloudinit_cdrom_storage` option which appears to be required when using `cicustom` to set the cloud-init drive content.

This will close #208 