### PR TITLE
change PXE boot order and clean

### DIFF
--- a/docs/resources/vm_qemu.md
+++ b/docs/resources/vm_qemu.md
@@ -102,7 +102,7 @@ boot of the VM.  A minimal Resource stanza for a PXE boot VM might look like thi
 resource "proxmox_vm_qemu" "pxe-minimal-example" {
     name                      = "pxe-minimal-example"
     agent                     = 0
-    boot                      = "order=net0;scsi0"
+    boot                      = "order=scsi0;net0"
     pxe                       = true
     target_node               = "test"
     network {
@@ -116,7 +116,7 @@ resource "proxmox_vm_qemu" "pxe-minimal-example" {
 
 The primary options that effect the correct operation of Network PXE boot mode are:
 
-  * `boot`: a valid boot order must be specified with Network type included (eg `order=net0;scsi0`)
+  * `boot`: a valid boot order must be specified with Network type included (eg `order=scsi0;net0`)
   * a valid NIC attached to a network with a PXE boot server must be added to the VM
   * generally speaking, disable the Agent (`agent = 0`) unless the installed OS contains the Agent in OS install configurations
 
@@ -144,7 +144,7 @@ The following arguments are supported in the top level resource block.
 | `bootdisk`                    | `str`  |                      | Enable booting from specified disk. You shouldn't need to change it under most circumstances.                                                                                                                                                                                                                               |
 | `agent`                       | `int`  | `0`                  | Set to `1` to enable the QEMU Guest Agent. Note, you must run the [`qemu-guest-agent`](https://pve.proxmox.com/wiki/Qemu-guest-agent) daemon in the guest for this to have any effect.                                                                                                                                      |
 | `iso`                         | `str`  |                      | The name of the ISO image to mount to the VM in the format: [storage pool]:iso/[name of iso file]. Only applies when `clone` is not set. Either `clone` or `iso` needs to be set.  Note that `iso` is mutually exclussive with `clone` and `pxe` modes.                                                                                                                          |
-| `pxe`                         | `bool` | `false`              | If set to `true`, enable PXE boot of the VM.  Also requires a `boot` order be set with Network included (eg `boot = "order=net0;scsi0"`).  Note that `pxe` is mutually exclusive with `iso` and `clone` modes.                                                                                                                      |
+| `pxe`                         | `bool` | `false`              | If set to `true`, enable PXE boot of the VM.  Also requires a `boot` order be set with Network included (eg `boot = "order=scsi0;net0"`).  Note that `pxe` is mutually exclusive with `iso` and `clone` modes.                                                                                                                      |
 | `clone`                       | `str`  |                      | The base VM from which to clone to create the new VM.  Note that `clone` is mutually exclussive with `pxe` and `iso` modes.                                                                                                                                                                                                 |
 | `full_clone`                  | `bool` | `true`               | Set to `true` to create a full clone, or `false` to create a linked clone. See the [docs about cloning](https://pve.proxmox.com/pve-docs/chapter-qm.html#qm_copy_and_clone) for more info. Only applies when `clone` is set.                                                                                                |
 | `hastate`                     | `str`  |                      | Requested HA state for the resource. One of "started", "stopped", "enabled", "disabled", or "ignored". See the [docs about HA](https://pve.proxmox.com/pve-docs/chapter-ha-manager.html#ha_manager_resource_config) for more info.                                                                                          |

--- a/docs/resources/vm_qemu.md
+++ b/docs/resources/vm_qemu.md
@@ -31,55 +31,6 @@ resource "proxmox_vm_qemu" "resource-name" {
 }
 ```
 
-<del>
-## Preprovision
-
-With preprovision, you can provision a VM directly from the resource block. This provisioning method is therefore ran **
-before** provision blocks. When using preprovision, there are three `os_type` options: `ubuntu`, `centos`
-or `cloud-init`.
-
-```hcl
-resource "proxmox_vm_qemu" "preprovision-test" {
-  preprovision = true
-  os_type      = "ubuntu"
-}
-```
-
-### Preprovision for Linux (Ubuntu / CentOS)
-
-There is a pre-provision phase which is used to set a hostname, initialize eth0, and resize the VM disk to available
-space. This is done over SSH with the `ssh_forward_ip`, `ssh_user` and `ssh_private_key`. Disk resize is done if the
-file [/etc/auto_resize_vda.sh](https://github.com/Telmate/terraform-ubuntu-proxmox-iso/blob/master/auto_resize_vda.sh)
-exists.
-
-```hcl
-resource "proxmox_vm_qemu" "preprovision-test" {
-  preprovision      = true
-  os_type           = "ubuntu"
-  ssh_forward_ip    = "10.0.0.1"
-  ssh_user          = "terraform"
-  ssh_private_key   = <<EOF
------BEGIN RSA PRIVATE KEY-----
-private ssh key terraform
------END RSA PRIVATE KEY-----
-EOF
-  os_network_config = <<EOF
-auto eth0
-iface eth0 inet dhcp
-EOF
-
-  connection {
-    type        = "ssh"
-    user        = "${self.ssh_user}"
-    private_key = "${self.ssh_private_key}"
-    host        = "${self.ssh_host}"
-    port        = "${self.ssh_port}"
-  }
-}
-```
-
-</del>
-
 ## Provision through Cloud-Init
 
 Cloud-init VMs must be cloned from a [cloud-init ready template](https://pve.proxmox.com/wiki/Cloud-Init_Support). When

--- a/proxmox/resource_vm_qemu_test.go
+++ b/proxmox/resource_vm_qemu_test.go
@@ -96,7 +96,7 @@ resource "proxmox_vm_qemu" "%s" {
   name = "%s"
   target_node = "%s"
 	pxe = true
-	boot = "order=net0;scsi0"
+	boot = "order=scsi0;net0"
 	network {
     bridge    = "vmbr0"
     firewall  = false


### PR DESCRIPTION
Once the OS is installed, you have to boot on the disk.
With the opposite, it will always boot on the network

Cf: Issue https://github.com/Telmate/terraform-provider-proxmox/issues/685

> Changing some of the documentation is good.
> Out changing the documentation and the code is better

PS: I don't understand why the part between `<del>` and `</del>` is there. So I delete.
