### PR TITLE
fix links in documentation index

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,7 +1,7 @@
 # Proxmox Provider
 
 A Terraform provider is responsible for understanding API interactions and exposing resources. The Proxmox provider
-uses the Proxmox API. This provider exposes two resources: [proxmox_vm_qemu](docs/resources/vm_qemu.md) and [proxmox_lxc](docs/resources/lxc.md).
+uses the Proxmox API. This provider exposes two resources: [proxmox_vm_qemu](resources/vm_qemu.md) and [proxmox_lxc](resources/lxc.md).
 
 ## Creating the connection via username and password
 


### PR DESCRIPTION
This pr fixes a minor annoyance I've run into when reading the documentation. When clicking the links for lxc and vm_qemu providers in the documentation index.md file, the url becomes 
```
https://github.com/Telmate/terraform-provider-proxmox/blob/master/docs/docs/resources/vm_qemu.md
```
instead of
```
https://github.com/Telmate/terraform-provider-proxmox/blob/master/docs/resources/vm_qemu.md
```
where the document is.