### PR TITLE
Added "args" parameter for passing arbitrary arguments to kvm. 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/Telmate/terraform-provider-proxmox
 go 1.13
 
 require (
-	github.com/Telmate/proxmox-api-go v0.0.0-20210422140841-c8d917116b7f
+        github.com/Telmate/proxmox-api-go v0.0.0-20210429201316-cb769f4e78c9
 	github.com/aws/aws-sdk-go v1.31.9
 	github.com/hashicorp/terraform v0.13.4 // indirect
 	github.com/hashicorp/terraform-plugin-sdk v1.13.0 // indirect

--- a/proxmox/resource_vm_qemu.go
+++ b/proxmox/resource_vm_qemu.go
@@ -216,7 +216,6 @@ func resourceVmQemu() *schema.Resource {
                                 Type:     schema.TypeString,
                                 Optional: true,
                         },
-
 			"memory": {
 				Type:     schema.TypeInt,
 				Optional: true,

--- a/proxmox/resource_vm_qemu.go
+++ b/proxmox/resource_vm_qemu.go
@@ -212,6 +212,11 @@ func resourceVmQemu() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
+                        "args": {
+                                Type:     schema.TypeString,
+                                Optional: true,
+                        },
+
 			"memory": {
 				Type:     schema.TypeInt,
 				Optional: true,
@@ -743,6 +748,7 @@ func resourceVmQemuCreate(d *schema.ResourceData, meta interface{}) error {
 		HaState:      d.Get("hastate").(string),
 		QemuOs:       d.Get("qemu_os").(string),
 		Tags:         d.Get("tags").(string),
+		Args:         d.Get("args").(string),
 		QemuNetworks: qemuNetworks,
 		QemuDisks:    qemuDisks,
 		QemuSerials:  qemuSerials,
@@ -997,6 +1003,7 @@ func resourceVmQemuUpdate(d *schema.ResourceData, meta interface{}) error {
 		HaState:      d.Get("hastate").(string),
 		QemuOs:       d.Get("qemu_os").(string),
 		Tags:         d.Get("tags").(string),
+		Args:         d.Get("args").(string),
 		QemuNetworks: qemuNetworks,
 		QemuDisks:    qemuDisks,
 		QemuSerials:  qemuSerials,
@@ -1229,6 +1236,7 @@ func _resourceVmQemuRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("hastate", vmr.HaState())
 	d.Set("qemu_os", config.QemuOs)
 	d.Set("tags", config.Tags)
+	d.Set("args", config.Args)
 	// Cloud-init.
 	d.Set("ciuser", config.CIuser)
 	// we purposely use the password from the terraform config here


### PR DESCRIPTION
Hi all,

Would like to add the args parameter. This would enable passing arbitrary arguments to KVM.
For this to work I have already submitted the relevant code to "proxmox-api-go" last week.
My personal use case is enabling ignition for a flatcar linux template. An example value for the args parameter to enable ignition would be the following: "-fw_cfg name=opt/org.flatcar-linux/config,file=/var/lib/vz/snippets/flatcar.ign".

Theo