### PR TITLE
Container HA support

### DIFF
--- a/docs/resources/lxc.md
+++ b/docs/resources/lxc.md
@@ -160,6 +160,7 @@ The following arguments may be optionally defined when using this resource:
     * `mount` - Defines the filesystem types (separated by semi-colons) that are allowed to be mounted.
     * `nesting` - A boolean to allow nested virtualization.
 * `force` - A boolean that allows the overwriting of pre-existing containers.
+* `hastate` - Requested HA state for the resource. One of "started", "stopped", "enabled", "disabled", or "ignored". See the [docs about HA](https://pve.proxmox.com/pve-docs/chapter-ha-manager.html#ha_manager_resource_config) for more info.
 * `hookscript` - A string containing [a volume identifier to a script](https://pve.proxmox.com/pve-docs/pve-admin-guide.html#_hookscripts_2) that will be executed during various steps throughout the container's lifetime. The script must be an executable file.
 * `hostname` - Specifies the host name of the container.
 * `ignore_unpack_errors` - A boolean that determines if template extraction errors are ignored during container creation.

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/Telmate/terraform-provider-proxmox
 go 1.16
 
 require (
-	github.com/Telmate/proxmox-api-go v0.0.0-20210507143528-c60bbda13c0c
+	github.com/Telmate/proxmox-api-go v0.0.0-20210708200918-d27e0fa5a4a4
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.6.1
 	github.com/rs/zerolog v1.21.0
 )

--- a/go.sum
+++ b/go.sum
@@ -42,6 +42,8 @@ github.com/Microsoft/go-winio v0.4.16 h1:FtSW/jqD+l4ba5iPBj9CODVtgfYAD8w2wS923g/
 github.com/Microsoft/go-winio v0.4.16/go.mod h1:XB6nPKklQyQ7GC9LdcBEcBl8PF76WugXOPRXwdLnMv0=
 github.com/Telmate/proxmox-api-go v0.0.0-20210507143528-c60bbda13c0c h1:s8BXeCeP5hLudxqEVwSScJMS/V25eyatTKpIg7JMSNQ=
 github.com/Telmate/proxmox-api-go v0.0.0-20210507143528-c60bbda13c0c/go.mod h1:keBhXWLa+UBajvf79xvKcfiqeIc7vZL9wOqxuy1CBGw=
+github.com/Telmate/proxmox-api-go v0.0.0-20210708200918-d27e0fa5a4a4 h1:nPcdJDO4MVAAUPsJtVV7rgjQGFvjxUEBkP53XrUve88=
+github.com/Telmate/proxmox-api-go v0.0.0-20210708200918-d27e0fa5a4a4/go.mod h1:keBhXWLa+UBajvf79xvKcfiqeIc7vZL9wOqxuy1CBGw=
 github.com/agext/levenshtein v1.2.1/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
 github.com/agext/levenshtein v1.2.2 h1:0S/Yg6LYmFJ5stwQeRp6EeOcCbj7xiqQSdNelsXvaqE=
 github.com/agext/levenshtein v1.2.2/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=

--- a/proxmox/resource_lxc.go
+++ b/proxmox/resource_lxc.go
@@ -96,6 +96,10 @@ func resourceLxc() *schema.Resource {
 				Type:     schema.TypeBool,
 				Optional: true,
 			},
+			"hastate": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
 			"hookscript": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -408,6 +412,7 @@ func resourceLxcCreate(d *schema.ResourceData, meta interface{}) error {
 		config.Features = featureSetList[0].(map[string]interface{})
 	}
 	config.Force = d.Get("force").(bool)
+	config.HaState = d.Get("hastate").(string)
 	config.Hookscript = d.Get("hookscript").(string)
 	config.Hostname = d.Get("hostname").(string)
 	config.IgnoreUnpackErrors = d.Get("ignore_unpack_errors").(bool)
@@ -519,6 +524,7 @@ func resourceLxcUpdate(d *schema.ResourceData, meta interface{}) error {
 		config.Features = featureSetList[0].(map[string]interface{})
 	}
 	config.Force = d.Get("force").(bool)
+	config.HaState = d.Get("hastate").(string)
 	config.Hookscript = d.Get("hookscript").(string)
 	config.Hostname = d.Get("hostname").(string)
 	config.IgnoreUnpackErrors = d.Get("ignore_unpack_errors").(bool)
@@ -678,6 +684,7 @@ func _resourceLxcRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("cpuunits", config.CPUUnits)
 	d.Set("description", config.Description)
 	d.Set("force", config.Force)
+	d.Set("hastate", vmr.HaState)
 	d.Set("hookscript", config.Hookscript)
 	d.Set("hostname", config.Hostname)
 	d.Set("ignore_unpack_errors", config.IgnoreUnpackErrors)


### PR DESCRIPTION
This change leverages the changes from https://github.com/Telmate/proxmox-api-go/pull/126 to allow setting the `hastate` parameter on LXC containers in addition to QEMU VMs.