### PR TITLE
 Add support for pool resource 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/Telmate/terraform-provider-proxmox
 go 1.16
 
 require (
-	github.com/Telmate/proxmox-api-go v0.0.0-20210713150936-9bfd169c655f
+	github.com/Telmate/proxmox-api-go v0.0.0-20210824171734-5a7bec182583
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.6.1
 	github.com/rs/zerolog v1.21.0
 )

--- a/go.sum
+++ b/go.sum
@@ -40,12 +40,8 @@ github.com/Masterminds/sprig v2.22.0+incompatible/go.mod h1:y6hNFY5UBTIWBxnzTeuN
 github.com/Microsoft/go-winio v0.4.14/go.mod h1:qXqCSQ3Xa7+6tgxaGTIe4Kpcdsi+P8jBhyzoq1bpyYA=
 github.com/Microsoft/go-winio v0.4.16 h1:FtSW/jqD+l4ba5iPBj9CODVtgfYAD8w2wS923g/cFDk=
 github.com/Microsoft/go-winio v0.4.16/go.mod h1:XB6nPKklQyQ7GC9LdcBEcBl8PF76WugXOPRXwdLnMv0=
-github.com/Telmate/proxmox-api-go v0.0.0-20210507143528-c60bbda13c0c h1:s8BXeCeP5hLudxqEVwSScJMS/V25eyatTKpIg7JMSNQ=
-github.com/Telmate/proxmox-api-go v0.0.0-20210507143528-c60bbda13c0c/go.mod h1:keBhXWLa+UBajvf79xvKcfiqeIc7vZL9wOqxuy1CBGw=
-github.com/Telmate/proxmox-api-go v0.0.0-20210708200918-d27e0fa5a4a4 h1:nPcdJDO4MVAAUPsJtVV7rgjQGFvjxUEBkP53XrUve88=
-github.com/Telmate/proxmox-api-go v0.0.0-20210708200918-d27e0fa5a4a4/go.mod h1:keBhXWLa+UBajvf79xvKcfiqeIc7vZL9wOqxuy1CBGw=
-github.com/Telmate/proxmox-api-go v0.0.0-20210713150936-9bfd169c655f h1:Lb9VXSg+7bJSVAf5pzUqc5X6GTN502NQsP+64tF+T4w=
-github.com/Telmate/proxmox-api-go v0.0.0-20210713150936-9bfd169c655f/go.mod h1:keBhXWLa+UBajvf79xvKcfiqeIc7vZL9wOqxuy1CBGw=
+github.com/Telmate/proxmox-api-go v0.0.0-20210824171734-5a7bec182583 h1:sL9zKd94Wst59MYibXCa7J5ipLMfrp1uUR6Z4rmrMrQ=
+github.com/Telmate/proxmox-api-go v0.0.0-20210824171734-5a7bec182583/go.mod h1:keBhXWLa+UBajvf79xvKcfiqeIc7vZL9wOqxuy1CBGw=
 github.com/agext/levenshtein v1.2.1/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
 github.com/agext/levenshtein v1.2.2 h1:0S/Yg6LYmFJ5stwQeRp6EeOcCbj7xiqQSdNelsXvaqE=
 github.com/agext/levenshtein v1.2.2/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=

--- a/proxmox/provider.go
+++ b/proxmox/provider.go
@@ -122,6 +122,7 @@ func Provider() *schema.Provider {
 			"proxmox_vm_qemu":  resourceVmQemu(),
 			"proxmox_lxc":      resourceLxc(),
 			"proxmox_lxc_disk": resourceLxcDisk(),
+			"proxmox_pool":     resourcePool(),
 			// TODO - proxmox_storage_iso
 			// TODO - proxmox_bridge
 			// TODO - proxmox_vm_qemu_template

--- a/proxmox/provider.go
+++ b/proxmox/provider.go
@@ -289,3 +289,17 @@ func parseResourceId(resId string) (targetNode string, resType string, vmId int,
 	vmId, err = strconv.Atoi(idMatch[3])
 	return
 }
+
+func clusterResourceId(resType string, resId string) string {
+	return fmt.Sprintf("%s/%s", resType, resId)
+}
+
+var rxClusterRsId = regexp.MustCompile("([^/]+)/([^/]+)")
+
+func parseClusterResourceId(resId string) (resType string, id string, err error) {
+	if !rxClusterRsId.MatchString(resId) {
+		return "", "", fmt.Errorf("Invalid resource format: %s. Must be type/resId", resId)
+	}
+	idMatch := rxClusterRsId.FindStringSubmatch(resId)
+	return idMatch[1], idMatch[2], nil
+}

--- a/proxmox/provider_test.go
+++ b/proxmox/provider_test.go
@@ -1,0 +1,60 @@
+package proxmox
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestParseClusteResources(t *testing.T) {
+	type ParseClusterResourceTestResult struct {
+		ResourceType string
+		ResourceId   string
+		Error        error
+	}
+
+	tests := []struct {
+		name   string
+		input  string
+		output ParseClusterResourceTestResult
+	}{{
+		name:  "basic pools",
+		input: "pools/test-pool",
+		output: ParseClusterResourceTestResult{
+			ResourceType: "pools",
+			ResourceId:   "test-pool",
+		},
+	}, {
+		name:  "basic storage",
+		input: "storage/backups",
+		output: ParseClusterResourceTestResult{
+			ResourceType: "storage",
+			ResourceId:   "backups",
+		},
+	}, {
+		name:  "invalid resource",
+		input: "storage",
+		output: ParseClusterResourceTestResult{
+			Error: errors.New("Invalid resource format: storage. Must be type/resId"),
+		},
+	}}
+
+	for _, test := range tests {
+		t.Run(test.name, func(*testing.T) {
+			resType, resId, err := parseClusterResourceId(test.input)
+
+			if test.output.Error != nil && err != nil &&
+				err.Error() != test.output.Error.Error() {
+				t.Errorf("%s: error expected `%+v`, got `%+v`",
+					test.name, test.output.Error, err)
+			}
+			if resType != test.output.ResourceType {
+				t.Errorf("%s: resource type expected `%+v`, got `%+v`",
+					test.name, test.output.ResourceType, resType)
+			}
+			if resId != test.output.ResourceId {
+				t.Errorf("%s: resource id expected `%+v`, got `%+v`",
+					test.name, test.output.ResourceId, resId)
+			}
+		})
+	}
+}

--- a/proxmox/resource_pool.go
+++ b/proxmox/resource_pool.go
@@ -1,0 +1,137 @@
+package proxmox
+
+import (
+	"fmt"
+
+	pxapi "github.com/Telmate/proxmox-api-go/proxmox"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+var poolResourceDef *schema.Resource
+
+func resourcePool() *schema.Resource {
+	*pxapi.Debug = true
+
+	poolResourceDef = &schema.Resource{
+		Create: resourcePoolCreate,
+		Read:   resourcePoolRead,
+		Update: resourcePoolUpdate,
+		Delete: resourcePoolDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"poolid": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"comment": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+		},
+	}
+
+	return poolResourceDef
+}
+
+func resourcePoolCreate(d *schema.ResourceData, meta interface{}) error {
+	pconf := meta.(*providerConfiguration)
+	client := pconf.Client
+	lock := pmParallelBegin(pconf)
+	defer lock.unlock()
+
+	poolid := d.Get("poolid").(string)
+	comment := d.Get("comment").(string)
+
+	err := client.CreatePool(poolid, comment)
+	if err != nil {
+		return err
+	}
+
+	d.SetId(clusterResourceId("pools", poolid))
+
+	return _resourcePoolRead(d, meta)
+}
+
+func resourcePoolRead(d *schema.ResourceData, meta interface{}) error {
+	pconf := meta.(*providerConfiguration)
+	lock := pmParallelBegin(pconf)
+	defer lock.unlock()
+	return _resourcePoolRead(d, meta)
+}
+
+func _resourcePoolRead(d *schema.ResourceData, meta interface{}) error {
+	pconf := meta.(*providerConfiguration)
+	client := pconf.Client
+
+	_, poolID, err := parseClusterResourceId(d.Id())
+	if err != nil {
+		d.SetId("")
+		return fmt.Errorf("Unexpected error when trying to read and parse resource id: %v", err)
+	}
+
+	logger, _ := CreateSubLogger("resource_pool_read")
+	logger.Info().Str("poolid", poolID).Msg("Reading configuration for poolid")
+
+	poolInfo, err := client.GetPoolInfo(poolID)
+	if err != nil {
+		d.SetId("")
+		return nil
+	}
+	a
+	d.SetId(clusterResourceId("pools", poolID))
+	d.Set("comment", "")
+	if poolInfo["data"].(map[string]interface{})["comment"] != nil {
+		d.Set("comment", poolInfo["data"].(map[string]interface{})["comment"].(string))
+	}
+
+	// DEBUG print the read result
+	logger.Debug().Str("poolid", poolID).Msgf("Finished pool read resulting in data: '%+v'", poolInfo["data"])
+	return nil
+}
+
+func resourcePoolUpdate(d *schema.ResourceData, meta interface{}) error {
+	pconf := meta.(*providerConfiguration)
+	lock := pmParallelBegin(pconf)
+	defer lock.unlock()
+
+	logger, _ := CreateSubLogger("resource_pool_update")
+
+	client := pconf.Client
+	_, poolID, err := parseClusterResourceId(d.Id())
+	if err != nil {
+		return err
+	}
+
+	logger.Info().Str("poolid", poolID).Msg("Starting update of the Pool resource")
+
+	if d.HasChange("comment") {
+		nextComment := d.Get("comment").(string)
+		err := client.UpdatePoolComment(poolID, nextComment)
+		if err != nil {
+			return err
+		}
+	}
+
+	return _resourcePoolRead(d, meta)
+}
+
+func resourcePoolDelete(d *schema.ResourceData, meta interface{}) error {
+	pconf
+	pconf := meta.(*providerConfiguration)
+	lock := pmParallelBegin(pconf)
+	defer lock.unlock()
+
+	client := pconf.Client
+	_, poolID, err := parseClusterResourceId(d.Id())
+
+	err = client.DeletePool(poolID)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}


### PR DESCRIPTION
I have doubts if this is the correct way to manage cluster-scoped resource ids.

I'm not sure if the pool resource should manage the vms/lxcs/storage attached, I think that should be done in the vm/lxc/storage side, but if you prefer to also be able to manage it here I add that option, it shouldn't be too hard.

I'm also would like to ask if you want me to keep adding tests, or that may be an issue