### PR TITLE
Allow set custom MTU.

### DIFF
--- a/proxmox/resource_vm_qemu.go
+++ b/proxmox/resource_vm_qemu.go
@@ -269,6 +269,10 @@ func resourceVmQemu() *schema.Resource {
 							Optional: true,
 							Computed: true,
 						},
+						"mtu": {
+							Type:     schema.TypeInt,
+							Optional: true,
+						},
 						"queues": {
 							Type:     schema.TypeInt,
 							Optional: true,


### PR DESCRIPTION
Hello, I use the provider, and on Hetzner we need set custom MTU on new VM interfaces when used VSWITCH.
I make changes in and wants to add the option. 

I checks locally and it works fine with proxmox 6x and 7.x