### PR TITLE
Add Missing Required Permission

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -16,7 +16,7 @@ Log into the Proxmox cluster or host using ssh (or mimic these in the GUI) then:
 - Add the TERRAFORM-PROV role to the terraform-prov user
 
 ```bash
-pveum role add TerraformProv -privs "Datastore.AllocateSpace Datastore.Audit Pool.Allocate Sys.Audit VM.Allocate VM.Audit VM.Clone VM.Config.CDROM VM.Config.CPU VM.Config.Cloudinit VM.Config.Disk VM.Config.HWType VM.Config.Memory VM.Config.Network VM.Config.Options VM.Monitor VM.PowerMgmt"
+pveum role add TerraformProv -privs "Datastore.AllocateSpace Datastore.Audit Pool.Allocate Sys.Audit Sys.Console Sys.Modify VM.Allocate VM.Audit VM.Clone VM.Config.CDROM VM.Config.Cloudinit VM.Config.CPU VM.Config.Disk VM.Config.HWType VM.Config.Memory VM.Config.Network VM.Config.Options VM.Migrate VM.Monitor VM.PowerMgmt"
 pveum user add terraform-prov@pve --password <password>
 pveum aclmod / -user terraform-prov@pve -role TerraformProv
 ```
@@ -27,7 +27,7 @@ After the role is in use, if there is a need to modify the privileges, simply is
 removing privileges as needed.
 
 ```bash
-pveum role modify TerraformProv -privs "Datastore.AllocateSpace Datastore.Audit Pool.Allocate Sys.Audit Sys.Console VM.Allocate VM.Audit VM.Clone VM.Config.CDROM VM.Config.Cloudinit VM.Config.CPU VM.Config.Disk VM.Config.HWType VM.Config.Memory VM.Config.Network VM.Config.Options VM.Migrate VM.Monitor VM.PowerMgmt"
+pveum role modify TerraformProv -privs "Datastore.AllocateSpace Datastore.Audit Pool.Allocate Sys.Audit Sys.Console Sys.Modify VM.Allocate VM.Audit VM.Clone VM.Config.CDROM VM.Config.Cloudinit VM.Config.CPU VM.Config.Disk VM.Config.HWType VM.Config.Memory VM.Config.Network VM.Config.Options VM.Migrate VM.Monitor VM.PowerMgmt"
 ```
 
 For more information on existing roles and privileges in Proxmox, refer to the vendor docs

--- a/proxmox/provider.go
+++ b/proxmox/provider.go
@@ -194,6 +194,7 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 		"Pool.Allocate",
 		"Sys.Audit",
 		"Sys.Console",
+		"Sys.Modify",
 		"VM.Allocate",
 		"VM.Audit",
 		"VM.Clone",


### PR DESCRIPTION
`Sys.Modify` permission is required in order to modify the `startup` value of a VM. Since this provide purports to support modifying the `startup` field, add `Sys.Modify` to the list of minimum permissions. Also fix several inconsistencies in the docs around setting up the PVE role.

(3rd PR in a week "fixing" this. turns out permissions are hard, who knew?)