### PR TITLE
extract pm_user from pm_api_token_id when GetUserPermissions

### DIFF
--- a/proxmox/provider.go
+++ b/proxmox/provider.go
@@ -209,6 +209,7 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 	var id string
 	if result, getok := d.GetOk("pm_api_token_id"); getok {
 		id = result.(string)
+		id = strings.Split(id, "!")[0]
 	} else if result, getok := d.GetOk("pm_user"); getok {
 		id = result.(string)
 	}


### PR DESCRIPTION
Using version v2.9.12 and configure provider using token method to communicate with PVE API, it complains

```
Error: cannot find provided user terraform-prov@pve!terraform-prov-token on proxmox
```

By checking the code, it seems that we should split user id from token_id string.

