### PR TITLE
Check if CloudInit Ip is already present on the vm and sets the sshHost to the cloudInit Ip.

### DIFF
--- a/proxmox/resource_vm_qemu.go
+++ b/proxmox/resource_vm_qemu.go
@@ -1927,10 +1927,10 @@ func initConnInfo(
 	}
 	log.Print("[DEBUG][initConnInfo] trying to find IP address of first network card")
 
-	interfaces, err := client.GetVmAgentNetworkInterfaces(vmr)
 	// wait until we find a valid ipv4 address
 	for guestAgentRunning && time.Now().Before(guestAgentWaitEnd) {
 		log.Printf("[DEBUG][initConnInfo] checking network card...")
+		interfaces, err := client.GetVmAgentNetworkInterfaces(vmr)
 		net0MacAddress := macAddressRegex.FindString(vmConfig["net0"].(string))
 		if err != nil {
 			return err
@@ -1969,14 +1969,19 @@ func initConnInfo(
 					sshHost = ipMatch[1]
 				}
 				ipconfig0 := net.ParseIP(strings.Split(ipMatch[1], ":")[0])
-				for _, iface := range interfaces {
-					if sshHost == ipMatch[1] {
-						break
-					}
-					for _, addr := range iface.IPAddresses {
-						if addr.Equal(ipconfig0) {
-							sshHost = ipMatch[1]
+				interfaces, errInterfaces := client.GetVmAgentNetworkInterfaces(vmr)
+				if errInterfaces != nil {
+					return err
+				} else {
+					for _, iface := range interfaces {
+						if sshHost == ipMatch[1] {
 							break
+						}
+						for _, addr := range iface.IPAddresses {
+							if addr.Equal(ipconfig0) {
+								sshHost = ipMatch[1]
+								break
+							}
 						}
 					}
 				}

--- a/proxmox/resource_vm_qemu.go
+++ b/proxmox/resource_vm_qemu.go
@@ -1971,7 +1971,7 @@ func initConnInfo(
 				ipconfig0 := net.ParseIP(strings.Split(ipMatch[1], ":")[0])
 				interfaces, errInterfaces := client.GetVmAgentNetworkInterfaces(vmr)
 				if errInterfaces != nil {
-					return err
+					return errInterfaces
 				} else {
 					for _, iface := range interfaces {
 						if sshHost == ipMatch[1] {


### PR DESCRIPTION
Fixes #593

This Pull Request checks if the vm has already the cloud init ip and if so then the sshHost and default_ipv4_address will be the cloudinit ip and not the dhcp ip address. 