### PR TITLE
Add new `aio` disk attribute and endorce `scsihw` values

### DIFF
--- a/proxmox/resource_vm_qemu.go
+++ b/proxmox/resource_vm_qemu.go
@@ -195,6 +195,14 @@ func resourceVmQemu() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					"lsi",
+					"lsi53c810",
+					"virtio-scsi-pci",
+					"virtio-scsi-single",
+					"megasas",
+					"pvscsi",
+				}, false),
 			},
 			"vga": {
 				Type:     schema.TypeSet,
@@ -350,6 +358,15 @@ func resourceVmQemu() *schema.Resource {
 								}
 								return
 							},
+						},
+						"aio": {
+							Type: schema.TypeString,
+							Optional: true,
+							ValidateFunc: validation.StringInSlice([]string{
+								"native",
+								"threads",
+								"io_uring",
+							}, false),
 						},
 						//Maximum r/w speed in megabytes per second
 						"mbps": {


### PR DESCRIPTION
I added the `aio` disk attribute, which was missing. And enforce the `scsihw` value. I'm not a go developer, so I took the `StringInSlice` method from this: https://github.com/hashicorp/terraform-provider-aws/issues/14601.