### PR TITLE
lxc: implement deletion of network interfaces

### DIFF
--- a/proxmox/resource_lxc.go
+++ b/proxmox/resource_lxc.go
@@ -232,6 +232,10 @@ func resourceLxc() *schema.Resource {
 				Optional: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
 						"name": {
 							Type:     schema.TypeString,
 							Required: true,
@@ -667,10 +671,28 @@ func resourceLxcUpdate(d *schema.ResourceData, meta interface{}) error {
 	config.Unprivileged = d.Get("unprivileged").(bool)
 
 	if d.HasChange("network") {
-		// TODO Delete extra networks
-		networks := d.Get("network").([]interface{})
-		if len(networks) > 0 {
-			lxcNetworks := DevicesListToDevices(networks, "")
+		oldSet, newSet := d.GetChange("network")
+		oldNetworks := make([]map[string]interface{}, 0)
+		newNetworks := make([]map[string]interface{}, 0)
+
+		// Convert from []interface{} to []map[string]interface{}
+		for _, network := range oldSet.([]interface{}) {
+			oldNetworks = append(oldNetworks, network.(map[string]interface{}))
+		}
+		for _, network := range newSet.([]interface{}) {
+			newNetworks = append(newNetworks, network.(map[string]interface{}))
+		}
+
+		processLxcNetworkChanges(oldNetworks, newNetworks, pconf, vmr)
+
+		if len(newNetworks) > 0 {
+			// Drop all the ids since they can't be sent to the API
+			newNetworks, _ = DropElementsFromMap([]string{"id"}, newNetworks)
+			// Convert from []map[string]interface{} to pxapi.QemuDevices
+			lxcNetworks := make(pxapi.QemuDevices, 0)
+			for index, network := range newNetworks {
+				lxcNetworks[index] = network
+			}
 			config.Networks = lxcNetworks
 		}
 	}
@@ -816,7 +838,6 @@ func _resourceLxcRead(d *schema.ResourceData, meta interface{}) error {
 			return err
 		}
 		flatNetworks, _ := FlattenDevicesList(config.Networks)
-		flatNetworks, _ = DropElementsFromMap([]string{"id"}, flatNetworks)
 		if err = d.Set("network", flatNetworks); err != nil {
 			return err
 		}
@@ -1017,5 +1038,48 @@ func processDiskResize(
 			return err
 		}
 	}
+	return nil
+}
+
+func processLxcNetworkChanges(prevNetworks []map[string]interface{}, newNetworks []map[string]interface{}, pconf *providerConfiguration, vmr *pxapi.VmRef) error {
+	delNetworks := make([]map[string]interface{}, 0)
+
+	// Collect the IDs of networks that exist in `prevNetworks` but not in `newNetworks`.
+	for _, prevNet := range prevNetworks {
+		found := false
+		prevName := prevNet["id"].(int)
+		for _, newNet := range newNetworks {
+			newName := newNet["id"].(int)
+			if prevName == newName {
+				found = true
+				break
+			}
+		}
+		if !found {
+			delNetworks = append(delNetworks, prevNet)
+		}
+	}
+
+	if len(delNetworks) > 0 {
+		deleteNetKeys := []string{}
+		for _, net := range delNetworks {
+			// Construct id that proxmox API expects (net+<number>)
+			deleteNetKeys = append(deleteNetKeys, "net"+strconv.Itoa(net["id"].(int)))
+		}
+
+		params := map[string]interface{}{
+			"delete": strings.Join(deleteNetKeys, ", "),
+		}
+		if vmr.GetVmType() == "lxc" {
+			if _, err := pconf.Client.SetLxcConfig(vmr, params); err != nil {
+				return err
+			}
+		} else {
+			if _, err := pconf.Client.SetVmConfig(vmr, params); err != nil {
+				return err
+			}
+		}
+	}
+
 	return nil
 }


### PR DESCRIPTION
Closes #753

Disclaimer: I did(/do) not know Go, so there probably is room for improvements. Please tell me how it can be improved  and I'll refactor.

### Approach

First I tried matching simply based on name (e.g. `eth0`) however I've found this not to be desirable since names don't have to be unique and a simple rename would lead to recreation of a interface.

I then switched to using the Proxmox `id` since it does not have these flaws. I'm not 100% happy with the fact that I now need to drop the ids before applying the config. Suggestions for a better approach are welcome.

I've tested it quite a bit but certainly more testing would be good. I also don't know the impact on already existing states (since id is now added and was not there before).