### PR TITLE
Set mountpoint size to optional for compatibility with bind mounts

### DIFF
--- a/proxmox/resource_lxc.go
+++ b/proxmox/resource_lxc.go
@@ -201,7 +201,7 @@ func resourceLxc() *schema.Resource {
 						},
 						"size": {
 							Type:     schema.TypeString,
-							Required: true,
+							Optional: true,
 							ValidateFunc: func(val interface{}, key string) (warns []string, errs []error) {
 								v := val.(string)
 								if !(strings.Contains(v, "G") || strings.Contains(v, "M") || strings.Contains(v, "n")) {

--- a/proxmox/resource_lxc.go
+++ b/proxmox/resource_lxc.go
@@ -573,24 +573,24 @@ func resourceLxcCreate(d *schema.ResourceData, meta interface{}) error {
 		if err != nil {
 			return err
 		}
-		
+
 		// Update all remaining stuff
 		err = config.UpdateConfig(vmr, client)
 		if err != nil {
 			return err
 		}
-		
+
 		//Start LXC if start parameter is set to true
 		if d.Get("start").(bool) {
-	  		log.Print("[DEBUG][LxcCreate] starting LXC")
-	  		_, err := client.StartVm(vmr)
+			log.Print("[DEBUG][LxcCreate] starting LXC")
+			_, err := client.StartVm(vmr)
 			if err != nil {
 				return err
 			}
 
 		} else {
 			log.Print("[DEBUG][LxcCreate] start = false, not starting LXC")
-    		}
+		}
 
 	} else {
 		err = config.CreateLxc(vmr, client)
@@ -718,7 +718,7 @@ func resourceLxcUpdate(d *schema.ResourceData, meta interface{}) error {
 			return err
 		}
 	}
-	
+
 	if d.HasChange("start") {
 		vmState, err := client.GetVmState(vmr)
 		if err == nil && vmState["status"] == "stopped" && d.Get("start").(bool) {


### PR DESCRIPTION
As referenced in [https://github.com/Telmate/terraform-provider-proxmox/issues/277](https://github.com/Telmate/terraform-provider-proxmox/issues/277) the `size` parameter for `mountpoint` is not required. It is only required if creating storage-backed mount points but in the case of a bind mount this is not required. I've set this to optional to allow you to specify this type of bind mount, such as NFS mounts into containers as referenced [here](https://pve.proxmox.com/pve-docs/pve-admin-guide.html#_bind_mount_points).