### PR TITLE
Support 'T' suffix for size attribute in LXC rootfs and mountpoints

### DIFF
--- a/docs/resources/lxc.md
+++ b/docs/resources/lxc.md
@@ -203,7 +203,7 @@ The following arguments may be optionally defined when using this resource:
 * `mountpoint` - An object for defining a volume to use as a container mount point. Can be specified multiple times.
     * `mp` __(required)__ - The path to the mount point as seen from inside the container. The path must not contain
       symlinks for security reasons.
-    * `size` __(required)__ - Size of the underlying volume. Must end in G, M, or K (e.g. `"1G"`, `"1024M"`
+    * `size` __(required)__ - Size of the underlying volume. Must end in T, G, M, or K (e.g. `"1T"`, `"1G"`, `"1024M"`
       , `"1048576K"`). Note that this is a read only value.
     * `slot` __(required)__ - A string containing the number that identifies the mount point (i.e. the `n`
       in [`mp[n]`](https://pve.proxmox.com/pve-docs/pve-admin-guide.html#pct_mount_points)).
@@ -245,7 +245,7 @@ The following arguments may be optionally defined when using this resource:
   being removed/updated. Default is `false`.
 * `restore` - A boolean to mark the container creation/update as a restore task.
 * `rootfs` - An object for configuring the root mount point of the container. Can only be specified once.
-    * `size` __(required)__ - Size of the underlying volume. Must end in G, M, or K (e.g. `"1G"`, `"1024M"`
+    * `size` __(required)__ - Size of the underlying volume. Must end in T, G, M, or K (e.g. `"1T"`, `"1G"`, `"1024M"`
       , `"1048576K"`). Note that this is a read only value.
     * `storage` __(required)__ - A string containing
       the [volume](https://pve.proxmox.com/pve-docs/pve-admin-guide.html#_storage_backed_mount_points)

--- a/proxmox/resource_lxc.go
+++ b/proxmox/resource_lxc.go
@@ -204,8 +204,8 @@ func resourceLxc() *schema.Resource {
 							Required: true,
 							ValidateFunc: func(val interface{}, key string) (warns []string, errs []error) {
 								v := val.(string)
-								if !(strings.Contains(v, "G") || strings.Contains(v, "M") || strings.Contains(v, "n")) {
-									errs = append(errs, fmt.Errorf("disk size must end in G, M, or K, got %s", v))
+								if !(strings.Contains(v, "T") || strings.Contains(v, "G") || strings.Contains(v, "M") || strings.Contains(v, "n")) {
+									errs = append(errs, fmt.Errorf("disk size must end in T, G, M, or K, got %s", v))
 								}
 								return
 							},
@@ -356,8 +356,8 @@ func resourceLxc() *schema.Resource {
 							Required: true,
 							ValidateFunc: func(val interface{}, key string) (warns []string, errs []error) {
 								v := val.(string)
-								if !(strings.Contains(v, "G") || strings.Contains(v, "M") || strings.Contains(v, "n")) {
-									errs = append(errs, fmt.Errorf("disk size must end in G, M, or K, got %s", v))
+								if !(strings.Contains(v, "T") || strings.Contains(v, "G") || strings.Contains(v, "M") || strings.Contains(v, "n")) {
+									errs = append(errs, fmt.Errorf("disk size must end in T, G, M, or K, got %s", v))
 								}
 								return
 							},

--- a/proxmox/resource_lxc_disk.go
+++ b/proxmox/resource_lxc_disk.go
@@ -67,8 +67,8 @@ func resourceLxcDisk() *schema.Resource {
 				Required: true,
 				ValidateFunc: func(val interface{}, key string) (warns []string, errs []error) {
 					v := val.(string)
-					if !(strings.Contains(v, "G") || strings.Contains(v, "M") || strings.Contains(v, "n")) {
-						errs = append(errs, fmt.Errorf("disk size must end in G, M, or K, got %s", v))
+					if !(strings.Contains(v, "T") || strings.Contains(v, "G") || strings.Contains(v, "M") || strings.Contains(v, "n")) {
+						errs = append(errs, fmt.Errorf("disk size must end in T, G, M, or K, got %s", v))
 					}
 					return
 				},


### PR DESCRIPTION
Hey guys! First of all, thanks for this great provider!

While using it, I noticed that the provider was not supporting sizes set in terabytes (ending in 'T') for LXC resources mountpoints and rootfs.

I don't know when the terabyte support was added to Proxmox, but I managed to build the provider locally and test it with success. I also found that the [pct CLI tool documentation](https://pve.proxmox.com/pve-docs/pct.1.html) details the valid sizes with the following regex ` \+?\d+(\.\d+)?[KMGT]? `.

Let me know if something needs to be fixed!