### PR TITLE
Fix out of range panic

### DIFF
--- a/proxmox/resource_vm_qemu.go
+++ b/proxmox/resource_vm_qemu.go
@@ -1180,8 +1180,16 @@ func resourceVmQemuUpdate(d *schema.ResourceData, meta interface{}) error {
 			// disk added or removed AND there is no disk hot(un)plug
 			d.Set("reboot_required", true)
 		} else {
+			r := len(oldValues)
+
+			// we have have to check if the new configuration has fewer disks
+			// otherwise an index out of range panic occurs if we don't reduce the range
+			if rangeNV := len(newValues); rangeNV < r {
+				r = rangeNV
+			}
+
 			// some of the existing disk parameters have changed
-			for i := range oldValues { // loop through the interfaces
+			for i := 0; i < r; i++ { // loop through the interfaces
 				if oldValues[i].(map[string]interface{})["ssd"] != newValues[i].(map[string]interface{})["ssd"] {
 					d.Set("reboot_required", true)
 				}


### PR DESCRIPTION
Fixes #409 but only the out of range panic.

If disks are removed from the plan Proxmox actually receives the correct configuration from Terraform but doesn't remove the unwanted/unlisted disks.
I couldn't find the corresponding api endpoint in the [Proxmox api viewer](https://pve.proxmox.com/pve-docs/api-viewer/index.html).
Anyway, I think this has to be first implemented into the api sdk.