### PR TITLE
remove pointless variable

### DIFF
--- a/proxmox/resource_vm_qemu.go
+++ b/proxmox/resource_vm_qemu.go
@@ -1412,8 +1412,7 @@ func resourceVmQemuDelete(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	// Wait until vm is stopped. Otherwise, deletion will fail.
-	waited := 0
-	for waited < 300 {
+	for {
 		vmState, err := client.GetVmState(vmr)
 		if err == nil && vmState["status"] == "stopped" {
 			break


### PR DESCRIPTION
Variable "waited" is not used, except for creating a while loop which is also possible by just creating a for loop without any argument in go -> removed "waited"