### PR TITLE
chore: bump proxmox-api-go dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/Telmate/terraform-provider-proxmox
 go 1.17
 
 require (
-	github.com/Telmate/proxmox-api-go v0.0.0-20220419083039-768690daeef0
+	github.com/Telmate/proxmox-api-go v0.0.0-20220427144307-a199a8705511
 	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.14.0
 	github.com/rs/zerolog v1.26.1

--- a/go.sum
+++ b/go.sum
@@ -8,6 +8,8 @@ github.com/ProtonMail/go-crypto v0.0.0-20210428141323-04723f9f07d7 h1:YoJbenK9C6
 github.com/ProtonMail/go-crypto v0.0.0-20210428141323-04723f9f07d7/go.mod h1:z4/9nQmJSSwwds7ejkxaJwO37dru3geImFUdJlaLzQo=
 github.com/Telmate/proxmox-api-go v0.0.0-20220419083039-768690daeef0 h1:XLG0LqKo9U8L+a5E+/p+/FA0OZRJ97Q6Tx6gXTVcTC8=
 github.com/Telmate/proxmox-api-go v0.0.0-20220419083039-768690daeef0/go.mod h1:R2cLzFQFU5Al/0PaYH2weoZorYUM4JXbHj4POyprAn4=
+github.com/Telmate/proxmox-api-go v0.0.0-20220427144307-a199a8705511 h1:9Mwy/7X1/Jttlt7UfL6TsBTGI68nII+CFg5puTFZml4=
+github.com/Telmate/proxmox-api-go v0.0.0-20220427144307-a199a8705511/go.mod h1:R2cLzFQFU5Al/0PaYH2weoZorYUM4JXbHj4POyprAn4=
 github.com/acomagu/bufpipe v1.0.3 h1:fxAGrHZTgQ9w5QqVItgzwj235/uYZYgbXitB+dLupOk=
 github.com/acomagu/bufpipe v1.0.3/go.mod h1:mxdxdup/WdsKVreO5GpW4+M/1CE2sMG4jeGJ2sYmHc4=
 github.com/agext/levenshtein v1.2.1/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=


### PR DESCRIPTION
Related to #547 based on [2dc76fe536b0306ed18c6e887c3a9e3eebd45328](https://github.com/Telmate/proxmox-api-go/commit/2dc76fe536b0306ed18c6e887c3a9e3eebd45328) to print the exact error

Signed-off-by: Seena Fallah <seenafallah@gmail.com>