### PR TITLE
Added multiple target nodes instead of a single node.

### DIFF
--- a/proxmox/data_ha_group.go
+++ b/proxmox/data_ha_group.go
@@ -1,0 +1,67 @@
+package proxmox
+
+import (
+	"sort"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func DataHAGroup() *schema.Resource {
+	return &schema.Resource{
+		Read: dataHaGroupRead,
+		Schema: map[string]*schema.Schema{
+			"group_name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"nodes": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+			"type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"restricted": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"nofailback": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"comment": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataHaGroupRead(data *schema.ResourceData, meta interface{}) error {
+	pconf := meta.(*providerConfiguration)
+	lock := pmParallelBegin(pconf)
+	defer lock.unlock()
+
+	client := pconf.Client
+
+	group, err := client.GetHAGroupByName(data.Get("group_name").(string))
+	if err != nil {
+		return err
+	}
+
+	nodes := group.Nodes
+	sort.Strings(nodes)
+
+	data.SetId(group.Group)
+	_ = data.Set("nodes", nodes)
+	_ = data.Set("type", group.Type)
+	_ = data.Set("restricted", group.Restricted)
+	_ = data.Set("nofailback", group.NoFailback)
+	_ = data.Set("comment", group.Comment)
+
+	return nil
+}

--- a/proxmox/data_ha_group.go
+++ b/proxmox/data_ha_group.go
@@ -49,8 +49,8 @@ func dataReadHAGroup(data *schema.ResourceData, meta interface{}) (err error) {
 
 	client := pconf.Client
 
-	var haGroup *proxmox.HAGroup
-	haGroup, err = client.GetHAGroupByName(d.Get("group_name").(string))
+	var group *proxmox.HAGroup
+	group, err = client.GetHAGroupByName(data.Get("group_name").(string))
 	if err != nil {
 		return err
 	}

--- a/proxmox/provider.go
+++ b/proxmox/provider.go
@@ -165,6 +165,10 @@ func Provider() *schema.Provider {
 			// TODO - proxmox_vm_qemu_template
 		},
 
+		DataSourcesMap: map[string]*schema.Resource{
+			"proxmox_ha_groups": DataHAGroup(),
+		},
+
 		ConfigureFunc: providerConfigure,
 	}
 }

--- a/proxmox/util.go
+++ b/proxmox/util.go
@@ -363,8 +363,14 @@ func resourceDataToFlatValues(d *schema.ResourceData, resource *schema.Resource)
 			values, _ := schemaSetToFlatValues(d.Get(key).(*schema.Set), value.Elem.(*schema.Resource))
 			flatValues[key] = values
 		case schema.TypeList:
-			values, _ := schemaListToFlatValues(d.Get(key).([]interface{}), value.Elem.(*schema.Resource))
-			flatValues[key] = values
+			_, ok := value.Elem.(*schema.Schema)
+
+			if ok {
+				flatValues[key] = value.Elem.(*schema.Schema)
+			} else {
+				values, _ := schemaListToFlatValues(d.Get(key).([]interface{}), value.Elem.(*schema.Resource))
+				flatValues[key] = values
+			}
 		default:
 			flatValues[key] = "? Print Not Implemented ?"
 		}


### PR DESCRIPTION
Imagine you have a cluster in which you migrate using High Availability Server. this is exactly the case I had. I have created a HA Group in Proxmox within which servers are automatically migrated in case of a failure or similar. 

With this code change it doesn't matter now. You can specify an array of possible nodes where the QEMU can be located. 

I also implemented my own change to your golang implementation (https://github.com/Telmate/proxmox-api-go/pull/262) to manage this with HA Groups.