### PR TITLE
qemuvm: allow to unspecify size of cloned block device

### DIFF
--- a/proxmox/resource_vm_qemu.go
+++ b/proxmox/resource_vm_qemu.go
@@ -728,7 +728,7 @@ func resourceVmQemuCreate(d *schema.ResourceData, meta interface{}) error {
 	if len(qemuVgaList) > 0 {
 		config.QemuVga = qemuVgaList[0].(map[string]interface{})
 	}
-	log.Print("[DEBUG][QemuVmCreate] checking for duplicate name")
+	log.Print("[DEBUG][QemuVmCreate] checking for duplicate name: %s", vmName)
 	dupVmr, _ := client.GetVmRefByName(vmName)
 
 	forceCreate := d.Get("force_create").(bool)
@@ -897,7 +897,7 @@ func resourceVmQemuCreate(d *schema.ResourceData, meta interface{}) error {
 	// give sometime to proxmox to catchup
 	//time.Sleep(time.Duration(d.Get("additional_wait").(int)) * time.Second)
 
-	log.Print("[DEBUG][QemuVmCreate] starting VM")
+	log.Print("[DEBUG][QemuVmCreate] starting VM: %d", vmr.VmId())
 	_, err := client.StartVm(vmr)
 	if err != nil {
 		return err
@@ -1469,7 +1469,7 @@ func prepareDiskSize(
 			if err != nil {
 				return err
 			}
-		} else if diskSize == clonedDiskSize {
+		} else if diskSize == clonedDiskSize || diskSize <= 0 {
 			logger.Debug().Int("diskId", diskID).Msgf("Disk is same size as before, skipping resize. Original '%+v', New '%+v'", diskSize, clonedDiskSize)
 		} else {
 			return fmt.Errorf("proxmox does not support decreasing disk size. Disk '%v' wanted to go from '%vG' to '%vG'", diskName, clonedDiskSize, diskSize)

--- a/proxmox/resource_vm_qemu.go
+++ b/proxmox/resource_vm_qemu.go
@@ -728,7 +728,7 @@ func resourceVmQemuCreate(d *schema.ResourceData, meta interface{}) error {
 	if len(qemuVgaList) > 0 {
 		config.QemuVga = qemuVgaList[0].(map[string]interface{})
 	}
-	log.Print("[DEBUG][QemuVmCreate] checking for duplicate name: %s", vmName)
+	log.Printf("[DEBUG][QemuVmCreate] checking for duplicate name: %s", vmName)
 	dupVmr, _ := client.GetVmRefByName(vmName)
 
 	forceCreate := d.Get("force_create").(bool)
@@ -897,7 +897,7 @@ func resourceVmQemuCreate(d *schema.ResourceData, meta interface{}) error {
 	// give sometime to proxmox to catchup
 	//time.Sleep(time.Duration(d.Get("additional_wait").(int)) * time.Second)
 
-	log.Print("[DEBUG][QemuVmCreate] starting VM: %d", vmr.VmId())
+	log.Printf("[DEBUG][QemuVmCreate] starting VM: %d", vmr.VmId())
 	_, err := client.StartVm(vmr)
 	if err != nil {
 		return err


### PR DESCRIPTION
Template can contain block device. During cloning, plugin checks size and fails
if size is not same. In advance, it may be impossible to specify size correctly.

Let's consider "0" as unspecified size to skip check.