### PR TITLE
Fix Ipconfigmap empty values

### DIFF
--- a/proxmox/resource_vm_qemu.go
+++ b/proxmox/resource_vm_qemu.go
@@ -901,24 +901,14 @@ func resourceVmQemuCreate(d *schema.ResourceData, meta interface{}) error {
 		Searchdomain: d.Get("searchdomain").(string),
 		Nameserver:   d.Get("nameserver").(string),
 		Sshkeys:      d.Get("sshkeys").(string),
-		Ipconfig: pxapi.IpconfigMap{
-			0:  d.Get("ipconfig0").(string),
-			1:  d.Get("ipconfig1").(string),
-			2:  d.Get("ipconfig2").(string),
-			3:  d.Get("ipconfig3").(string),
-			4:  d.Get("ipconfig4").(string),
-			5:  d.Get("ipconfig5").(string),
-			6:  d.Get("ipconfig6").(string),
-			7:  d.Get("ipconfig7").(string),
-			8:  d.Get("ipconfig8").(string),
-			9:  d.Get("ipconfig9").(string),
-			10: d.Get("ipconfig10").(string),
-			11: d.Get("ipconfig11").(string),
-			12: d.Get("ipconfig12").(string),
-			13: d.Get("ipconfig13").(string),
-			14: d.Get("ipconfig14").(string),
-			15: d.Get("ipconfig15").(string),
-		},
+		Ipconfig:     pxapi.IpconfigMap{},
+	}
+	// Populate Ipconfig map
+	for i := 0; i < 16; i++ {
+		iface := fmt.Sprintf("ipconfig%d", i)
+		if v, ok := d.GetOk(iface); ok {
+			config.Ipconfig[i] = v.(string)
+		}
 	}
 	if len(qemuVgaList) > 0 {
 		config.QemuVga = qemuVgaList[0].(map[string]interface{})


### PR DESCRIPTION
See the following correlated PR for an issue description and details:

https://github.com/Telmate/proxmox-api-go/pull/238

Currently, every `ipconfigX` config property is set to an empty string no matter what. This is due to the use of `.Get()`:

>Get returns the data for the given key, or nil if the key doesn't exist
in the schema.
>
>If the key does exist in the schema but doesn't exist in the configuration,
then the default value for that type will be returned. For strings, this is
"", for numbers it is 0, etc.

The problem is this will always return an empty string. That mixed with the `.(string)` cast makes for a bug.

The map value for each `ipconfig` entry should not be set unless it actually is set in the config. This PR uses `.GetOk()` instead, and only sets the map value when there actually is one.