### PR TITLE
Update example username in documentation to match username used earlier

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -40,7 +40,7 @@ One can supply fields using the provider syntax in Terraform. It is recommended 
 variables.
 
 ```bash
-export PM_USER="terraform-user@pve"
+export PM_USER="terraform-prov@pve"
 export PM_PASS="password"
 ```
 
@@ -56,7 +56,7 @@ provider "proxmox" {
 ## Creating the connection via username and API token
 
 ```bash
-export PM_API_TOKEN_ID="terraform-user@pve!mytoken"
+export PM_API_TOKEN_ID="terraform-prov@pve!mytoken"
 export PM_API_TOKEN_SECRET="afcd8f45-acc1-4d0f-bb12-a70b0777ec11"
 ```
 

--- a/examples/cloudinit_example.tf
+++ b/examples/cloudinit_example.tf
@@ -2,7 +2,7 @@ provider "proxmox" {
     pm_tls_insecure = true
     pm_api_url = "https://proxmox-server01.example.com:8006/api2/json"
     pm_password = "secret"
-    pm_user = "terraform-user@pve"
+    pm_user = "terraform-prov@pve"
     pm_otp = ""
 }
 

--- a/examples/lxc_example.tf
+++ b/examples/lxc_example.tf
@@ -2,7 +2,7 @@ provider "proxmox" {
     pm_tls_insecure = true
     pm_api_url = "https://proxmox.org/api2/json"
     pm_password = "supersecret"
-    pm_user = "terraform-user@pve"
+    pm_user = "terraform-prov@pve"
     pm_otp = ""
 }
 


### PR DESCRIPTION
If following the examples in the documentation for setting up the provider, users may not notice that the username changes from `terraform-prov` (e.g. [_here_](https://github.com/Telmate/terraform-provider-proxmox/blob/b2d39bbb0f6a7133fc922da31dd49792c94e85e9/docs/index.md?plain=1#L20)) to `terraform-user` (e.g. [_here_](https://github.com/Telmate/terraform-provider-proxmox/blob/b2d39bbb0f6a7133fc922da31dd49792c94e85e9/docs/index.md?plain=1#L43)), I don't know if either of these is preferred however I feel that they should be consistent.