### PR TITLE
Fix VMIDValidator for next available ID

### DIFF
--- a/proxmox/validators.go
+++ b/proxmox/validators.go
@@ -16,12 +16,11 @@ func VMIDValidator() schema.SchemaValidateDiagFunc {
 
 		if !ok {
 			return diag.Errorf("expected type of %v to be int", k)
-
 		}
 
-		if val != -1 {
+		if val != 0 {
 			if val < min || val > max {
-				return diag.Errorf("proxmox %s must be in the range (%d - %d), got %d", k, min, max, val)
+				return diag.Errorf("proxmox %s must be in the range (%d - %d) or 0 for next available ID, got %d", k, min, max, val)
 			}
 		}
 


### PR DESCRIPTION
Hi !

According to the documentation and tests we must use the vmid 0 in order to have the vmid automaticaly defined to the next available ID. Example : 

```
resource "proxmox_vm_qemu" "vm" {
  [...]
  vmid = 0
  [...]
}
```

But it's seems that in the new VMIDValidator() the value 0 is not accepted but only the value -1 or any value between 100 and 999999999. So the previous code wasn't valid.

This PR intend to fix this and allow the value 0 or any value between 100 and 999999999. This is tested on the version 2.9.6 and seems to be fully functional.

Feel free to edit or comment if I miss or forget something.

Kind Regards