### PR TITLE
Set mountpoint size to optional for compatibility with bind mounts

### DIFF
--- a/proxmox/resource_lxc.go
+++ b/proxmox/resource_lxc.go
@@ -201,7 +201,7 @@ func resourceLxc() *schema.Resource {
 						},
 						"size": {
 							Type:     schema.TypeString,
-							Required: true,
+							Optional: true,
 							ValidateFunc: func(val interface{}, key string) (warns []string, errs []error) {
 								v := val.(string)
 								if !(strings.Contains(v, "G") || strings.Contains(v, "M") || strings.Contains(v, "n")) {


### PR DESCRIPTION
As referenced in [https://github.com/Telmate/terraform-provider-proxmox/issues/277](https://github.com/Telmate/terraform-provider-proxmox/issues/277) the `size` parameter for `mountpoint` is not required. It is only required if creating storage-backed mount points but in the case of a bind mount this is not required. I've set this to optional to allow you to specify this type of bind mount, such as NFS mounts into containers as referenced [here](https://pve.proxmox.com/pve-docs/pve-admin-guide.html#_bind_mount_points).