### PR TITLE
Fix incorrect path

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,7 +1,7 @@
 # Proxmox Provider
 
 A Terraform provider is responsible for understanding API interactions and exposing resources. The Proxmox provider
-uses the Proxmox API. This provider exposes two resources: [proxmox_vm_qemu](docs/resources/vm_qemu.md) and [proxmox_lxc](docs/resources/lxc.md).
+uses the Proxmox API. This provider exposes two resources: [proxmox_vm_qemu](resources/vm_qemu.md) and [proxmox_lxc](resources/lxc.md).
 
 ## Creating the connection via username and password
 


### PR DESCRIPTION
Line 4:
```
This provider exposes two resources: [proxmox_vm_qemu](docs/resources/vm_qemu.md) and [proxmox_lxc](docs/resources/lxc.md).
```

This path relative. Using docs/resources will lead to an absolute path like /docs/docs/resources, leading to a 404 error.

 I removed the unnecessary `docs/` from this line.