### PR TITLE
Issue # 345 - expanding ipconfigN to support total of six interfaces. …

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,7 +1,31 @@
 # Proxmox Provider
 
-A Terraform provider is responsible for understanding API interactions and exposing resources. The Proxmox provider
-uses the Proxmox API. This provider exposes two resources: [proxmox_vm_qemu](docs/resources/vm_qemu.md) and [proxmox_lxc](docs/resources/lxc.md).
+A Terraform provider is responsible for understanding API interactions and exposing resources. The Proxmox provider uses the Proxmox API. This provider exposes two resources: [proxmox_vm_qemu](docs/resources/vm_qemu.md) and [proxmox_lxc](docs/resources/lxc.md).
+
+## Creating the Proxmox user and role for terraform 
+
+The particular priveledges required may change but here is a suitable starting point rather than using cluster-wide Administrator rights
+
+Log into the Proxmox cluster or host using ssh (or mimic these in the GUI) then:
+- Create a new role for the future terraform user.
+- Create the user "terraform-prov@pve"
+- Add the TERRAFORM-PROV role to the terraform-prov user
+
+```bash
+pveum role add TerraformProv -privs "VM.Allocate VM.Clone VM.Config.CDROM VM.Config.CPU VM.Config.Cloudinit VM.Config.Disk VM.Config.HWType VM.Config.Memory VM.Config.Network VM.Config.Options VM.Monitor VM.Audit VM.PowerMgmt Datastore.AllocateSpace Datastore.Audit"
+pveum user add terraform-prov@pve --password <password>
+pveum aclmod / -user terraform-prov@pve -role TerraformProv
+```
+
+The provider also supports using an API key rather than a password, see below for details. 
+
+After the role is in use, if there is a need to modofy the privledges, simply issue the command showed, adding or removing priviledges as needed. 
+
+```bash
+pveum role modify TerraformProv -privs "VM.Allocate VM.Clone VM.Config.CDROM VM.Config.CPU VM.Config.Cloudinit VM.Config.Disk VM.Config.HWType VM.Config.Memory VM.Config.Network VM.Config.Options VM.Monitor VM.Audit VM.PowerMgmt Datastore.AllocateSpace Datastore.Audit"
+```
+
+For more information on existing roles and priviledges in Proxmox, refer to the vendor docs on [PVE User Management](https://pve.proxmox.com/wiki/User_Management)
 
 ## Creating the connection via username and password
 
@@ -13,6 +37,8 @@ variables.
 export PM_USER="terraform-user@pve"
 export PM_PASS="password"
 ```
+
+Note: these values can also be set in main.tf but users are encouraged to explore Vault as a way to remove secrets from their HCL.
 
 ```hcl
 provider "proxmox" {

--- a/docs/resources/vm_qemu.md
+++ b/docs/resources/vm_qemu.md
@@ -64,7 +64,7 @@ EOF
 
 ## Preprovision for Cloud-Init
 
-Cloud-init VMs must be cloned from a [cloud-init ready template](https://pve.proxmox.com/wiki/Cloud-Init_Support). When creating a resource that is using Cloud-Init, there are multi configurations possible. You can use either the `ciconfig` parameter to create based on [a Cloud-init configuration file](https://cloudinit.readthedocs.io/en/latest/topics/examples.html) or use the Proxmox variable `ciuser`, `cipassword`, `ipconfig0`, `ipconfig1`, `searchdomain`, `nameserver` and `sshkeys`.
+Cloud-init VMs must be cloned from a [cloud-init ready template](https://pve.proxmox.com/wiki/Cloud-Init_Support). When creating a resource that is using Cloud-Init, there are multi configurations possible. You can use either the `ciconfig` parameter to create based on [a Cloud-init configuration file](https://cloudinit.readthedocs.io/en/latest/topics/examples.html) or use the Proxmox variable `ciuser`, `cipassword`, `ipconfig0`, `ipconfig1`, `ipconfig2`, `ipconfig3`, `ipconfig4`, `ipconfig5`, `searchdomain`, `nameserver` and `sshkeys`.
 
 For more information, see the [Cloud-init guide](docs/guides/cloud_init.md).
 
@@ -125,6 +125,11 @@ The following arguments are supported in the top level resource block.
 |`ipconfig0`|`str`||The first IP address to assign to the guest. Format: `[gw=<GatewayIPv4>] [,gw6=<GatewayIPv6>] [,ip=<IPv4Format/CIDR>] [,ip6=<IPv6Format/CIDR>]`.|
 |`ipconfig1`|`str`||The second IP address to assign to the guest. Same format as `ipconfig0`.|
 |`ipconfig2`|`str`||The third IP address to assign to the guest. Same format as `ipconfig0`.|
+|`ipconfig3`|`str`||The fourth IP address to assign to the guest. Same format as `ipconfig0`.|
+|`ipconfig4`|`str`||The fifth IP address to assign to the guest. Same format as `ipconfig0`.|
+|`ipconfig5`|`str`||The sixth IP address to assign to the guest. Same format as `ipconfig0`.|
+
+Note: Proxmox supports ipconfigN arbritrary numbers of interfaces, but at the moment this Terraform provider has support for 0-5 addresses only. If there is interest, this could be refactored to support any number of interfaces.
 
 ### VGA Block
 

--- a/proxmox/resource_vm_qemu.go
+++ b/proxmox/resource_vm_qemu.go
@@ -661,6 +661,21 @@ func resourceVmQemu() *schema.Resource {
 				Optional: true,
 				ForceNew: true,
 			},
+			"ipconfig3": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"ipconfig4": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"ipconfig5": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
 			"preprovision": {
 				Type:          schema.TypeBool,
 				Optional:      true,
@@ -760,6 +775,9 @@ func resourceVmQemuCreate(d *schema.ResourceData, meta interface{}) error {
 		Ipconfig0:    d.Get("ipconfig0").(string),
 		Ipconfig1:    d.Get("ipconfig1").(string),
 		Ipconfig2:    d.Get("ipconfig2").(string),
+		Ipconfig3:    d.Get("ipconfig3").(string),
+		Ipconfig4:    d.Get("ipconfig4").(string),
+		Ipconfig5:    d.Get("ipconfig5").(string),
 		// Deprecated single disk config.
 		Storage:  d.Get("storage").(string),
 		DiskSize: d.Get("disk_gb").(float64),
@@ -1023,6 +1041,9 @@ func resourceVmQemuUpdate(d *schema.ResourceData, meta interface{}) error {
 		Ipconfig0:    d.Get("ipconfig0").(string),
 		Ipconfig1:    d.Get("ipconfig1").(string),
 		Ipconfig2:    d.Get("ipconfig2").(string),
+		Ipconfig3:    d.Get("ipconfig3").(string),
+		Ipconfig4:    d.Get("ipconfig4").(string),
+		Ipconfig5:    d.Get("ipconfig5").(string),
 		// Deprecated single disk config.
 		Storage:  d.Get("storage").(string),
 		DiskSize: d.Get("disk_gb").(float64),
@@ -1079,6 +1100,9 @@ func resourceVmQemuUpdate(d *schema.ResourceData, meta interface{}) error {
 		"ipconfig0",
 		"ipconfig1",
 		"ipconfig2",
+		"ipconfig3",
+		"ipconfig4",
+		"ipconfig5",
 		"kvm",
 		"vga",
 		"serial",
@@ -1255,6 +1279,9 @@ func _resourceVmQemuRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("ipconfig0", config.Ipconfig0)
 	d.Set("ipconfig1", config.Ipconfig1)
 	d.Set("ipconfig2", config.Ipconfig2)
+	d.Set("ipconfig3", config.Ipconfig3)
+	d.Set("ipconfig4", config.Ipconfig4)
+	d.Set("ipconfig5", config.Ipconfig5)
 
 	// Some dirty hacks to populate undefined keys with default values.
 	checkedKeys := []string{"clone_wait", "additional_wait", "force_create", "define_connection_info", "preprovision"}


### PR DESCRIPTION
This goes beyond the four interfaces requested in Issue #345 because I have/am deploying dozens of VMs using this provider that each have six interfaces (SDN/routers) As with the changes in proxmox-api-go code, yes, this is an ugly way to code, but I'm offering this initial contribution like this so that it is easily understood, requires limited testing, and because I need six interfaces right now. If you adopt this change into a release, I would be open to refactoring and testing with more elegant code. 