### PR TITLE
Do not return error if MAC address value is empty

### DIFF
--- a/proxmox/validators.go
+++ b/proxmox/validators.go
@@ -18,6 +18,11 @@ func MacAddressValidator() schema.SchemaValidateDiagFunc {
 			return diag.Errorf("expected type of %v to be string", k)
 		}
 		mac := strings.Replace(value, ":", "", -1)
+		
+		// Check if a MAC address has been provided. If not, proxmox will generate random one.
+		if len(mac) == 0 {
+			return nil
+		}
 
 		// Check if the length of the MAC address is correct (12 hexadecimal characters)
 		if len(mac) != 12 {


### PR DESCRIPTION
Proxmox will generate a new MAC address when the provided value is empty and therefore MacAddressValidator function should not fail if the provided value is an empty string.