### PR TITLE
change boot order in example

### DIFF
--- a/docs/resources/vm_qemu.md
+++ b/docs/resources/vm_qemu.md
@@ -26,7 +26,7 @@ resource "proxmox_vm_qemu" "resource-name" {
 
   ### or for a PXE boot VM operation
   # pxe = true
-  # boot = "net0;scsi0"
+  # boot = "scsi0;net0"
   # agent = 0
 }
 ```

--- a/examples/pxe_example.tf
+++ b/examples/pxe_example.tf
@@ -30,7 +30,7 @@ resource "proxmox_vm_qemu" "pxe-example" {
 # boot order MUST include network, this is enforced in the Provider
 # Optinally, setting a disk first means that PXE will be used first boot
 # and future boots will run off the disk
-    boot                      = "order=net0;scsi0"
+    boot                      = "order=scsi0;net0"
     cores                     = 2
     cpu                       = "host"
     define_connection_info    = true


### PR DESCRIPTION
Once the OS is installed, you have to boot on the disk.
With the opposite, it will always boot on the network

Cf: Issue [685](https://github.com/Telmate/terraform-provider-proxmox/issues/685)