### PR TITLE
Change pool management

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/Telmate/terraform-provider-proxmox
 go 1.16
 
 require (
-	github.com/Telmate/proxmox-api-go v0.0.0-20210713150936-9bfd169c655f
+	github.com/Telmate/proxmox-api-go v0.0.0-20210824171734-5a7bec182583
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.6.1
 	github.com/rs/zerolog v1.21.0
 )

--- a/go.sum
+++ b/go.sum
@@ -40,12 +40,8 @@ github.com/Masterminds/sprig v2.22.0+incompatible/go.mod h1:y6hNFY5UBTIWBxnzTeuN
 github.com/Microsoft/go-winio v0.4.14/go.mod h1:qXqCSQ3Xa7+6tgxaGTIe4Kpcdsi+P8jBhyzoq1bpyYA=
 github.com/Microsoft/go-winio v0.4.16 h1:FtSW/jqD+l4ba5iPBj9CODVtgfYAD8w2wS923g/cFDk=
 github.com/Microsoft/go-winio v0.4.16/go.mod h1:XB6nPKklQyQ7GC9LdcBEcBl8PF76WugXOPRXwdLnMv0=
-github.com/Telmate/proxmox-api-go v0.0.0-20210507143528-c60bbda13c0c h1:s8BXeCeP5hLudxqEVwSScJMS/V25eyatTKpIg7JMSNQ=
-github.com/Telmate/proxmox-api-go v0.0.0-20210507143528-c60bbda13c0c/go.mod h1:keBhXWLa+UBajvf79xvKcfiqeIc7vZL9wOqxuy1CBGw=
-github.com/Telmate/proxmox-api-go v0.0.0-20210708200918-d27e0fa5a4a4 h1:nPcdJDO4MVAAUPsJtVV7rgjQGFvjxUEBkP53XrUve88=
-github.com/Telmate/proxmox-api-go v0.0.0-20210708200918-d27e0fa5a4a4/go.mod h1:keBhXWLa+UBajvf79xvKcfiqeIc7vZL9wOqxuy1CBGw=
-github.com/Telmate/proxmox-api-go v0.0.0-20210713150936-9bfd169c655f h1:Lb9VXSg+7bJSVAf5pzUqc5X6GTN502NQsP+64tF+T4w=
-github.com/Telmate/proxmox-api-go v0.0.0-20210713150936-9bfd169c655f/go.mod h1:keBhXWLa+UBajvf79xvKcfiqeIc7vZL9wOqxuy1CBGw=
+github.com/Telmate/proxmox-api-go v0.0.0-20210824171734-5a7bec182583 h1:sL9zKd94Wst59MYibXCa7J5ipLMfrp1uUR6Z4rmrMrQ=
+github.com/Telmate/proxmox-api-go v0.0.0-20210824171734-5a7bec182583/go.mod h1:keBhXWLa+UBajvf79xvKcfiqeIc7vZL9wOqxuy1CBGw=
 github.com/agext/levenshtein v1.2.1/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
 github.com/agext/levenshtein v1.2.2 h1:0S/Yg6LYmFJ5stwQeRp6EeOcCbj7xiqQSdNelsXvaqE=
 github.com/agext/levenshtein v1.2.2/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=

--- a/proxmox/resource_lxc.go
+++ b/proxmox/resource_lxc.go
@@ -674,6 +674,22 @@ func _resourceLxcRead(d *schema.ResourceData, meta interface{}) error {
 		}
 	}
 
+	// Pool
+	pools, err := client.GetPoolList()
+	if err == nil {
+		for _, poolInfo := range pools["data"].([]interface{}) {
+			// logToFile(fmt.Sprintf("%+v\n", poolInfo))
+			poolContent, _ := client.GetPoolInfo(poolInfo.(map[string]interface{})["poolid"].(string))
+			poolMembers := poolContent["data"].(map[string]interface{})["members"]
+			for _, member := range poolMembers.([]interface{}) {
+				if vmID == int(member.(map[string]interface{})["vmid"].(float64)) {
+					d.Set("pool", poolInfo.(map[string]interface{})["poolid"].(string))
+				}
+
+			}
+		}
+	}
+
 	// Read Misc
 	d.Set("arch", config.Arch)
 	d.Set("bwlimit", config.BWLimit)
@@ -693,7 +709,6 @@ func _resourceLxcRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("nameserver", config.Nameserver)
 	d.Set("onboot", config.OnBoot)
 	d.Set("ostype", config.OsType)
-	d.Set("pool", config.Pool)
 	d.Set("protection", config.Protection)
 	d.Set("restore", config.Restore)
 	d.Set("searchdomain", config.SearchDomain)

--- a/proxmox/resource_lxc.go
+++ b/proxmox/resource_lxc.go
@@ -693,14 +693,12 @@ func _resourceLxcRead(d *schema.ResourceData, meta interface{}) error {
 	pools, err := client.GetPoolList()
 	if err == nil {
 		for _, poolInfo := range pools["data"].([]interface{}) {
-			// logToFile(fmt.Sprintf("%+v\n", poolInfo))
 			poolContent, _ := client.GetPoolInfo(poolInfo.(map[string]interface{})["poolid"].(string))
 			poolMembers := poolContent["data"].(map[string]interface{})["members"]
 			for _, member := range poolMembers.([]interface{}) {
 				if vmID == int(member.(map[string]interface{})["vmid"].(float64)) {
 					d.Set("pool", poolInfo.(map[string]interface{})["poolid"].(string))
 				}
-
 			}
 		}
 	}

--- a/proxmox/resource_lxc.go
+++ b/proxmox/resource_lxc.go
@@ -591,6 +591,21 @@ func resourceLxcUpdate(d *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 
+	if d.HasChange("pool") {
+		oldPool, newPool := func() (string, string) {
+			a, b := d.GetChange("pool")
+			return a.(string), b.(string)
+		}()
+
+		vmr := pxapi.NewVmRef(vmID)
+		vmr.SetPool(oldPool)
+
+		_, err := client.UpdateVMPool(vmr, newPool)
+		if err != nil {
+			return err
+		}
+	}
+
 	return _resourceLxcRead(d, meta)
 }
 

--- a/proxmox/resource_vm_qemu.go
+++ b/proxmox/resource_vm_qemu.go
@@ -1378,14 +1378,12 @@ func _resourceVmQemuRead(d *schema.ResourceData, meta interface{}) error {
 	pools, err := client.GetPoolList()
 	if err == nil {
 		for _, poolInfo := range pools["data"].([]interface{}) {
-			// logToFile(fmt.Sprintf("%+v\n", poolInfo))
 			poolContent, _ := client.GetPoolInfo(poolInfo.(map[string]interface{})["poolid"].(string))
 			poolMembers := poolContent["data"].(map[string]interface{})["members"]
 			for _, member := range poolMembers.([]interface{}) {
 				if vmID == int(member.(map[string]interface{})["vmid"].(float64)) {
 					d.Set("pool", poolInfo.(map[string]interface{})["poolid"].(string))
 				}
-
 			}
 		}
 	}

--- a/proxmox/resource_vm_qemu.go
+++ b/proxmox/resource_vm_qemu.go
@@ -1223,7 +1223,6 @@ func _resourceVmQemuRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("target_node", vmr.Node())
 	d.Set("name", config.Name)
 	d.Set("desc", config.Description)
-	d.Set("pool", config.Pool)
 	d.Set("bios", config.Bios)
 	d.Set("onboot", config.Onboot)
 	d.Set("boot", config.Boot)
@@ -1359,6 +1358,22 @@ func _resourceVmQemuRead(d *schema.ResourceData, meta interface{}) error {
 
 	// Reset reboot_required variable. It should change only during updates.
 	d.Set("reboot_required", false)
+
+	// Pool
+	pools, err := client.GetPoolList()
+	if err == nil {
+		for _, poolInfo := range pools["data"].([]interface{}) {
+			// logToFile(fmt.Sprintf("%+v\n", poolInfo))
+			poolContent, _ := client.GetPoolInfo(poolInfo.(map[string]interface{})["poolid"].(string))
+			poolMembers := poolContent["data"].(map[string]interface{})["members"]
+			for _, member := range poolMembers.([]interface{}) {
+				if vmID == int(member.(map[string]interface{})["vmid"].(float64)) {
+					d.Set("pool", poolInfo.(map[string]interface{})["poolid"].(string))
+				}
+
+			}
+		}
+	}
 
 	// DEBUG print out the read result
 	flatValue, _ := resourceDataToFlatValues(d, thisResource)

--- a/proxmox/resource_vm_qemu.go
+++ b/proxmox/resource_vm_qemu.go
@@ -1051,6 +1051,21 @@ func resourceVmQemuUpdate(d *schema.ResourceData, meta interface{}) error {
 	// Give some time to proxmox to catchup.
 	time.Sleep(15 * time.Second)
 
+	if d.HasChange("pool") {
+		oldPool, newPool := func() (string, string) {
+			a, b := d.GetChange("pool")
+			return a.(string), b.(string)
+		}()
+
+		vmr := pxapi.NewVmRef(vmID)
+		vmr.SetPool(oldPool)
+
+		_, err := client.UpdateVMPool(vmr, newPool)
+		if err != nil {
+			return err
+		}
+	}
+
 	err = initConnInfo(d, pconf, client, vmr, &config, lock)
 	if err != nil {
 		return err


### PR DESCRIPTION
Currently, the endpoint /config does not give the pool, we have to obtain it manually. It may be interesting to refactor this to a single function.

I have also included the possibility of changing the pool of already created resources