### PR TITLE
Add all IOPS related parameters from Proxmox API

### DIFF
--- a/proxmox/resource_vm_qemu.go
+++ b/proxmox/resource_vm_qemu.go
@@ -410,6 +410,52 @@ func resourceVmQemu() *schema.Resource {
 							Optional: true,
 							Default:  0,
 						},
+						// Maximum I/O operations per second
+						"iops": {
+							Type:     schema.TypeInt,
+							Optional: true,
+							Default:  0,
+						},
+						"iops_max": {
+							Type:     schema.TypeInt,
+							Optional: true,
+							Default:  0,
+						},
+						"iops_max_length": {
+							Type:     schema.TypeInt,
+							Optional: true,
+							Default:  0,
+						},
+						"iops_rd": {
+							Type:     schema.TypeInt,
+							Optional: true,
+							Default:  0,
+						},
+						"iops_rd_max": {
+							Type:     schema.TypeInt,
+							Optional: true,
+							Default:  0,
+						},
+						"iops_rd_max_length": {
+							Type:     schema.TypeInt,
+							Optional: true,
+							Default:  0,
+						},
+						"iops_wr": {
+							Type:     schema.TypeInt,
+							Optional: true,
+							Default:  0,
+						},
+						"iops_wr_max": {
+							Type:     schema.TypeInt,
+							Optional: true,
+							Default:  0,
+						},
+						"iops_wr_max_length": {
+							Type:     schema.TypeInt,
+							Optional: true,
+							Default:  0,
+						},
 						// Misc
 						"file": {
 							Type:     schema.TypeString,


### PR DESCRIPTION
In addition to setting throughput limits on disks in MB/s, it's also possible to set limits based on IOPS. This change adds the various IOPS related parameters to the disk configuration.