### PR TITLE
use trimpath for reproducibility

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ test:
 build: clean
 	@echo " -> Building"
 	mkdir -p bin
-	CGO_ENABLED=0 go build -o bin/terraform-provider-proxmox
+	CGO_ENABLED=0 go build -trimpath -o bin/terraform-provider-proxmox
 	@echo "Built terraform-provider-proxmox"
 
 acctest: build


### PR DESCRIPTION
for better reproducible builds add trimpath, pull out sensitive user/system specific strings. github auto added end of file newline too. neither seems to cause issues with building or running provider

maintainer edits allowed