### PR TITLE
Support rootfs flags

### DIFF
--- a/proxmox/resource_lxc.go
+++ b/proxmox/resource_lxc.go
@@ -320,6 +320,26 @@ func resourceLxc() *schema.Resource {
 				Optional: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
+						"acl": {
+							Type:     schema.TypeBool,
+							Optional: true,
+						},
+						"quota": {
+							Type:     schema.TypeBool,
+							Optional: true,
+						},
+						"replicate": {
+							Type:     schema.TypeBool,
+							Optional: true,
+						},
+						"ro": {
+							Type:     schema.TypeBool,
+							Optional: true,
+						},
+						"shared": {
+							Type:     schema.TypeBool,
+							Optional: true,
+						},
 						"storage": {
 							Type:     schema.TypeString,
 							ForceNew: true,


### PR DESCRIPTION
Partially address #523.
Includes support for all boolean flags according to API.

Not sure what the best way to implement the mountoptions option is.