### PR TITLE
proxmox vm names must now meet dns name limitations

### DIFF
--- a/docs/resources/vm_qemu.md
+++ b/docs/resources/vm_qemu.md
@@ -10,7 +10,7 @@ When creating a VM Qemu resource, you create a `proxmox_vm_qemu` resource block.
 
 ```hcl
 resource "proxmox_vm_qemu" "resource-name" {
-    name = "VM name"
+    name = "VM-name"
     target_node = "Node to create the VM on"
     iso = "ISO file name"
     # or 

--- a/examples/vagrant_example.tf
+++ b/examples/vagrant_example.tf
@@ -16,7 +16,7 @@ provider "proxmox" {
 }
 
 resource "proxmox_vm_qemu" "example" {
-    name = "servy_mcserverface"
+    name = "servy-mcserverface"
     desc = "A test for using terraform and vagrant"
     target_node = "pve"
 }


### PR DESCRIPTION
This change updates the docs to reflect the [requirement that VM names must conform to DNS name limitations](https://forum.proxmox.com/threads/qm-unable-to-parse-value-of-name-value-does-not-look-like-a-valid-dns-name.8839/#post-50004).

At present these examples result in an API error.