### PR TITLE
fix: Ignore disk resize if media is cdrom

### DIFF
--- a/proxmox/resource_vm_qemu.go
+++ b/proxmox/resource_vm_qemu.go
@@ -1740,6 +1740,9 @@ func prepareDiskSize(
 	}
 	// log.Printf("%s", clonedConfig)
 	for diskID, diskConf := range diskConfMap {
+		if diskConf["media"] == "cdrom" {
+			continue
+		}
 		diskName := fmt.Sprintf("%v%v", diskConf["type"], diskID)
 
 		diskSize := pxapi.DiskSizeGB(diskConf["size"])


### PR DESCRIPTION
When you clone a template, ignore disk resize if media  is `cdrom`.