### PR TITLE
clone: choose template located on target node if possible

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/Telmate/terraform-provider-proxmox
 go 1.16
 
 require (
-	github.com/Telmate/proxmox-api-go v0.0.0-20210708200918-d27e0fa5a4a4
+	github.com/Telmate/proxmox-api-go v0.0.0-20210713150936-9bfd169c655f
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.6.1
 	github.com/rs/zerolog v1.21.0
 )

--- a/go.sum
+++ b/go.sum
@@ -44,6 +44,8 @@ github.com/Telmate/proxmox-api-go v0.0.0-20210507143528-c60bbda13c0c h1:s8BXeCeP
 github.com/Telmate/proxmox-api-go v0.0.0-20210507143528-c60bbda13c0c/go.mod h1:keBhXWLa+UBajvf79xvKcfiqeIc7vZL9wOqxuy1CBGw=
 github.com/Telmate/proxmox-api-go v0.0.0-20210708200918-d27e0fa5a4a4 h1:nPcdJDO4MVAAUPsJtVV7rgjQGFvjxUEBkP53XrUve88=
 github.com/Telmate/proxmox-api-go v0.0.0-20210708200918-d27e0fa5a4a4/go.mod h1:keBhXWLa+UBajvf79xvKcfiqeIc7vZL9wOqxuy1CBGw=
+github.com/Telmate/proxmox-api-go v0.0.0-20210713150936-9bfd169c655f h1:Lb9VXSg+7bJSVAf5pzUqc5X6GTN502NQsP+64tF+T4w=
+github.com/Telmate/proxmox-api-go v0.0.0-20210713150936-9bfd169c655f/go.mod h1:keBhXWLa+UBajvf79xvKcfiqeIc7vZL9wOqxuy1CBGw=
 github.com/agext/levenshtein v1.2.1/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
 github.com/agext/levenshtein v1.2.2 h1:0S/Yg6LYmFJ5stwQeRp6EeOcCbj7xiqQSdNelsXvaqE=
 github.com/agext/levenshtein v1.2.2/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=

--- a/proxmox/resource_vm_qemu.go
+++ b/proxmox/resource_vm_qemu.go
@@ -813,9 +813,17 @@ func resourceVmQemuCreate(d *schema.ResourceData, meta interface{}) error {
 			}
 			config.FullClone = &fullClone
 
-			sourceVmr, err := client.GetVmRefByName(d.Get("clone").(string))
+			sourceVmrs, err := client.GetVmRefsByName(d.Get("clone").(string))
 			if err != nil {
 				return err
+			}
+
+			// prefer source Vm located on same node
+			sourceVmr := sourceVmrs[0]
+			for _, candVmr := range sourceVmrs {
+				if candVmr.Node() == vmr.Node() {
+					sourceVmr = candVmr
+				}
 			}
 
 			log.Print("[DEBUG] cloning VM")


### PR DESCRIPTION
In case of multiple templates with same name, clone procedure chooses first template
returned by Proxmox. This commit forces it to choose template located on
target node if possible. It's helpful if templates use local storage and it's
impossible to clone templates between nodes, i.e. to avoid errors like:
"500 can't clone VM to node 'host2' (VM uses local storage)"
or
"500 storage 'xyz' is not available on node 'host1'"