### PR TITLE
updated docs/resources/vm_qemu.md broken link

### DIFF
--- a/docs/resources/vm_qemu.md
+++ b/docs/resources/vm_qemu.md
@@ -66,7 +66,7 @@ EOF
 
 Cloud-init VMs must be cloned from a [cloud-init ready template](https://pve.proxmox.com/wiki/Cloud-Init_Support). When creating a resource that is using Cloud-Init, there are multi configurations possible. You can use either the `ciconfig` parameter to create based on [a Cloud-init configuration file](https://cloudinit.readthedocs.io/en/latest/topics/examples.html) or use the Proxmox variable `ciuser`, `cipassword`, `ipconfig0`, `ipconfig1`, `ipconfig2`, `ipconfig3`, `ipconfig4`, `ipconfig5`, `searchdomain`, `nameserver` and `sshkeys`.
 
-For more information, see the [Cloud-init guide](docs/guides/cloud_init.md).
+For more information, see the [Cloud-init guide](../../docs/guides/cloud_init.md).
 
 ## Argument reference
 


### PR DESCRIPTION
IMHO better than #389 because `/` could mean different things between GitHub and the `registry.terraform.io` documentation section website/framework.
But I might be totally wrong and YMMV, if so, feel free to accept #389 and just close this PR instead.