### PR TITLE
Fix HA VM deletion

### DIFF
--- a/proxmox/resource_vm_qemu.go
+++ b/proxmox/resource_vm_qemu.go
@@ -1375,8 +1375,20 @@ func resourceVmQemuDelete(d *schema.ResourceData, meta interface{}) error {
 	if err != nil {
 		return err
 	}
-	// give sometime to proxmox to catchup
-	time.Sleep(2 * time.Second)
+
+	// Wait until vm is stopped. Otherwise, deletion will fail.
+	waited := 0
+	for waited < 300 {
+		vmState, err := client.GetVmState(vmr)
+		if err == nil && vmState["status"] == "stopped" {
+			break
+		} else if err != nil {
+			return err
+		}
+
+		time.Sleep(1 * time.Second)
+	}
+
 	_, err = client.DeleteVm(vmr)
 	return err
 }


### PR DESCRIPTION
This PR fixes #145 by waiting until the VM is stopped before deleting it.

I've tested the changes manually against our proxmox cluster (version 6.3).