### PR TITLE
Add initial efidisk support

### DIFF
--- a/docs/resources/vm_qemu.md
+++ b/docs/resources/vm_qemu.md
@@ -240,6 +240,29 @@ See the [docs about disks](https://pve.proxmox.com/pve-docs/chapter-qm.html#qm_h
 | `slot`               | `int` |               | _(not sure what this is for, seems to be deprecated, do not use)_. |
 | `storage_type`       | `str` |               | The type of pool that `storage` is backed by. You shouldn't need to specify this, use the `storage` parameter instead. |
 
+### EFI Disk Block
+
+The `efidisk` block is used to configure the disk used for EFI data storage. There may only be one EFI disk block.
+The EFI disk will be automatically pre-loaded with distribution-specific and Microsoft Standard Secure Boot keys.
+
+```hcl
+resource "proxmox_vm_qemu" "resource-name" {
+  // ...
+
+  efidisk {
+    efitype = "4m"
+    storage = "local-lvm"
+  }
+}
+```
+
+See the [docs about EFI disks](https://pve.proxmox.com/pve-docs/chapter-qm.html#qm_bios_and_uefi) for more details.
+
+| Argument       | Type  | Default Value | Description                                                                                                                                                                                                                                                                            |
+|----------------|-------|---------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `efitype`      | `str` | `"4m"`        | The type of efi disk device to add. Options: `2m`, `4m`                                                                                                                                                                                                                                |
+| `storage`      | `str` |               | **Required** The name of the storage pool on which to store the disk.                                                                                                                                                                                                                  |
+
 ### Serial Block
 
 Create a serial device inside the VM (up to a maximum of 4 can be specified), and either pass through a host serial


### PR DESCRIPTION
Fixes: #341 

The `size` parameter was ignored as it appears proxmox only supports two flash types--2m and 4m--and creates a 4M backing file regardless.

The `pre-enrolled-keys` flag was skipped due to the work needed to snake_case the key back/forth to meet terraform requirements. The default value (1) seems satisfactory for most scenarios. We can revisit if the need arises.

Changing `efidisk` properties will force a replacement in this initial implementation. 

While it's _technically possible_ to remove the efidisk and replace it, there appears to be some quirky proxmox behavior in this area. Specifically, proxmox will accept updates to the efidisk but drop those changes on the floor. Proxmox also exhibits strange behavior when removing an efidisk from a running hotplug-enabled machine. (It will attempt to hot unplug, fail, but commit the change.) Given most users will create the efidisk and not touch it again, I opted for the simpler approach here. We can revisit if the need arises.

<details>
  <summary>Completed tasks</summary>

- [x] Investigate `pre-enrolled-keys` / `pre_enrolled_keys` mismatch
   Outcome: Not going to support this on first pass.
- [x] Determine if there's a more idiomatic way to handle `efidisk` other than using the first item in the slice `ExpandDevicesList` returns
   Outcome: Will defer to code review; added check to handle negative efidisk case.
- [x] Test create, destroy, and clone scenarios
  Outcome: Basic scenario tests successful.
- [x] Update docs
  Outcome: Docs updated.

</details>
