### PR TITLE
[fix-crash] Correct usage of changed proxmox-api (GetPoolInfo)

### DIFF
--- a/proxmox/resource_lxc.go
+++ b/proxmox/resource_lxc.go
@@ -794,8 +794,7 @@ func _resourceLxcRead(d *schema.ResourceData, meta interface{}) error {
 	if err == nil {
 		for _, poolInfo := range pools["data"].([]interface{}) {
 			poolContent, _ := client.GetPoolInfo(poolInfo.(map[string]interface{})["poolid"].(string))
-			poolMembers := poolContent["data"].(map[string]interface{})["members"]
-			for _, member := range poolMembers.([]interface{}) {
+			for _, member := range poolContent["members"].([]interface{}) {
 				if member.(map[string]interface{})["type"] != "storage" {
 					if vmID == int(member.(map[string]interface{})["vmid"].(float64)) {
 						d.Set("pool", poolInfo.(map[string]interface{})["poolid"].(string))

--- a/proxmox/resource_pool.go
+++ b/proxmox/resource_pool.go
@@ -82,12 +82,12 @@ func _resourcePoolRead(d *schema.ResourceData, meta interface{}) error {
 
 	d.SetId(clusterResourceId("pools", poolID))
 	d.Set("comment", "")
-	if poolInfo["data"].(map[string]interface{})["comment"] != nil {
-		d.Set("comment", poolInfo["data"].(map[string]interface{})["comment"].(string))
+	if poolInfo["comment"] != nil {
+		d.Set("comment", poolInfo["comment"].(string))
 	}
 
 	// DEBUG print the read result
-	logger.Debug().Str("poolid", poolID).Msgf("Finished pool read resulting in data: '%+v'", poolInfo["data"])
+	logger.Debug().Str("poolid", poolID).Msgf("Finished pool read resulting in data: '%+v'", poolInfo)
 	return nil
 }
 

--- a/proxmox/resource_vm_qemu.go
+++ b/proxmox/resource_vm_qemu.go
@@ -1500,8 +1500,7 @@ func _resourceVmQemuRead(d *schema.ResourceData, meta interface{}) error {
 	if err == nil {
 		for _, poolInfo := range pools["data"].([]interface{}) {
 			poolContent, _ := client.GetPoolInfo(poolInfo.(map[string]interface{})["poolid"].(string))
-			poolMembers := poolContent["data"].(map[string]interface{})["members"]
-			for _, member := range poolMembers.([]interface{}) {
+			for _, member := range poolContent["members"].([]interface{}) {
 				if member.(map[string]interface{})["type"] != "storage" {
 					if vmID == int(member.(map[string]interface{})["vmid"].(float64)) {
 						d.Set("pool", poolInfo.(map[string]interface{})["poolid"].(string))


### PR DESCRIPTION
Release 2.9.8 contain new version of proxmox-api. The previous version of
function GetPoolInfo returned as-is JSON payload, but new version trims
upper layer ("data"). It results into incorrect processing of pool data and
results into crash:
```
goroutine 11 [running]:
github.com/Telmate/terraform-provider-proxmox/proxmox._resourceVmQemuRead(0x85011f900, {0xc0c640, 0x8502fc000})
        /home/mizhka/repo/pgpro/terraform-provider-proxmox/proxmox/resource_vm_qemu.go:1503 +0x2fdf
github.com/Telmate/terraform-provider-proxmox/proxmox.resourceVmQemuRead(...)
        /home/mizhka/repo/pgpro/terraform-provider-proxmox/proxmox/resource_vm_qemu.go:1305
github.com/Telmate/terraform-provider-proxmox/proxmox.resourceVmQemuCreate(0x85011f900, {0xc0c640, 0x8502fc000})
        /home/mizhka/repo/pgpro/terraform-provider-proxmox/proxmox/resource_vm_qemu.go:987 +0x3006
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*Resource).create(0x8503b2700, {0xe39940, 0x8503cf2c0}, 0x85011f900, {0xc0c640, 0x8502fc000})
        /home/mizhka/go/pkg/mod/github.com/hashicorp/terraform-plugin-sdk/v2@v2.14.0/helper/schema/resource.go:695 +0x1ee
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*Resource).Apply(0x8503b2700, {0xe39940, 0x8503cf2c0}, 0x850438d00, 0x85011f780, {0xc0c640, 0x8502fc000})
        /home/mizhka/go/pkg/mod/github.com/hashicorp/terraform-plugin-sdk/v2@v2.14.0/helper/schema/resource.go:837 +0xfce
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*GRPCProviderServer).ApplyResourceChange(0x850141128, {0xe39898, 0x850413780}, 0x8502fd4f0)
        /home/mizhka/go/pkg/mod/github.com/hashicorp/terraform-plugin-sdk/v2@v2.14.0/helper/schema/grpc_provider.go:1021 +0x12b2
github.com/hashicorp/terraform-plugin-go/tfprotov5/tf5server.(*server).ApplyResourceChange(0x8503b60a0, {0xe39940, 0x8503ce9c0}, 0x850154770)
        /home/mizhka/go/pkg/mod/github.com/hashicorp/terraform-plugin-go@v0.9.0/tfprotov5/tf5server/server.go:812 +0x742
github.com/hashicorp/terraform-plugin-go/tfprotov5/internal/tfplugin5._Provider_ApplyResourceChange_Handler({0xd00580, 0x8503b60a0}, {0xe39940, 0x8503ce9c0}, 0x85040e900, 0x0)
        /home/mizhka/go/pkg/mod/github.com/hashicorp/terraform-plugin-go@v0.9.0/tfprotov5/internal/tfplugin5/tfplugin5_grpc.pb.go:385 +0x1fd
google.golang.org/grpc.(*Server).processUnaryRPC(0x850134700, {0xe458a0, 0x8502a21a0}, 0x85001b680, 0x8503ce960, 0x1311e00, 0x0)
        /home/mizhka/go/pkg/mod/google.golang.org/grpc@v1.45.0/server.go:1282 +0xe54
google.golang.org/grpc.(*Server).handleStream(0x850134700, {0xe458a0, 0x8502a21a0}, 0x85001b680, 0x0)
        /home/mizhka/go/pkg/mod/google.golang.org/grpc@v1.45.0/server.go:1619 +0xcb3
google.golang.org/grpc.(*Server).serveStreams.func1.2(0x850039f70, 0x850134700, {0xe458a0, 0x8502a21a0}, 0x85001b680)
        /home/mizhka/go/pkg/mod/google.golang.org/grpc@v1.45.0/server.go:921 +0xad
created by google.golang.org/grpc.(*Server).serveStreams.func1
        /home/mizhka/go/pkg/mod/google.golang.org/grpc@v1.45.0/server.go:919 +0x1ec
```
Error: The terraform-provider-proxmox_v2.9.8 plugin crashed!