### PR TITLE
Backup should be a Int

### DIFF
--- a/proxmox/resource_vm_qemu.go
+++ b/proxmox/resource_vm_qemu.go
@@ -749,7 +749,7 @@ func resourceVmQemuCreate(d *schema.ResourceData, meta interface{}) error {
 		Pool:         d.Get("pool").(string),
 		Bios:         d.Get("bios").(string),
 		Onboot:       d.Get("onboot").(bool),
-		Startup:	  d.Get("startup").(string),
+		Startup:      d.Get("startup").(string),
 		Tablet:       d.Get("tablet").(bool),
 		Boot:         d.Get("boot").(string),
 		BootDisk:     d.Get("bootdisk").(string),
@@ -1435,10 +1435,10 @@ func _resourceVmQemuRead(d *schema.ResourceData, meta interface{}) error {
 		if qemuDisk["cache"] == "" || qemuDisk["cache"] == nil {
 			qemuDisk["cache"] = "none"
 		}
-		if qemuDisk["backup"] == 0 {
-			qemuDisk["backup"] = false
-		} else if qemuDisk["backup"] == 1 {
-			qemuDisk["backup"] = true
+		if qemuDisk["backup"] == false {
+			qemuDisk["backup"] = 0
+		} else if qemuDisk["backup"] == true {
+			qemuDisk["backup"] = 1
 		}
 	}
 


### PR DESCRIPTION
This PR ensure that backups is a int and not a bool. See
```
[ERROR] setting state: disk.1.backup: '' expected type 'int', got unconvertible type 'bool', value: 'true'
```

With this PR #284 should be fixed. 

