### PR TITLE
docs: add smbios to qemu docs + example

### DIFF
--- a/docs/resources/vm_qemu.md
+++ b/docs/resources/vm_qemu.md
@@ -268,6 +268,20 @@ details.
 | `host`   | `str`  |               | **Required** USB device host. This can either be done via the vendor- and product-id, or via the host bus and port. |
 | `usb3`   | `bool` | `false`       | Specifies whether if given host option is a USB3 device or port.                                                    |
 
+## SMBIOS Block
+
+The `smbios` block sets SMBIOS type 1 settings for the VM.
+
+| Argument       | Type     | Description               |
+|----------------|----------|---------------------------|
+| `family`       | `string` | The SMBIOS family.        |
+| `manufacturer` | `string` | The SMBIOS manufacturer.  |
+| `serial`       | `string` | The SMBIOS serial number. |
+| `product`      | `string` | The SMBIOS product.       |
+| `sku`          | `string` | The SMBIOS SKU.           |
+| `uuid`         | `string` | The SMBIOS UUID.          |
+| `version`      | `string` | The SMBIOS version.       |
+
 ## Attribute Reference
 
 In addition to the arguments above, the following attributes can be referenced from this resource.

--- a/examples/pxe_example.tf
+++ b/examples/pxe_example.tf
@@ -50,7 +50,7 @@ resource "proxmox_vm_qemu" "pxe-example" {
     vcpus                     = 0
 
     disk {
-        backup       = 0
+        backup       = false
         cache        = "none"
         discard      = "on"
         iothread     = 1
@@ -71,5 +71,15 @@ resource "proxmox_vm_qemu" "pxe-example" {
         firewall  = false
         link_down = false
         model     = "e1000"
+    }
+
+    smbios {
+        family       = "VM"
+        manufacturer = "Hashibrown"
+        product      = "Terraform"
+        sku          = "dQw4w9WgXcQ"
+        uuid         = "5b710d2f-4ea2-4d49-9eaa-c18392fd734d"
+        version      = "v1.0"
+        serial       = "ABC123"
     }
 }


### PR DESCRIPTION
Fixes #775.

- This creates bare minimum documentation for SMBIOS settings to the module documentation.
- This also fixes the backup example in the sample QEMU terraform file.