### PR TITLE
fix naming of  memory item in the VGA block

### DIFF
--- a/docs/resources/vm_qemu.md
+++ b/docs/resources/vm_qemu.md
@@ -137,7 +137,7 @@ See the [docs about display](https://pve.proxmox.com/pve-docs/chapter-qm.html#qm
 | Argument | Type  | Default Value | Description                                                                                                                                                         |
 | -------- | ----- | ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `type`   | `str` | `"std"`       | The type of display to virtualize. Options: `cirrus`, `none`, `qxl`, `qxl2`, `qxl3`, `qxl4`, `serial0`, `serial1`, `serial2`, `serial3`, `std`, `virtio`, `vmware`. |
-| `type`   | `int` |               | Sets the VGA memory (in MiB). Has no effect with serial display type.                                                                                               |
+| `memory`   | `int` |               | Sets the VGA memory (in MiB). Has no effect with serial display type.                                                                                               |
 
 ### Network Block
 


### PR DESCRIPTION
Fixed the incorrect naming of the VGA memory variable.

Resolves Issue #417 
