### PR TITLE
Fix MTU type for LXC container

### DIFF
--- a/proxmox/resource_lxc.go
+++ b/proxmox/resource_lxc.go
@@ -256,7 +256,7 @@ func resourceLxc() *schema.Resource {
 							Optional: true,
 						},
 						"mtu": {
-							Type:     schema.TypeString,
+							Type:     schema.TypeInt,
 							Optional: true,
 						},
 						"rate": {

--- a/proxmox/resource_vm_qemu.go
+++ b/proxmox/resource_vm_qemu.go
@@ -269,6 +269,10 @@ func resourceVmQemu() *schema.Resource {
 							Optional: true,
 							Computed: true,
 						},
+						"mtu": {
+							Type:     schema.TypeInt,
+							Optional: true,
+						},
 						"queues": {
 							Type:     schema.TypeInt,
 							Optional: true,


### PR DESCRIPTION
Currently mtu for LXC container is expected as string and there is no possibility to use this option.