### PR TITLE
Overhaul qemu disks

### DIFF
--- a/docs/resources/vm_qemu.md
+++ b/docs/resources/vm_qemu.md
@@ -195,7 +195,7 @@ resource "proxmox_vm_qemu" "resource-name" {
 
 ### Disks.Ide Block
 
-The `disks.ide` block is used to configure disks of type ide. It may only be specified once. It has the options `disk_0` through `disk_1`. Each disk can have only one of the following mutually exclusive sub types `cdrom`, `disk`, `passthrough`. Configuration for these sub types can be found in their respective chapters:
+The `disks.ide` block is used to configure disks of type ide. It may only be specified once. It has the options `ide0` through `ide1`. Each disk can have only one of the following mutually exclusive sub types `cdrom`, `disk`, `passthrough`. Configuration for these sub types can be found in their respective chapters:
 
 * `cdrom`: [Disks.x.Cdrom Block](#disksxcdrom-block).
 * `disk`: [Disks.x.Disk Block](#disksxdisk-block).
@@ -207,12 +207,12 @@ resource "proxmox_vm_qemu" "resource-name" {
 
   disks {
     ide {
-      disk_0 {
+      ide0 {
         disk {
           //<arguments omitted for brevity...>
         }
       }
-      disk_1 {
+      ide1 {
         passthrough {
           //<arguments omitted for brevity...>
         }
@@ -225,7 +225,7 @@ resource "proxmox_vm_qemu" "resource-name" {
 
 ### Disks.Sata Block
 
-The `disks.sata` block is used to configure disks of type sata. It may only be specified once. It has the options `disk_0` through `disk_5`. Each disk can have only one of the following mutually exclusive sub types `cdrom`, `disk`, `passthrough`. Configuration for these sub types can be found in their respective chapters:
+The `disks.sata` block is used to configure disks of type sata. It may only be specified once. It has the options `sata0` through `sata5`. Each disk can have only one of the following mutually exclusive sub types `cdrom`, `disk`, `passthrough`. Configuration for these sub types can be found in their respective chapters:
 
 * `cdrom`: [Disks.x.Cdrom Block](#disksxcdrom-block).
 * `disk`: [Disks.x.Disk Block](#disksxdisk-block).
@@ -237,17 +237,17 @@ resource "proxmox_vm_qemu" "resource-name" {
 
   disks {
     sata {
-      disk_0 {
+      sata0 {
         cdrom {
           //<arguments omitted for brevity...>
         }
       }
-      disk_1 {
+      sata1 {
         disk {
           //<arguments omitted for brevity...>
         }
       }
-      disk_2 {
+      sata2 {
         passthrough {
           //<arguments omitted for brevity...>
         }
@@ -261,7 +261,7 @@ resource "proxmox_vm_qemu" "resource-name" {
 
 ### Disks.Scsi Block
 
-The `disks.scsi` block is used to configure disks of type scsi. It may only be specified once. It has the options `disk_0` through `disk_30`. Each disk can have only one of the following mutually exclusive sub types `cdrom`, `disk`, `passthrough`. Configuration for these sub types can be found in their respective chapters:
+The `disks.scsi` block is used to configure disks of type scsi. It may only be specified once. It has the options `scsi0` through `scsi30`. Each disk can have only one of the following mutually exclusive sub types `cdrom`, `disk`, `passthrough`. Configuration for these sub types can be found in their respective chapters:
 
 * `cdrom`: [Disks.x.Cdrom Block](#disksxcdrom-block).
 * `disk`: [Disks.x.Disk Block](#disksxdisk-block).
@@ -273,17 +273,17 @@ resource "proxmox_vm_qemu" "resource-name" {
 
   disks {
     scsi {
-      disk_0 {
+      scsi0 {
         cdrom {
           //<arguments omitted for brevity...>
         }
       }
-      disk_1 {
+      scsi1 {
         disk {
           //<arguments omitted for brevity...>
         }
       }
-      disk_2 {
+      scsi2 {
         passthrough {
           //<arguments omitted for brevity...>
         }
@@ -297,7 +297,7 @@ resource "proxmox_vm_qemu" "resource-name" {
 
 ### Disks.Virtio Block
 
-The `disks.scsi` block is used to configure disks of type scsi. It may only be specified once. It has the options `disk_0` through `disk_15`. Each disk can have only one of the following mutually exclusive sub types `cdrom`, `disk`, `passthrough`. Configuration for these sub types can be found in their respective chapters:
+The `disks.scsi` block is used to configure disks of type scsi. It may only be specified once. It has the options `virtio0` through `virtio15`. Each disk can have only one of the following mutually exclusive sub types `cdrom`, `disk`, `passthrough`. Configuration for these sub types can be found in their respective chapters:
 
 * `cdrom`: [Disks.x.Cdrom Block](#disksxcdrom-block).
 * `disk`: [Disks.x.Disk Block](#disksxdisk-block).
@@ -309,17 +309,17 @@ resource "proxmox_vm_qemu" "resource-name" {
 
   disks {
     virtio {
-      disk_0 {
+      virtio0 {
         cdrom {
           //<arguments omitted for brevity...>
         }
       }
-      disk_1 {
+      virtio1 {
         disk {
           //<arguments omitted for brevity...>
         }
       }
-      disk_2 {
+      virtio2 {
         passthrough {
           //<arguments omitted for brevity...>
         }

--- a/docs/resources/vm_qemu.md
+++ b/docs/resources/vm_qemu.md
@@ -164,81 +164,240 @@ details.
 | `queues`    | `int`  | `1`           | Number of packet queues to be used on the device. Requires `virtio` model to have an effect.                                                                                                                                                                                                                                                                    |
 | `link_down` | `bool` | `false`       | Whether this interface should be disconnected (like pulling the plug).                                                                                                                                                                                                                                                                                          |
 
-### Disk Block
+### Disks Block
 
-The `disk` block is used to configure the disk devices. It may be specified multiple times. The order in which the
-blocks are specified and the disk device type determines the ID for each disk device. Take the following for example:
+The `disks` block is used to configure the disk devices. It may be specified once. There are four types of disk `ide`,`sata`,`scsi` and `virtio`. Configuration for these sub types can be found in their respective chapters:
+
+* `cdrom`: [Disks.x.Cdrom Block](#disksxcdrom-block).
+* `disk`: [Disks.x.Disk Block](#disksxdisk-block).
+* `passthrough`: [Disks.x.Passthrough Block](#disksxpassthrough-block).
 
 ```hcl
 resource "proxmox_vm_qemu" "resource-name" {
   //<arguments omitted for brevity...>
 
-  disk {
-    // This disk will become scsi0
-    type = "scsi"
-
-    //<arguments omitted for brevity...>
+  disks {
+    ide {
+      //<arguments omitted for brevity...>
+    }
+    sata {
+      //<arguments omitted for brevity...>
+    }
+    scsi {
+      //<arguments omitted for brevity...>
+    }
+    virtio {
+      //<arguments omitted for brevity...>
+    }
   }
+}
+```
 
-  disk {
-    // This disk will become ide0
-    type = "ide"
+### Disks.Ide Block
 
-    //<arguments omitted for brevity...>
-  }
+The `disks.ide` block is used to configure disks of type ide. It may only be specified once. It has the options `disk_0` through `disk_1`. Each disk can have only one of the following mutually exclusive sub types `cdrom`, `disk`, `passthrough`. Configuration for these sub types can be found in their respective chapters:
 
-  disk {
-    // This disk will become scsi1
-    type = "scsi"
+* `cdrom`: [Disks.x.Cdrom Block](#disksxcdrom-block).
+* `disk`: [Disks.x.Disk Block](#disksxdisk-block).
+* `passthrough`: [Disks.x.Passthrough Block](#disksxpassthrough-block).
 
-    //<arguments omitted for brevity...>
-  }
+```hcl
+resource "proxmox_vm_qemu" "resource-name" {
+  //<arguments omitted for brevity...>
 
-  disk {
-    // This disk will become sata0
-    type = "sata"
-
+  disks {
+    ide {
+      disk_0 {
+        disk {
+          //<arguments omitted for brevity...>
+        }
+      }
+      disk_1 {
+        passthrough {
+          //<arguments omitted for brevity...>
+        }
+      }
+    }
     //<arguments omitted for brevity...>
   }
 }
 ```
 
+### Disks.Sata Block
+
+The `disks.sata` block is used to configure disks of type sata. It may only be specified once. It has the options `disk_0` through `disk_5`. Each disk can have only one of the following mutually exclusive sub types `cdrom`, `disk`, `passthrough`. Configuration for these sub types can be found in their respective chapters:
+
+* `cdrom`: [Disks.x.Cdrom Block](#disksxcdrom-block).
+* `disk`: [Disks.x.Disk Block](#disksxdisk-block).
+* `passthrough`: [Disks.x.Passthrough Block](#disksxpassthrough-block).
+
+```hcl
+resource "proxmox_vm_qemu" "resource-name" {
+  //<arguments omitted for brevity...>
+
+  disks {
+    sata {
+      disk_0 {
+        cdrom {
+          //<arguments omitted for brevity...>
+        }
+      }
+      disk_1 {
+        disk {
+          //<arguments omitted for brevity...>
+        }
+      }
+      disk_2 {
+        passthrough {
+          //<arguments omitted for brevity...>
+        }
+      }
+      //<arguments omitted for brevity...>
+    }
+    //<arguments omitted for brevity...>
+  }
+}
+```
+
+### Disks.Scsi Block
+
+The `disks.scsi` block is used to configure disks of type scsi. It may only be specified once. It has the options `disk_0` through `disk_30`. Each disk can have only one of the following mutually exclusive sub types `cdrom`, `disk`, `passthrough`. Configuration for these sub types can be found in their respective chapters:
+
+* `cdrom`: [Disks.x.Cdrom Block](#disksxcdrom-block).
+* `disk`: [Disks.x.Disk Block](#disksxdisk-block).
+* `passthrough`: [Disks.x.Passthrough Block](#disksxpassthrough-block).
+
+```hcl
+resource "proxmox_vm_qemu" "resource-name" {
+  //<arguments omitted for brevity...>
+
+  disks {
+    scsi {
+      disk_0 {
+        cdrom {
+          //<arguments omitted for brevity...>
+        }
+      }
+      disk_1 {
+        disk {
+          //<arguments omitted for brevity...>
+        }
+      }
+      disk_2 {
+        passthrough {
+          //<arguments omitted for brevity...>
+        }
+      }
+      //<arguments omitted for brevity...>
+    }
+    //<arguments omitted for brevity...>
+  }
+}
+```
+
+### Disks.Virtio Block
+
+The `disks.scsi` block is used to configure disks of type scsi. It may only be specified once. It has the options `disk_0` through `disk_15`. Each disk can have only one of the following mutually exclusive sub types `cdrom`, `disk`, `passthrough`. Configuration for these sub types can be found in their respective chapters:
+
+* `cdrom`: [Disks.x.Cdrom Block](#disksxcdrom-block).
+* `disk`: [Disks.x.Disk Block](#disksxdisk-block).
+* `passthrough`: [Disks.x.Passthrough Block](#disksxpassthrough-block).
+
+```hcl
+resource "proxmox_vm_qemu" "resource-name" {
+  //<arguments omitted for brevity...>
+
+  disks {
+    virtio {
+      disk_0 {
+        cdrom {
+          //<arguments omitted for brevity...>
+        }
+      }
+      disk_1 {
+        disk {
+          //<arguments omitted for brevity...>
+        }
+      }
+      disk_2 {
+        passthrough {
+          //<arguments omitted for brevity...>
+        }
+      }
+      //<arguments omitted for brevity...>
+    }
+    //<arguments omitted for brevity...>
+  }
+}
+```
+
+### Disks.x.Cdrom Block
+
+| Argument    | Type | Default Value | Description |
+|:------------|:-----|:-------------:|:------------|
+|`iso`        |`str` |               |The name of the ISO image to mount to the VM in the format: [storage pool]:iso/[name of iso file]. Note that `iso` is mutually exclusive with `passthrough`.|
+|`passthrough`|`bool`|`false`        |Wether the physical cdrom drive should be passed through.|
+
+When `iso` and `passthrough` are omitted an empty cdrom drive will be created.
+
+### Disks.x.Disk Block
+
 See the [docs about disks](https://pve.proxmox.com/pve-docs/chapter-qm.html#qm_hard_disk) for more details.
 
-| Argument       | Type  | Default Value | Description                                                                                                                                                                                                                                                                            |
-|----------------|-------|---------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `type`               | `str` |               | **Required** The type of disk device to add. Options: `ide`, `sata`, `scsi`, `virtio`. |
-| `storage`            | `str` |               | **Required** The name of the storage pool on which to store the disk. |
-| `size`               | `str` |               | **Required** The size of the created disk, format must match the regex `\d+[GMK]`, where G, M, and K represent Gigabytes, Megabytes, and Kilobytes respectively. |
-| `format`             | `str` | `"raw"`       | The drive’s backing file’s data format.  |
-| `cache`              | `str` | `"none"`      | The drive’s cache mode. Options: `directsync`, `none`, `unsafe`, `writeback`, `writethrough`  |
-| `backup`             | `bool` | `true`       | Whether the drive should be included when making backups. |
-| `iothread`           | `int` | `0`           | Whether to use iothreads for this drive. Only effective with a disk of type `virtio`, or `scsi` when the the emulated controller type (`scsihw` top level block argument) is `virtio-scsi-single`. |
-| `replicate`          | `int` | `0`           | Whether the drive should considered for replication jobs. |
-| `ssd`                | `int` | `0`           | Whether to expose this drive as an SSD, rather than a rotational hard disk. |
-| `discard`            | `str` |               | Controls whether to pass discard/trim requests to the underlying storage. Only effective when the underlying storage supports thin provisioning. There are other caveats too, see the [docs about disks](https://pve.proxmox.com/pve-docs/chapter-qm.html#qm_hard_disk) for more info. |
-| `aio`                | `str` |               | AIO type to use. Options: `io_uring`, `native`, `threads`. |
-| `mbps`               | `int` | `0`           | Maximum r/w speed in megabytes per second. `0` means unlimited.
-| `mbps_rd`            | `int` | `0`           | Maximum read speed in megabytes per second. `0` means unlimited. |
-| `mbps_rd_max`        | `int` | `0`           | Maximum read speed in megabytes per second. `0` means unlimited. |
-| `mbps_wr`            | `int` | `0`           | Maximum write speed in megabytes per second. `0` means unlimited.     |
-| `mbps_wr_max`        | `int` | `0`           | Maximum throttled write pool in megabytes per second. `0` means unlimited. |
-| `iops`               | `int` | `0`           | Maximum r/w I/O in operations per second. `0` means unlimited. |
-| `iops_max`           | `int` | `0`           | Maximum unthrottled r/w I/O pool in operations per second. `0` means unlimited. |
-| `iops_max_length`    | `int` | `0`           | Maximum length of I/O bursts in seconds. `0` means unlimited. |
-| `iops_rd`            | `int` | `0`           | Maximum read I/O in operations per second. `0` means unlimited. |
-| `iops_rd_max`        | `int` | `0`           | Maximum unthrottled read I/O pool in operations per second. `0` means unlimited. |
-| `iops_rd_max_length` | `int` | `0`           | Maximum length of read I/O bursts in seconds. `0` means unlimited. |
-| `iops_wr`            | `int` | `0`           | Maximum write I/O in operations per second. `0` means unlimited. |
-| `iops_wr_max`        | `int` | `0`           | Maximum unthrottled write I/O pool in operations per second. `0` means unlimited. |
-| `iops_wr_max_length` | `int` | `0`           | Maximum length of write I/O bursts in seconds. `0` means unlimited. |
-| `serial`             | `str` |               | The drive’s reported serial number, url-encoded, up to 20 bytes long. |
-| `wwn`                | `str` |               | The drive’s worldwide name, encoded as 16 bytes hex string, prefixed by 0x. |
-| `file`               | `str` |               | The filename portion of the path to the drive’s backing volume. You shouldn't need to specify this, use the `storage` parameter instead. |
-| `media`              | `str` | `"disk"`      | The drive’s media type. Options: `cdrom`, `disk`. |
-| `volume`             | `str` |               | The full path to the drive’s backing volume including the storage pool name. You shouldn't need to specify this, use the `storage` parameter instead. |
-| `slot`               | `int` |               | _(not sure what this is for, seems to be deprecated, do not use)_. |
-| `storage_type`       | `str` |               | The type of pool that `storage` is backed by. You shouldn't need to specify this, use the `storage` parameter instead. |
+| Argument             | Type  | Default Value | Disk Types          | Description |
+|:---------------------|:-----:|:-------------:|:-------------------:|:------------|
+|`asyncio`             |`str`  |               |`all`                |The drive's asyncio setting. Options: `io_uring`, `native`, `threads`|
+|`backup`              |`bool` |`true`         |`all`                |Whether the drive should be included when making backups.|
+|`cache`               |`str`  |               |`all`                |The drive’s cache mode. Options: `directsync`, `none`, `unsafe`, `writeback`, `writethrough`.|
+|`discard`             |`bool` |`false`        |`all`                |Controls whether to pass discard/trim requests to the underlying storage. Only effective when the underlying storage supports thin provisioning. There are other caveats too, see the [docs about disks](https://pve.proxmox.com/pve-docs/chapter-qm.html#qm_hard_disk) for more info.|
+|`emulatessd`          |`bool` |`false`        |`ide`, `sata`, `scsi`|Whether to expose this drive as an SSD, rather than a rotational hard disk.|
+|`format`              |`str`  |`raw`          |`all`                |The drive’s backing file’s data format.|
+|`id`                  |`int`  |               |`all`                |**Computed** Unique id of the disk.|
+|`iops_r_burst`        |`int`  |`0`            |`all`                |Maximum number of iops while reading in short bursts. `0` means unlimited.|
+|`iops_r_burst_length` |`int`  |`0`            |`all`                |Length of the read burst duration in seconds. `0` means the default duration dictated by proxmox.|
+|`iops_r_concurrent`   |`int`  |`0`            |`all`                |Maximum number of iops while reading concurrently. `0` means unlimited.|
+|`iops_wr_burst`       |`int`  |`0`            |`all`                |Maximum number of iops while writing in short bursts. `0` means unlimited.|
+|`iops_wr_burst_length`|`int`  |`0`            |`all`                |Length of the write burst duration in seconds. `0` means the default duration dictated by proxmox.|
+|`iops_wr_concurrent`  |`int`  |`0`            |`all`                |Maximum number of iops while writing concurrently. `0` means unlimited.|
+|`iothread`            |`bool` |`false`        |`scsi`, `virtio`    |Whether to use iothreads for this drive. Only effective when the the emulated controller type (`scsihw` top level block argument) is `virtio-scsi-single`.|
+|`linked_disk_id`      |`int`  |               |`all`                |**Computed** The `vmid` of the linked vm this disk was cloned from.|
+|`mbps_r_burst`        |`float`|`0.0`          |`all`                |Maximum read speed in megabytes per second. `0` means unlimited.|
+|`mbps_r_concurrent`   |`float`|`0.0`          |`all`                |Maximum read speed in megabytes per second. `0` means unlimited.|
+|`mbps_wr_burst`       |`float`|`0.0`          |`all`                |Maximum write speed in megabytes per second. `0` means unlimited.|
+|`mbps_wr_concurrent`  |`float`|`0.0`          |`all`                |Maximum throttled write pool in megabytes per second. `0` means unlimited.|
+|`readonly`            |`bool` |`false`        |`scsi`, `virtio`     |Whether the drive should be readonly.|
+|`replicate`           |`bool` |`false`        |`all`                |Whether the drive should considered for replication jobs.|
+|`serial`              |`str`  |               |`all`                |The serial number of the disk.|
+|`size`                |`int`  |               |`all`                |**Required** The size of the created disk in Gigabytes.|
+|`storage`             |`str`  |               |`all`                |**Required** The name of the storage pool on which to store the disk.|
+
+### Disks.x.Passthrough Block
+
+See the [docs about disks](https://pve.proxmox.com/pve-docs/chapter-qm.html#qm_hard_disk) for more details.
+
+| Argument             | Type  | Default Value | Disk Types          | Description |
+|:---------------------|:-----:|:-------------:|:-------------------:|:------------|
+|`asyncio`             |`str`  |               |`all`                |The drive's asyncio setting. Options: `io_uring`, `native`, `threads`|
+|`backup`              |`bool` |`true`         |`all`                |Whether the drive should be included when making backups.|
+|`cache`               |`str`  |               |`all`                |The drive’s cache mode. Options: `directsync`, `none`, `unsafe`, `writeback`, `writethrough`.|
+|`discard`             |`bool` |`false`        |`all`                |Controls whether to pass discard/trim requests to the underlying storage. Only effective when the underlying storage supports thin provisioning. There are other caveats too, see the [docs about disks](https://pve.proxmox.com/pve-docs/chapter-qm.html#qm_hard_disk) for more info.|
+|`emulatessd`          |`bool` |`false`        |`ide`, `sata`, `scsi`|Whether to expose this drive as an SSD, rather than a rotational hard disk.|
+|`file`                |`str`  |               |`all`                |**Required** The full unix file path to the disk.|
+|`iops_r_burst`        |`int`  |`0`            |`all`                |Maximum number of iops while reading in short bursts. `0` means unlimited.|
+|`iops_r_burst_length` |`int`  |`0`            |`all`                |Length of the read burst duration in seconds. `0` means the default duration dictated by proxmox.|
+|`iops_r_concurrent`   |`int`  |`0`            |`all`                |Maximum number of iops while reading concurrently. `0` means unlimited.|
+|`iops_wr_burst`       |`int`  |`0`            |`all`                |Maximum number of iops while writing in short bursts. `0` means unlimited.|
+|`iops_wr_burst_length`|`int`  |`0`            |`all`                |Length of the write burst duration in seconds. `0` means the default duration dictated by proxmox.|
+|`iops_wr_concurrent`  |`int`  |`0`            |`all`                |Maximum number of iops while writing concurrently. `0` means unlimited.|
+|`iothread`            |`bool` |`false`        |`scsi`, `virtio`     |Whether to use iothreads for this drive. Only effective when the the emulated controller type (`scsihw` top level block argument) is `virtio-scsi-single`.|
+|`mbps_r_burst`        |`float`|`0.0`          |`all`                |Maximum read speed in megabytes per second. `0` means unlimited.|
+|`mbps_r_concurrent`   |`float`|`0.0`          |`all`                |Maximum read speed in megabytes per second. `0` means unlimited.|
+|`mbps_wr_burst`       |`float`|`0.0`          |`all`                |Maximum write speed in megabytes per second. `0` means unlimited.|
+|`mbps_wr_concurrent`  |`float`|`0.0`          |`all`                |Maximum throttled write pool in megabytes per second. `0` means unlimited.|
+|`readonly`            |`bool` |`false`        |`scsi`, `virtio`     |Whether the drive should be readonly.|
+|`replicate`           |`bool` |`false`        |`all`                |Whether the drive should considered for replication jobs.|
+|`serial`              |`str`  |               |`all`                |The serial number of the disk.|
+|`size`                |`int`  |               |`all`                |**Computed** Size of the disk.|
 
 ### Serial Block
 
@@ -298,6 +457,7 @@ In addition to the arguments above, the following attributes can be referenced f
 
 The following arguments are deprecated, and should no longer be used.
 
+- `disk` - (Optional; use disks instead)
 - `disk_gb` - (Optional; use disk.size instead)
 - `storage` - (Optional; use disk.storage instead)
 - `storage_type` - (Optional; use disk.type instead)

--- a/examples/pxe_example.tf
+++ b/examples/pxe_example.tf
@@ -49,21 +49,25 @@ resource "proxmox_vm_qemu" "pxe-example" {
     target_node               = "test"
     vcpus                     = 0
 
-    disk {
-        backup       = false
-        cache        = "none"
-        discard      = "on"
-        iothread     = 1
-        mbps         = 0
-        mbps_rd      = 0
-        mbps_rd_max  = 0
-        mbps_wr      = 0
-        mbps_wr_max  = 0
-        replicate    = 0
-        size         = "32G"
-        ssd          = 1
-        storage      = "local-lvm"
-        type         = "scsi"
+    disks {
+        scsi {
+            disk_0 {
+                disk {
+                    backup             = true
+                    cache              = "none"
+                    discard            = true
+                    emulatessd         = true
+                    iothread           = true
+                    mbps_r_burst       = 0.0
+                    mbps_r_concurrent  = 0.0
+                    mbps_wr_burst      = 0.0
+                    mbps_wr_concurrent = 0.0
+                    replicate          = true
+                    size               = 32
+                    storage            = "local-lvm"
+                }
+            }
+        }
     }
 
     network {

--- a/examples/pxe_example.tf
+++ b/examples/pxe_example.tf
@@ -51,7 +51,7 @@ resource "proxmox_vm_qemu" "pxe-example" {
 
     disks {
         scsi {
-            disk_0 {
+            scsi0 {
                 disk {
                     backup             = true
                     cache              = "none"

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/Telmate/terraform-provider-proxmox
 go 1.19
 
 require (
-	github.com/Telmate/proxmox-api-go v0.0.0-20230411210559-73bbbf4297e1
+	github.com/Telmate/proxmox-api-go v0.0.0-20230514205936-68d4b6775a64
 	github.com/google/uuid v1.3.0
 	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.26.1
@@ -50,11 +50,11 @@ require (
 	github.com/zclconf/go-cty v1.13.1 // indirect
 	golang.org/x/crypto v0.7.0 // indirect
 	golang.org/x/mod v0.8.0 // indirect
-	golang.org/x/net v0.9.0 // indirect
-	golang.org/x/sys v0.7.0 // indirect
+	golang.org/x/net v0.10.0 // indirect
+	golang.org/x/sys v0.8.0 // indirect
 	golang.org/x/text v0.9.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/genproto v0.0.0-20230410155749-daa745c078e1 // indirect
-	google.golang.org/grpc v1.54.0 // indirect
+	google.golang.org/grpc v1.55.0 // indirect
 	google.golang.org/protobuf v1.30.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -6,8 +6,8 @@ github.com/Microsoft/go-winio v0.4.16 h1:FtSW/jqD+l4ba5iPBj9CODVtgfYAD8w2wS923g/
 github.com/Microsoft/go-winio v0.4.16/go.mod h1:XB6nPKklQyQ7GC9LdcBEcBl8PF76WugXOPRXwdLnMv0=
 github.com/ProtonMail/go-crypto v0.0.0-20210428141323-04723f9f07d7 h1:YoJbenK9C67SkzkDfmQuVln04ygHj3vjZfd9FL+GmQQ=
 github.com/ProtonMail/go-crypto v0.0.0-20210428141323-04723f9f07d7/go.mod h1:z4/9nQmJSSwwds7ejkxaJwO37dru3geImFUdJlaLzQo=
-github.com/Telmate/proxmox-api-go v0.0.0-20230411210559-73bbbf4297e1 h1:OwwFd8l+Zosmn1Auh0RTyVcrAMAvx5wrIhY/CpQ2PBg=
-github.com/Telmate/proxmox-api-go v0.0.0-20230411210559-73bbbf4297e1/go.mod h1:zQ/B1nkMv6ueUlAEr0D/x5eaFe3rHSScuTc08dcvvPI=
+github.com/Telmate/proxmox-api-go v0.0.0-20230514205936-68d4b6775a64 h1:7SJSQbRXDM3XXoLbbwo+/xJsQMdwo7f/O4e1rlR5FoU=
+github.com/Telmate/proxmox-api-go v0.0.0-20230514205936-68d4b6775a64/go.mod h1:HKwnwBcgJxT+UjTUyRP7+aDxXSgu0kLWvlrRhd4i1YU=
 github.com/acomagu/bufpipe v1.0.3 h1:fxAGrHZTgQ9w5QqVItgzwj235/uYZYgbXitB+dLupOk=
 github.com/acomagu/bufpipe v1.0.3/go.mod h1:mxdxdup/WdsKVreO5GpW4+M/1CE2sMG4jeGJ2sYmHc4=
 github.com/agext/levenshtein v1.2.3 h1:YB2fHEn0UJagG8T1rrWknE3ZQzWM06O8AMAatNn7lmo=
@@ -173,7 +173,7 @@ github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.2/go.mod h1:R6va5+xMeoiuVRoj+gSkQ7d3FALtqAAGI1FQKckRals=
-github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PKk=
+github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ8=
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/vmihailenco/msgpack v4.0.4+incompatible h1:dSLoQfGFAo3F6OoNhwUmLwVgaUXK79GlxNBwueZn0xI=
 github.com/vmihailenco/msgpack v4.0.4+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
@@ -207,8 +207,8 @@ golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v
 golang.org/x/net v0.0.0-20210326060303-6b1517762897/go.mod h1:uSPa2vr4CLtc/ILN5odXGNXS6mhrKVzTaCXzk9m6W3k=
 golang.org/x/net v0.0.0-20220722155237-a158d28d115b/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
 golang.org/x/net v0.5.0/go.mod h1:DivGGAXEgPSlEBzxGzZI+ZLohi+xUj054jfeKui00ws=
-golang.org/x/net v0.9.0 h1:aWJ/m6xSmxWBx+V0XRHTlrYrPG56jKsLdTFmsSsCzOM=
-golang.org/x/net v0.9.0/go.mod h1:d48xBJpPfHeWQsugry2m+kC02ZBRGRgulfHnEXEuWns=
+golang.org/x/net v0.10.0 h1:X2//UzNDwYmtCLn7To6G58Wr6f5ahEAQgKNzv9Y951M=
+golang.org/x/net v0.10.0/go.mod h1:0qNGK6F8kojg2nk9dLZ2mShWaEBan6FAoqfSigmmuDg=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -233,12 +233,12 @@ golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.4.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.7.0 h1:3jlCCIQZPdOYu1h8BkNvLz8Kgwtae2cagcG/VamtZRU=
-golang.org/x/sys v0.7.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.8.0 h1:EBmGv8NaZBZTWvrbjNoL6HVt+IVy3QDQpJs7VRIw3tU=
+golang.org/x/sys v0.8.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 golang.org/x/term v0.4.0/go.mod h1:9P2UbLfCdcvo3p/nzKvsmas4TnlujnuoV9hGgYzW1lQ=
-golang.org/x/term v0.7.0 h1:BEvjmm5fURWqcfbSKTdpkDXYBrUS1c0m8agp14W48vQ=
+golang.org/x/term v0.8.0 h1:n5xxQn2i3PC0yLAbjTpNT85q/Kgzcr2gIoX9OrJUols=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
@@ -256,8 +256,8 @@ google.golang.org/appengine v1.6.7 h1:FZR1q0exgwxzPzp/aF+VccGrSfxfPpkBqjIIEq3ru6
 google.golang.org/appengine v1.6.7/go.mod h1:8WjMMxjGQR8xUklV/ARdw2HLXBOI7O7uCIDZVag1xfc=
 google.golang.org/genproto v0.0.0-20230410155749-daa745c078e1 h1:KpwkzHKEF7B9Zxg18WzOa7djJ+Ha5DzthMyZYQfEn2A=
 google.golang.org/genproto v0.0.0-20230410155749-daa745c078e1/go.mod h1:nKE/iIaLqn2bQwXBg8f1g2Ylh6r5MN5CmZvuzZCgsCU=
-google.golang.org/grpc v1.54.0 h1:EhTqbhiYeixwWQtAEZAxmV9MGqcjEU2mFx52xCzNyag=
-google.golang.org/grpc v1.54.0/go.mod h1:PUSEXI6iWghWaB6lXM4knEgpJNu2qUcKfDtNci3EC2g=
+google.golang.org/grpc v1.55.0 h1:3Oj82/tFSCeUrRTg/5E/7d/W5A1tj6Ky1ABAuZuv5ag=
+google.golang.org/grpc v1.55.0/go.mod h1:iYEXKGkEBhg1PjZQvoYEVPTDkHo1/bjTnfwTeGONTY8=
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 google.golang.org/protobuf v1.30.0 h1:kPPoIgf3TsEvrm0PFe15JQ+570QVxYzEvvHqChK+cng=

--- a/proxmox/resource_vm_qemu.go
+++ b/proxmox/resource_vm_qemu.go
@@ -602,6 +602,109 @@ func resourceVmQemu() *schema.Resource {
 					},
 				},
 			},
+			"disks": {
+				Type:          schema.TypeList,
+				Optional:      true,
+				ConflictsWith: []string{"disk_gb", "storage", "storage_type"},
+				MaxItems:      1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"ide": {
+							Type:     schema.TypeList,
+							Optional: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"disk_0": schema_Ide("disk_0"),
+									"disk_1": schema_Ide("disk_1"),
+									"disk_2": schema_Ide("disk_2"),
+									"disk_3": schema_Ide("disk_3"),
+								},
+							},
+						},
+						"sata": {
+							Type:     schema.TypeList,
+							Optional: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"disk_0": schema_Sata("disk_0"),
+									"disk_1": schema_Sata("disk_1"),
+									"disk_2": schema_Sata("disk_2"),
+									"disk_3": schema_Sata("disk_3"),
+									"disk_4": schema_Sata("disk_4"),
+									"disk_5": schema_Sata("disk_5"),
+								},
+							},
+						},
+						"scsi": {
+							Type:     schema.TypeList,
+							Optional: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"disk_0":  schema_Scsi("disk_0"),
+									"disk_1":  schema_Scsi("disk_1"),
+									"disk_2":  schema_Scsi("disk_2"),
+									"disk_3":  schema_Scsi("disk_3"),
+									"disk_4":  schema_Scsi("disk_4"),
+									"disk_5":  schema_Scsi("disk_5"),
+									"disk_6":  schema_Scsi("disk_6"),
+									"disk_7":  schema_Scsi("disk_7"),
+									"disk_8":  schema_Scsi("disk_8"),
+									"disk_9":  schema_Scsi("disk_9"),
+									"disk_10": schema_Scsi("disk_10"),
+									"disk_11": schema_Scsi("disk_11"),
+									"disk_12": schema_Scsi("disk_12"),
+									"disk_13": schema_Scsi("disk_13"),
+									"disk_14": schema_Scsi("disk_14"),
+									"disk_15": schema_Scsi("disk_15"),
+									"disk_16": schema_Scsi("disk_16"),
+									"disk_17": schema_Scsi("disk_17"),
+									"disk_18": schema_Scsi("disk_18"),
+									"disk_19": schema_Scsi("disk_19"),
+									"disk_20": schema_Scsi("disk_20"),
+									"disk_21": schema_Scsi("disk_21"),
+									"disk_22": schema_Scsi("disk_22"),
+									"disk_23": schema_Scsi("disk_23"),
+									"disk_24": schema_Scsi("disk_24"),
+									"disk_25": schema_Scsi("disk_25"),
+									"disk_26": schema_Scsi("disk_26"),
+									"disk_27": schema_Scsi("disk_27"),
+									"disk_28": schema_Scsi("disk_28"),
+									"disk_29": schema_Scsi("disk_29"),
+									"disk_30": schema_Scsi("disk_30"),
+								},
+							},
+						},
+						"virtio": {
+							Type:     schema.TypeList,
+							Optional: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"disk_0":  schema_Virtio("disk_0"),
+									"disk_1":  schema_Virtio("disk_1"),
+									"disk_2":  schema_Virtio("disk_2"),
+									"disk_3":  schema_Virtio("disk_3"),
+									"disk_4":  schema_Virtio("disk_4"),
+									"disk_5":  schema_Virtio("disk_5"),
+									"disk_6":  schema_Virtio("disk_6"),
+									"disk_7":  schema_Virtio("disk_7"),
+									"disk_8":  schema_Virtio("disk_8"),
+									"disk_9":  schema_Virtio("disk_9"),
+									"disk_10": schema_Virtio("disk_10"),
+									"disk_11": schema_Virtio("disk_11"),
+									"disk_12": schema_Virtio("disk_12"),
+									"disk_13": schema_Virtio("disk_13"),
+									"disk_14": schema_Virtio("disk_14"),
+									"disk_15": schema_Virtio("disk_15"),
+								},
+							},
+						},
+					},
+				},
+			},
 			// Deprecated single disk config.
 			"disk_gb": {
 				Type:       schema.TypeFloat,
@@ -2284,4 +2387,534 @@ func initConnInfo(ctx context.Context,
 		"port": sshPort,
 	})
 	return diags
+}
+
+func schema_CdRom(path string) *schema.Schema {
+	return &schema.Schema{
+		Type:          schema.TypeList,
+		Optional:      true,
+		MaxItems:      1,
+		ConflictsWith: []string{path + ".disk", path + ".passthrough"},
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"iso": schema_IsoFile(path + ".cdrom.0.passthrough"),
+				"passthrough": {
+					Type:          schema.TypeBool,
+					Optional:      true,
+					ConflictsWith: []string{path + ".cdrom.0.iso"},
+				},
+			},
+		},
+	}
+}
+
+func schema_CloudInit() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeSet,
+		Optional: true,
+		MaxItems: 1,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"file": {
+					Type:     schema.TypeString,
+					Required: true,
+				},
+				"storage": {
+					Type:     schema.TypeString,
+					Required: true,
+				},
+			},
+		},
+	}
+}
+
+func schema_IsoFile(setting string) *schema.Schema {
+	return &schema.Schema{
+		Type:          schema.TypeList,
+		Optional:      true,
+		ConflictsWith: []string{setting},
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"file": {
+					Type:     schema.TypeString,
+					Required: true,
+				},
+				"storage": {
+					Type:     schema.TypeString,
+					Required: true,
+				},
+			},
+		},
+	}
+}
+
+func schema_Ide(setting string) *schema.Schema {
+	path := "disks.0.ide.0." + setting + ".0"
+	return &schema.Schema{
+		Type:     schema.TypeList,
+		Optional: true,
+		MaxItems: 1,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"cdrom":     schema_CdRom(path),
+				"cloudinit": schema_CloudInit(),
+				"disk": {
+					Type:          schema.TypeList,
+					Optional:      true,
+					MaxItems:      1,
+					ConflictsWith: []string{path + ".cdrom", path + ".passthrough"},
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"asyncio":    schema_DiskAsyncIO(),
+							"backup":     schema_DiskBackup(),
+							"bandwidth":  schema_DiskBandwidth(),
+							"cache":      schema_DiskCache(),
+							"discard":    {Type: schema.TypeBool, Optional: true},
+							"emulatessd": {Type: schema.TypeBool, Optional: true},
+							"format":     schema_DiskFormat(),
+							"id":         schema_DiskId(),
+							"replicate":  {Type: schema.TypeBool, Optional: true},
+							"serial":     schema_DiskSerial(),
+							"size":       schema_DiskSize(),
+							"storage":    schema_DiskStorage(),
+						},
+					},
+				},
+				"passthrough": {
+					Type:          schema.TypeList,
+					Optional:      true,
+					MaxItems:      1,
+					ConflictsWith: []string{path + ".cdrom", path + ".disk"},
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"asyncio":    schema_DiskAsyncIO(),
+							"backup":     schema_DiskBackup(),
+							"bandwidth":  schema_DiskBandwidth(),
+							"cache":      schema_DiskCache(),
+							"discard":    {Type: schema.TypeBool, Optional: true},
+							"emulatessd": {Type: schema.TypeBool, Optional: true},
+							"file":       schema_PassthroughFile(),
+							"replicate":  {Type: schema.TypeBool, Optional: true},
+							"serial":     schema_DiskSerial(),
+							"size":       schema_PassthroughSize(),
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func schema_Sata(setting string) *schema.Schema {
+	path := "disks.0.sata.0." + setting + ".0"
+	return &schema.Schema{
+		Type:     schema.TypeList,
+		Optional: true,
+		MaxItems: 1,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"cdrom":     schema_CdRom(path),
+				"cloudinit": schema_CloudInit(),
+				"disk": {
+					Type:          schema.TypeList,
+					Optional:      true,
+					MaxItems:      1,
+					ConflictsWith: []string{path + ".cdrom", path + ".passthrough"},
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"asyncio":    schema_DiskAsyncIO(),
+							"backup":     schema_DiskBackup(),
+							"bandwidth":  schema_DiskBandwidth(),
+							"cache":      schema_DiskCache(),
+							"discard":    {Type: schema.TypeBool, Optional: true},
+							"emulatessd": {Type: schema.TypeBool, Optional: true},
+							"format":     schema_DiskFormat(),
+							"id":         schema_DiskId(),
+							"replicate":  {Type: schema.TypeBool, Optional: true},
+							"serial":     schema_DiskSerial(),
+							"size":       schema_DiskSize(),
+							"storage":    schema_DiskStorage(),
+						},
+					},
+				},
+				"passthrough": {
+					Type:          schema.TypeList,
+					Optional:      true,
+					MaxItems:      1,
+					ConflictsWith: []string{path + ".cdrom", path + ".disk"},
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"asyncio":    schema_DiskAsyncIO(),
+							"backup":     schema_DiskBackup(),
+							"bandwidth":  schema_DiskBandwidth(),
+							"cache":      schema_DiskCache(),
+							"discard":    {Type: schema.TypeBool, Optional: true},
+							"emulatessd": {Type: schema.TypeBool, Optional: true},
+							"file":       schema_PassthroughFile(),
+							"replicate":  {Type: schema.TypeBool, Optional: true},
+							"serial":     schema_DiskSerial(),
+							"size":       schema_PassthroughSize(),
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func schema_Scsi(setting string) *schema.Schema {
+	path := "disks.0.scsi.0." + setting + ".0"
+	return &schema.Schema{
+		Type:     schema.TypeList,
+		Optional: true,
+		MaxItems: 1,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"cdrom":     schema_CdRom(path),
+				"cloudinit": schema_CloudInit(),
+				"disk": {
+					Type:          schema.TypeList,
+					Optional:      true,
+					MaxItems:      1,
+					ConflictsWith: []string{path + ".cdrom", path + ".passthrough"},
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"asyncio":    schema_DiskAsyncIO(),
+							"backup":     schema_DiskBackup(),
+							"bandwidth":  schema_DiskBandwidth(),
+							"cache":      schema_DiskCache(),
+							"discard":    {Type: schema.TypeBool, Optional: true},
+							"emulatessd": {Type: schema.TypeBool, Optional: true},
+							"format":     schema_DiskFormat(),
+							"id":         schema_DiskId(),
+							"iothread":   {Type: schema.TypeBool, Optional: true},
+							"readonly":   {Type: schema.TypeBool, Optional: true},
+							"replicate":  {Type: schema.TypeBool, Optional: true},
+							"serial":     schema_DiskSerial(),
+							"size":       schema_DiskSize(),
+							"storage":    schema_DiskStorage(),
+						},
+					},
+				},
+				"passthrough": {
+					Type:          schema.TypeList,
+					Optional:      true,
+					MaxItems:      1,
+					ConflictsWith: []string{path + ".cdrom", path + ".disk"},
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"asyncio":    schema_DiskAsyncIO(),
+							"backup":     schema_DiskBackup(),
+							"bandwidth":  schema_DiskBandwidth(),
+							"cache":      schema_DiskCache(),
+							"discard":    {Type: schema.TypeBool, Optional: true},
+							"emulatessd": {Type: schema.TypeBool, Optional: true},
+							"file":       schema_PassthroughFile(),
+							"iothread":   {Type: schema.TypeBool, Optional: true},
+							"readonly":   {Type: schema.TypeBool, Optional: true},
+							"replicate":  {Type: schema.TypeBool, Optional: true},
+							"serial":     schema_DiskSerial(),
+							"size":       schema_PassthroughSize(),
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func schema_Virtio(setting string) *schema.Schema {
+	path := "disks.0.virtio.0." + setting + ".0"
+	return &schema.Schema{
+		Type:     schema.TypeList,
+		Optional: true,
+		MaxItems: 1,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"cdrom":     schema_CdRom(path),
+				"cloudinit": schema_CloudInit(),
+				"disk": {
+					Type:          schema.TypeList,
+					Optional:      true,
+					MaxItems:      1,
+					ConflictsWith: []string{path + ".cdrom", path + ".passthrough"},
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"asyncio":   schema_DiskAsyncIO(),
+							"backup":    schema_DiskBackup(),
+							"bandwidth": schema_DiskBandwidth(),
+							"cache":     schema_DiskCache(),
+							"discard":   {Type: schema.TypeBool, Optional: true},
+							"format":    schema_DiskFormat(),
+							"id":        schema_DiskId(),
+							"iothread":  {Type: schema.TypeBool, Optional: true},
+							"readonly":  {Type: schema.TypeBool, Optional: true},
+							"replicate": {Type: schema.TypeBool, Optional: true},
+							"serial":    schema_DiskSerial(),
+							"size":      schema_DiskSize(),
+							"storage":   schema_DiskStorage(),
+						},
+					},
+				},
+				"passthrough": {
+					Type:          schema.TypeList,
+					Optional:      true,
+					MaxItems:      1,
+					ConflictsWith: []string{path + ".cdrom", path + ".disk"},
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"asyncio":   schema_DiskAsyncIO(),
+							"backup":    schema_DiskBackup(),
+							"bandwidth": schema_DiskBandwidth(),
+							"cache":     schema_DiskCache(),
+							"discard":   {Type: schema.TypeBool, Optional: true},
+							"file":      schema_PassthroughFile(),
+							"iothread":  {Type: schema.TypeBool, Optional: true},
+							"readonly":  {Type: schema.TypeBool, Optional: true},
+							"replicate": {Type: schema.TypeBool, Optional: true},
+							"serial":    schema_DiskSerial(),
+							"size":      schema_PassthroughSize(),
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func schema_DiskAsyncIO() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeString,
+		Optional: true,
+		ValidateFunc: func(i interface{}, k string) (warnings []string, errors []error) {
+			v, ok := i.(string)
+			if !ok {
+				errors = append(errors, fmt.Errorf("expected type of %s to be string", k))
+				return
+			}
+			if err := pxapi.QemuDiskAsyncIO(v).Validate(); err != nil {
+				errors = append(errors, err)
+			}
+			return
+		},
+	}
+}
+
+func schema_DiskBackup() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeBool,
+		Optional: true,
+		Default:  true,
+	}
+}
+
+func schema_DiskBandwidth() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeList,
+		Optional: true,
+		MaxItems: 1,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"data": {
+					Type:     schema.TypeList,
+					Optional: true,
+					MaxItems: 1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"read":  schema_DiskBandwidthData(),
+							"write": schema_DiskBandwidthData(),
+						},
+					},
+				},
+				"iops": {
+					Type:     schema.TypeList,
+					Optional: true,
+					MaxItems: 1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"read":  schema_DiskBandwidthIops(),
+							"write": schema_DiskBandwidthIops(),
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func schema_DiskBandwidthData() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeList,
+		Optional: true,
+		MaxItems: 1,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"burst": {
+					Type:     schema.TypeFloat,
+					Optional: true,
+					ValidateFunc: func(i interface{}, k string) (warnings []string, errors []error) {
+						v, ok := i.(float64)
+						if !ok {
+							errors = append(errors, fmt.Errorf("expected type of %s to be a float", k))
+							return
+						}
+						if err := pxapi.QemuDiskBandwidthDataLimitConcurrent(v).Validate(); err != nil {
+							errors = append(errors, err)
+						}
+						return
+					},
+				},
+				"concurrent": {
+					Type:     schema.TypeFloat,
+					Optional: true,
+					ValidateFunc: func(i interface{}, k string) (warnings []string, errors []error) {
+						v, ok := i.(float64)
+						if !ok {
+							errors = append(errors, fmt.Errorf("expected type of %s to be a float", k))
+							return
+						}
+						if err := pxapi.QemuDiskBandwidthDataLimitConcurrent(v).Validate(); err != nil {
+							errors = append(errors, err)
+						}
+						return
+					},
+				},
+			},
+		},
+	}
+}
+
+func schema_DiskBandwidthIops() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeList,
+		Optional: true,
+		MaxItems: 1,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"burst": {
+					Type:     schema.TypeInt,
+					Optional: true,
+					ValidateFunc: func(i interface{}, k string) (warnings []string, errors []error) {
+						v, ok := i.(int)
+						if !ok || v < 0 {
+							errors = append(errors, fmt.Errorf("expected type of %s to be a positive number (uint)", k))
+							return
+						}
+						if err := pxapi.QemuDiskBandwidthIopsLimitBurst(v).Validate(); err != nil {
+							errors = append(errors, err)
+						}
+						return
+					},
+				},
+				"concurrent": {
+					Type:     schema.TypeInt,
+					Optional: true,
+					ValidateFunc: func(i interface{}, k string) (warnings []string, errors []error) {
+						v, ok := i.(int)
+						if !ok || v < 0 {
+							errors = append(errors, fmt.Errorf("expected type of %s to be a positive number (uint)", k))
+							return
+						}
+						if err := pxapi.QemuDiskBandwidthIopsLimitConcurrent(v).Validate(); err != nil {
+							errors = append(errors, err)
+						}
+						return
+					},
+				},
+			},
+		},
+	}
+}
+
+func schema_DiskCache() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeString,
+		Optional: true,
+		Default:  "",
+		ValidateFunc: func(i interface{}, k string) (warnings []string, errors []error) {
+			v, ok := i.(string)
+			if !ok {
+				errors = append(errors, fmt.Errorf("expected type of %s to be string", k))
+				return
+			}
+			if err := pxapi.QemuDiskCache(v).Validate(); err != nil {
+				errors = append(errors, err)
+			}
+			return
+		},
+	}
+}
+
+func schema_DiskFormat() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeString,
+		Optional: true,
+		Default:  "raw",
+		ValidateFunc: func(i interface{}, k string) (warnings []string, errors []error) {
+			v, ok := i.(string)
+			if !ok {
+				errors = append(errors, fmt.Errorf("expected type of %s to be string", k))
+				return
+			}
+			if err := pxapi.QemuDiskFormat(v).Validate(); err != nil {
+				errors = append(errors, err)
+			}
+			return
+		},
+	}
+}
+
+func schema_DiskId() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeInt,
+		Computed: true,
+	}
+}
+
+func schema_DiskSerial() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeString,
+		Optional: true,
+		Default:  "",
+		ValidateFunc: func(i interface{}, k string) (warnings []string, errors []error) {
+			v, ok := i.(string)
+			if !ok {
+				errors = append(errors, fmt.Errorf("expected type of %s to be string", k))
+				return
+			}
+			if err := pxapi.QemuDiskSerial(v).Validate(); err != nil {
+				errors = append(errors, err)
+			}
+			return
+		},
+	}
+}
+
+func schema_DiskSize() *schema.Schema {
+	return &schema.Schema{
+		Type:         schema.TypeInt,
+		Required:     true,
+		ValidateFunc: uint_Validator(),
+	}
+}
+
+func schema_DiskStorage() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeString,
+		Required: true,
+	}
+}
+
+func schema_PassthroughFile() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeString,
+		Required: true,
+	}
+}
+
+func schema_PassthroughSize() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeInt,
+		Computed: true,
+	}
 }

--- a/proxmox/resource_vm_qemu.go
+++ b/proxmox/resource_vm_qemu.go
@@ -3521,9 +3521,9 @@ func schema_DiskSerial() *schema.Schema {
 
 func schema_DiskSize() *schema.Schema {
 	return &schema.Schema{
-		Type:         schema.TypeInt,
-		Required:     true,
-		ValidateFunc: uint_Validator(),
+		Type:             schema.TypeInt,
+		Required:         true,
+		ValidateDiagFunc: uint_Validator(),
 	}
 }
 

--- a/proxmox/resource_vm_qemu.go
+++ b/proxmox/resource_vm_qemu.go
@@ -2464,20 +2464,20 @@ func schema_Ide(setting string) *schema.Schema {
 					MaxItems:      1,
 					ConflictsWith: []string{path + ".cdrom", path + ".passthrough"},
 					Elem: &schema.Resource{
-						Schema: map[string]*schema.Schema{
-							"asyncio":    schema_DiskAsyncIO(),
-							"backup":     schema_DiskBackup(),
-							"bandwidth":  schema_DiskBandwidth(),
-							"cache":      schema_DiskCache(),
-							"discard":    {Type: schema.TypeBool, Optional: true},
-							"emulatessd": {Type: schema.TypeBool, Optional: true},
-							"format":     schema_DiskFormat(),
-							"id":         schema_DiskId(),
-							"replicate":  {Type: schema.TypeBool, Optional: true},
-							"serial":     schema_DiskSerial(),
-							"size":       schema_DiskSize(),
-							"storage":    schema_DiskStorage(),
-						},
+						Schema: schema_DiskBandwidth(map[string]*schema.Schema{
+							"asyncio":        schema_DiskAsyncIO(),
+							"backup":         schema_DiskBackup(),
+							"cache":          schema_DiskCache(),
+							"discard":        {Type: schema.TypeBool, Optional: true},
+							"emulatessd":     {Type: schema.TypeBool, Optional: true},
+							"format":         schema_DiskFormat(),
+							"id":             schema_DiskId(),
+							"linked_disk_id": schema_LinkedDiskId(),
+							"replicate":      {Type: schema.TypeBool, Optional: true},
+							"serial":         schema_DiskSerial(),
+							"size":           schema_DiskSize(),
+							"storage":        schema_DiskStorage(),
+						}),
 					},
 				},
 				"passthrough": {
@@ -2486,10 +2486,9 @@ func schema_Ide(setting string) *schema.Schema {
 					MaxItems:      1,
 					ConflictsWith: []string{path + ".cdrom", path + ".disk"},
 					Elem: &schema.Resource{
-						Schema: map[string]*schema.Schema{
+						Schema: schema_DiskBandwidth(map[string]*schema.Schema{
 							"asyncio":    schema_DiskAsyncIO(),
 							"backup":     schema_DiskBackup(),
-							"bandwidth":  schema_DiskBandwidth(),
 							"cache":      schema_DiskCache(),
 							"discard":    {Type: schema.TypeBool, Optional: true},
 							"emulatessd": {Type: schema.TypeBool, Optional: true},
@@ -2497,7 +2496,7 @@ func schema_Ide(setting string) *schema.Schema {
 							"replicate":  {Type: schema.TypeBool, Optional: true},
 							"serial":     schema_DiskSerial(),
 							"size":       schema_PassthroughSize(),
-						},
+						}),
 					},
 				},
 			},
@@ -2521,20 +2520,20 @@ func schema_Sata(setting string) *schema.Schema {
 					MaxItems:      1,
 					ConflictsWith: []string{path + ".cdrom", path + ".passthrough"},
 					Elem: &schema.Resource{
-						Schema: map[string]*schema.Schema{
-							"asyncio":    schema_DiskAsyncIO(),
-							"backup":     schema_DiskBackup(),
-							"bandwidth":  schema_DiskBandwidth(),
-							"cache":      schema_DiskCache(),
-							"discard":    {Type: schema.TypeBool, Optional: true},
-							"emulatessd": {Type: schema.TypeBool, Optional: true},
-							"format":     schema_DiskFormat(),
-							"id":         schema_DiskId(),
-							"replicate":  {Type: schema.TypeBool, Optional: true},
-							"serial":     schema_DiskSerial(),
-							"size":       schema_DiskSize(),
-							"storage":    schema_DiskStorage(),
-						},
+						Schema: schema_DiskBandwidth(map[string]*schema.Schema{
+							"asyncio":        schema_DiskAsyncIO(),
+							"backup":         schema_DiskBackup(),
+							"cache":          schema_DiskCache(),
+							"discard":        {Type: schema.TypeBool, Optional: true},
+							"emulatessd":     {Type: schema.TypeBool, Optional: true},
+							"format":         schema_DiskFormat(),
+							"id":             schema_DiskId(),
+							"linked_disk_id": schema_LinkedDiskId(),
+							"replicate":      {Type: schema.TypeBool, Optional: true},
+							"serial":         schema_DiskSerial(),
+							"size":           schema_DiskSize(),
+							"storage":        schema_DiskStorage(),
+						}),
 					},
 				},
 				"passthrough": {
@@ -2543,10 +2542,9 @@ func schema_Sata(setting string) *schema.Schema {
 					MaxItems:      1,
 					ConflictsWith: []string{path + ".cdrom", path + ".disk"},
 					Elem: &schema.Resource{
-						Schema: map[string]*schema.Schema{
+						Schema: schema_DiskBandwidth(map[string]*schema.Schema{
 							"asyncio":    schema_DiskAsyncIO(),
 							"backup":     schema_DiskBackup(),
-							"bandwidth":  schema_DiskBandwidth(),
 							"cache":      schema_DiskCache(),
 							"discard":    {Type: schema.TypeBool, Optional: true},
 							"emulatessd": {Type: schema.TypeBool, Optional: true},
@@ -2554,7 +2552,7 @@ func schema_Sata(setting string) *schema.Schema {
 							"replicate":  {Type: schema.TypeBool, Optional: true},
 							"serial":     schema_DiskSerial(),
 							"size":       schema_PassthroughSize(),
-						},
+						}),
 					},
 				},
 			},
@@ -2578,22 +2576,22 @@ func schema_Scsi(setting string) *schema.Schema {
 					MaxItems:      1,
 					ConflictsWith: []string{path + ".cdrom", path + ".passthrough"},
 					Elem: &schema.Resource{
-						Schema: map[string]*schema.Schema{
-							"asyncio":    schema_DiskAsyncIO(),
-							"backup":     schema_DiskBackup(),
-							"bandwidth":  schema_DiskBandwidth(),
-							"cache":      schema_DiskCache(),
-							"discard":    {Type: schema.TypeBool, Optional: true},
-							"emulatessd": {Type: schema.TypeBool, Optional: true},
-							"format":     schema_DiskFormat(),
-							"id":         schema_DiskId(),
-							"iothread":   {Type: schema.TypeBool, Optional: true},
-							"readonly":   {Type: schema.TypeBool, Optional: true},
-							"replicate":  {Type: schema.TypeBool, Optional: true},
-							"serial":     schema_DiskSerial(),
-							"size":       schema_DiskSize(),
-							"storage":    schema_DiskStorage(),
-						},
+						Schema: schema_DiskBandwidth(map[string]*schema.Schema{
+							"asyncio":        schema_DiskAsyncIO(),
+							"backup":         schema_DiskBackup(),
+							"cache":          schema_DiskCache(),
+							"discard":        {Type: schema.TypeBool, Optional: true},
+							"emulatessd":     {Type: schema.TypeBool, Optional: true},
+							"format":         schema_DiskFormat(),
+							"id":             schema_DiskId(),
+							"iothread":       {Type: schema.TypeBool, Optional: true},
+							"linked_disk_id": schema_LinkedDiskId(),
+							"readonly":       {Type: schema.TypeBool, Optional: true},
+							"replicate":      {Type: schema.TypeBool, Optional: true},
+							"serial":         schema_DiskSerial(),
+							"size":           schema_DiskSize(),
+							"storage":        schema_DiskStorage(),
+						}),
 					},
 				},
 				"passthrough": {
@@ -2602,10 +2600,9 @@ func schema_Scsi(setting string) *schema.Schema {
 					MaxItems:      1,
 					ConflictsWith: []string{path + ".cdrom", path + ".disk"},
 					Elem: &schema.Resource{
-						Schema: map[string]*schema.Schema{
+						Schema: schema_DiskBandwidth(map[string]*schema.Schema{
 							"asyncio":    schema_DiskAsyncIO(),
 							"backup":     schema_DiskBackup(),
-							"bandwidth":  schema_DiskBandwidth(),
 							"cache":      schema_DiskCache(),
 							"discard":    {Type: schema.TypeBool, Optional: true},
 							"emulatessd": {Type: schema.TypeBool, Optional: true},
@@ -2615,7 +2612,7 @@ func schema_Scsi(setting string) *schema.Schema {
 							"replicate":  {Type: schema.TypeBool, Optional: true},
 							"serial":     schema_DiskSerial(),
 							"size":       schema_PassthroughSize(),
-						},
+						}),
 					},
 				},
 			},
@@ -2639,21 +2636,21 @@ func schema_Virtio(setting string) *schema.Schema {
 					MaxItems:      1,
 					ConflictsWith: []string{path + ".cdrom", path + ".passthrough"},
 					Elem: &schema.Resource{
-						Schema: map[string]*schema.Schema{
-							"asyncio":   schema_DiskAsyncIO(),
-							"backup":    schema_DiskBackup(),
-							"bandwidth": schema_DiskBandwidth(),
-							"cache":     schema_DiskCache(),
-							"discard":   {Type: schema.TypeBool, Optional: true},
-							"format":    schema_DiskFormat(),
-							"id":        schema_DiskId(),
-							"iothread":  {Type: schema.TypeBool, Optional: true},
-							"readonly":  {Type: schema.TypeBool, Optional: true},
-							"replicate": {Type: schema.TypeBool, Optional: true},
-							"serial":    schema_DiskSerial(),
-							"size":      schema_DiskSize(),
-							"storage":   schema_DiskStorage(),
-						},
+						Schema: schema_DiskBandwidth(map[string]*schema.Schema{
+							"asyncio":        schema_DiskAsyncIO(),
+							"backup":         schema_DiskBackup(),
+							"cache":          schema_DiskCache(),
+							"discard":        {Type: schema.TypeBool, Optional: true},
+							"format":         schema_DiskFormat(),
+							"id":             schema_DiskId(),
+							"iothread":       {Type: schema.TypeBool, Optional: true},
+							"linked_disk_id": schema_LinkedDiskId(),
+							"readonly":       {Type: schema.TypeBool, Optional: true},
+							"replicate":      {Type: schema.TypeBool, Optional: true},
+							"serial":         schema_DiskSerial(),
+							"size":           schema_DiskSize(),
+							"storage":        schema_DiskStorage(),
+						}),
 					},
 				},
 				"passthrough": {
@@ -2661,11 +2658,10 @@ func schema_Virtio(setting string) *schema.Schema {
 					Optional:      true,
 					MaxItems:      1,
 					ConflictsWith: []string{path + ".cdrom", path + ".disk"},
-					Elem: &schema.Resource{
-						Schema: map[string]*schema.Schema{
+					Elem: &schema.Resource{Schema: schema_DiskBandwidth(
+						map[string]*schema.Schema{
 							"asyncio":   schema_DiskAsyncIO(),
 							"backup":    schema_DiskBackup(),
-							"bandwidth": schema_DiskBandwidth(),
 							"cache":     schema_DiskCache(),
 							"discard":   {Type: schema.TypeBool, Optional: true},
 							"file":      schema_PassthroughFile(),
@@ -2675,7 +2671,7 @@ func schema_Virtio(setting string) *schema.Schema {
 							"serial":    schema_DiskSerial(),
 							"size":      schema_PassthroughSize(),
 						},
-					},
+					)},
 				},
 			},
 		},
@@ -2708,120 +2704,101 @@ func schema_DiskBackup() *schema.Schema {
 	}
 }
 
-func schema_DiskBandwidth() *schema.Schema {
+func schema_DiskBandwidth(params map[string]*schema.Schema) map[string]*schema.Schema {
+	params["mbps_r_burst"] = schema_DiskBandwidthMBpsBurst()
+	params["mbps_r_concurrent"] = schema_DiskBandwidthMBpsConcurrent()
+	params["mbps_wr_burst"] = schema_DiskBandwidthMBpsBurst()
+	params["mbps_wr_concurrent"] = schema_DiskBandwidthMBpsConcurrent()
+	params["iops_r_burst"] = schema_DiskBandwidthIopsBurst()
+	params["iops_r_burst_length"] = schema_DiskBandwidthIopsBurstLength()
+	params["iops_r_concurrent"] = schema_DiskBandwidthIopsConcurrent()
+	params["iops_wr_burst"] = schema_DiskBandwidthIopsBurst()
+	params["iops_wr_burst_length"] = schema_DiskBandwidthIopsBurstLength()
+	params["iops_wr_concurrent"] = schema_DiskBandwidthIopsConcurrent()
+	return params
+}
+
+func schema_DiskBandwidthIopsBurst() *schema.Schema {
 	return &schema.Schema{
-		Type:     schema.TypeList,
+		Type:     schema.TypeInt,
 		Optional: true,
-		MaxItems: 1,
-		Elem: &schema.Resource{
-			Schema: map[string]*schema.Schema{
-				"data": {
-					Type:     schema.TypeList,
-					Optional: true,
-					MaxItems: 1,
-					Elem: &schema.Resource{
-						Schema: map[string]*schema.Schema{
-							"read":  schema_DiskBandwidthData(),
-							"write": schema_DiskBandwidthData(),
-						},
-					},
-				},
-				"iops": {
-					Type:     schema.TypeList,
-					Optional: true,
-					MaxItems: 1,
-					Elem: &schema.Resource{
-						Schema: map[string]*schema.Schema{
-							"read":  schema_DiskBandwidthIops(),
-							"write": schema_DiskBandwidthIops(),
-						},
-					},
-				},
-			},
+		Default:  0,
+		ValidateFunc: func(i interface{}, k string) (warnings []string, errors []error) {
+			v, ok := i.(int)
+			if !ok || v < 0 {
+				errors = append(errors, fmt.Errorf("expected type of %s to be a positive number (uint)", k))
+				return
+			}
+			if err := pxapi.QemuDiskBandwidthIopsLimitBurst(v).Validate(); err != nil {
+				errors = append(errors, err)
+			}
+			return
 		},
 	}
 }
 
-func schema_DiskBandwidthData() *schema.Schema {
+func schema_DiskBandwidthIopsBurstLength() *schema.Schema {
 	return &schema.Schema{
-		Type:     schema.TypeList,
+		Type:     schema.TypeInt,
 		Optional: true,
-		MaxItems: 1,
-		Elem: &schema.Resource{
-			Schema: map[string]*schema.Schema{
-				"burst": {
-					Type:     schema.TypeFloat,
-					Optional: true,
-					ValidateFunc: func(i interface{}, k string) (warnings []string, errors []error) {
-						v, ok := i.(float64)
-						if !ok {
-							errors = append(errors, fmt.Errorf("expected type of %s to be a float", k))
-							return
-						}
-						if err := pxapi.QemuDiskBandwidthDataLimitConcurrent(v).Validate(); err != nil {
-							errors = append(errors, err)
-						}
-						return
-					},
-				},
-				"concurrent": {
-					Type:     schema.TypeFloat,
-					Optional: true,
-					ValidateFunc: func(i interface{}, k string) (warnings []string, errors []error) {
-						v, ok := i.(float64)
-						if !ok {
-							errors = append(errors, fmt.Errorf("expected type of %s to be a float", k))
-							return
-						}
-						if err := pxapi.QemuDiskBandwidthDataLimitConcurrent(v).Validate(); err != nil {
-							errors = append(errors, err)
-						}
-						return
-					},
-				},
-			},
+		Default:  0,
+	}
+}
+
+func schema_DiskBandwidthIopsConcurrent() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeInt,
+		Optional: true,
+		Default:  0,
+		ValidateFunc: func(i interface{}, k string) (warnings []string, errors []error) {
+			v, ok := i.(int)
+			if !ok || v < 0 {
+				errors = append(errors, fmt.Errorf("expected type of %s to be a positive number (uint)", k))
+				return
+			}
+			if err := pxapi.QemuDiskBandwidthIopsLimitConcurrent(v).Validate(); err != nil {
+				errors = append(errors, err)
+			}
+			return
 		},
 	}
 }
 
-func schema_DiskBandwidthIops() *schema.Schema {
+func schema_DiskBandwidthMBpsBurst() *schema.Schema {
 	return &schema.Schema{
-		Type:     schema.TypeList,
+		Type:     schema.TypeFloat,
 		Optional: true,
-		MaxItems: 1,
-		Elem: &schema.Resource{
-			Schema: map[string]*schema.Schema{
-				"burst": {
-					Type:     schema.TypeInt,
-					Optional: true,
-					ValidateFunc: func(i interface{}, k string) (warnings []string, errors []error) {
-						v, ok := i.(int)
-						if !ok || v < 0 {
-							errors = append(errors, fmt.Errorf("expected type of %s to be a positive number (uint)", k))
-							return
-						}
-						if err := pxapi.QemuDiskBandwidthIopsLimitBurst(v).Validate(); err != nil {
-							errors = append(errors, err)
-						}
-						return
-					},
-				},
-				"concurrent": {
-					Type:     schema.TypeInt,
-					Optional: true,
-					ValidateFunc: func(i interface{}, k string) (warnings []string, errors []error) {
-						v, ok := i.(int)
-						if !ok || v < 0 {
-							errors = append(errors, fmt.Errorf("expected type of %s to be a positive number (uint)", k))
-							return
-						}
-						if err := pxapi.QemuDiskBandwidthIopsLimitConcurrent(v).Validate(); err != nil {
-							errors = append(errors, err)
-						}
-						return
-					},
-				},
-			},
+		Default:  0.0,
+		ValidateFunc: func(i interface{}, k string) (warnings []string, errors []error) {
+			v, ok := i.(float64)
+			if !ok {
+				errors = append(errors, fmt.Errorf("expected type of %s to be a float", k))
+				return
+			}
+			if err := pxapi.QemuDiskBandwidthMBpsLimitConcurrent(v).Validate(); err != nil {
+				errors = append(errors, err)
+			}
+			return
+		},
+	}
+}
+
+func schema_DiskBandwidthMBpsConcurrent() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeFloat,
+		Optional: true,
+		Default:  0.0,
+		ValidateFunc: func(i interface{}, k string) (warnings []string, errors []error) {
+			v, ok := i.(float64)
+			if !ok {
+				errors = append(errors, fmt.Errorf("expected type of %s to be a float", k))
+				return
+			}
+
+			if err := pxapi.QemuDiskBandwidthMBpsLimitConcurrent(v).Validate(); err != nil {
+				errors = append(errors, err)
+			}
+			return
 		},
 	}
 }
@@ -2902,6 +2879,13 @@ func schema_DiskStorage() *schema.Schema {
 	return &schema.Schema{
 		Type:     schema.TypeString,
 		Required: true,
+	}
+}
+
+func schema_LinkedDiskId() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeInt,
+		Computed: true,
 	}
 }
 

--- a/proxmox/resource_vm_qemu.go
+++ b/proxmox/resource_vm_qemu.go
@@ -1008,6 +1008,10 @@ func resourceVmQemu() *schema.Resource {
 				Default:     true,
 				Description: "Automatically reboot the VM if any of the modified parameters requires a reboot to take effect.",
 			},
+			"linked_vmid": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
 		},
 		Timeouts: resourceTimeouts(),
 	}

--- a/proxmox/resource_vm_qemu.go
+++ b/proxmox/resource_vm_qemu.go
@@ -2397,7 +2397,11 @@ func schema_CdRom(path string) *schema.Schema {
 		ConflictsWith: []string{path + ".disk", path + ".passthrough"},
 		Elem: &schema.Resource{
 			Schema: map[string]*schema.Schema{
-				"iso": schema_IsoFile(path + ".cdrom.0.passthrough"),
+				"iso": {
+					Type:          schema.TypeString,
+					Optional:      true,
+					ConflictsWith: []string{path + ".cdrom.0.passthrough"},
+				},
 				"passthrough": {
 					Type:          schema.TypeBool,
 					Optional:      true,
@@ -2413,26 +2417,6 @@ func schema_CloudInit() *schema.Schema {
 		Type:     schema.TypeSet,
 		Optional: true,
 		MaxItems: 1,
-		Elem: &schema.Resource{
-			Schema: map[string]*schema.Schema{
-				"file": {
-					Type:     schema.TypeString,
-					Required: true,
-				},
-				"storage": {
-					Type:     schema.TypeString,
-					Required: true,
-				},
-			},
-		},
-	}
-}
-
-func schema_IsoFile(setting string) *schema.Schema {
-	return &schema.Schema{
-		Type:          schema.TypeList,
-		Optional:      true,
-		ConflictsWith: []string{setting},
 		Elem: &schema.Resource{
 			Schema: map[string]*schema.Schema{
 				"file": {

--- a/proxmox/resource_vm_qemu.go
+++ b/proxmox/resource_vm_qemu.go
@@ -2456,8 +2456,7 @@ func schema_Ide(setting string) *schema.Schema {
 		MaxItems: 1,
 		Elem: &schema.Resource{
 			Schema: map[string]*schema.Schema{
-				"cdrom":     schema_CdRom(path),
-				"cloudinit": schema_CloudInit(),
+				"cdrom": schema_CdRom(path),
 				"disk": {
 					Type:          schema.TypeList,
 					Optional:      true,
@@ -2512,8 +2511,7 @@ func schema_Sata(setting string) *schema.Schema {
 		MaxItems: 1,
 		Elem: &schema.Resource{
 			Schema: map[string]*schema.Schema{
-				"cdrom":     schema_CdRom(path),
-				"cloudinit": schema_CloudInit(),
+				"cdrom": schema_CdRom(path),
 				"disk": {
 					Type:          schema.TypeList,
 					Optional:      true,
@@ -2568,8 +2566,7 @@ func schema_Scsi(setting string) *schema.Schema {
 		MaxItems: 1,
 		Elem: &schema.Resource{
 			Schema: map[string]*schema.Schema{
-				"cdrom":     schema_CdRom(path),
-				"cloudinit": schema_CloudInit(),
+				"cdrom": schema_CdRom(path),
 				"disk": {
 					Type:          schema.TypeList,
 					Optional:      true,
@@ -2628,8 +2625,7 @@ func schema_Virtio(setting string) *schema.Schema {
 		MaxItems: 1,
 		Elem: &schema.Resource{
 			Schema: map[string]*schema.Schema{
-				"cdrom":     schema_CdRom(path),
-				"cloudinit": schema_CloudInit(),
+				"cdrom": schema_CdRom(path),
 				"disk": {
 					Type:          schema.TypeList,
 					Optional:      true,

--- a/proxmox/resource_vm_qemu.go
+++ b/proxmox/resource_vm_qemu.go
@@ -1037,7 +1037,6 @@ func resourceVmQemuCreate(ctx context.Context, d *schema.ResourceData, meta inte
 	qemuVgaList := vga.List()
 
 	qemuNetworks, _ := ExpandDevicesList(d.Get("network").([]interface{}))
-	qemuDisks, _ := ExpandDevicesList(d.Get("disk").([]interface{}))
 
 	serials := d.Get("serial").(*schema.Set)
 	qemuSerials, _ := DevicesSetToMap(serials)
@@ -1074,7 +1073,6 @@ func resourceVmQemuCreate(ctx context.Context, d *schema.ResourceData, meta inte
 		Tags:           d.Get("tags").(string),
 		Args:           d.Get("args").(string),
 		QemuNetworks:   qemuNetworks,
-		QemuDisks:      qemuDisks,
 		QemuSerials:    qemuSerials,
 		QemuPCIDevices: qemuPCIDevices,
 		QemuUsbs:       qemuUsbs,
@@ -1088,6 +1086,11 @@ func resourceVmQemuCreate(ctx context.Context, d *schema.ResourceData, meta inte
 		Sshkeys:      d.Get("sshkeys").(string),
 		Ipconfig:     pxapi.IpconfigMap{},
 	}
+
+	config.Disks = mapToStruct_QemuStorages(d)
+	setIso(d, &config)
+	setCloudInitDisk(d, &config)
+
 	// Populate Ipconfig map
 	for i := 0; i < 16; i++ {
 		iface := fmt.Sprintf("ipconfig%d", i)
@@ -1112,6 +1115,9 @@ func resourceVmQemuCreate(ctx context.Context, d *schema.ResourceData, meta inte
 	}
 
 	vmr := dupVmr
+
+	var rebootRequired bool
+	var err error
 
 	if vmr == nil {
 		// get unique id
@@ -1161,45 +1167,16 @@ func resourceVmQemuCreate(ctx context.Context, d *schema.ResourceData, meta inte
 			// give sometime to proxmox to catchup
 			time.Sleep(time.Duration(d.Get("clone_wait").(int)) * time.Second)
 
-			config_post_clone, err := pxapi.NewConfigQemuFromApi(vmr, client)
-			if err != nil {
-				return diag.FromErr(err)
-			}
-
-			logger.Debug().Str("vmid", d.Id()).Msgf("Original disks: '%+v', Clone Disks '%+v'", config.QemuDisks, config_post_clone.QemuDisks)
-
-			// update the current working state to use the appropriate file specification
-			// proxmox needs so we can correctly update the existing disks (post-clone)
-			// instead of accidentially causing the existing disk to be detached.
-			// see https://github.com/Telmate/terraform-provider-proxmox/issues/239
-			for slot, disk := range config_post_clone.QemuDisks {
-				// only update the desired configuration if it was not set by the user
-				// we do not want to overwrite the desired config with the results from
-				// proxmox if the user indicates they wish a particular file or volume config
-				if config.QemuDisks[slot]["file"] == "" {
-					config.QemuDisks[slot]["file"] = disk["file"]
-				}
-				if config.QemuDisks[slot]["volume"] == "" {
-					config.QemuDisks[slot]["volume"] = disk["volume"]
-				}
-			}
-
-			err = config.UpdateConfig(vmr, client)
+			rebootRequired, err = config.Update(false, vmr, client)
 			if err != nil {
 				// Set the id because when update config fail the vm is still created
 				d.SetId(resourceId(targetNode, "qemu", vmr.VmId()))
 				return diag.FromErr(err)
 			}
 
-			err = prepareDiskSize(client, vmr, qemuDisks, d)
-			if err != nil {
-				d.SetId(resourceId(targetNode, "qemu", vmr.VmId()))
-				return diag.FromErr(err)
-			}
-
 		} else if d.Get("iso").(string) != "" {
 			config.QemuIso = d.Get("iso").(string)
-			err := config.CreateVm(vmr, client)
+			err := config.Create(vmr, client)
 			if err != nil {
 				return diag.FromErr(err)
 			}
@@ -1226,7 +1203,7 @@ func resourceVmQemuCreate(ctx context.Context, d *schema.ResourceData, meta inte
 				return diag.FromErr(fmt.Errorf("no network boot option matched in 'boot' config"))
 			}
 
-			err := config.CreateVm(vmr, client)
+			err := config.Create(vmr, client)
 			if err != nil {
 				return diag.FromErr(err)
 			}
@@ -1238,34 +1215,16 @@ func resourceVmQemuCreate(ctx context.Context, d *schema.ResourceData, meta inte
 
 		client.StopVm(vmr)
 
-		err := config.UpdateConfig(vmr, client)
+		rebootRequired, err = config.Update(false, vmr, client)
 		if err != nil {
 			// Set the id because when update config fail the vm is still created
 			d.SetId(resourceId(targetNode, "qemu", vmr.VmId()))
 			return diag.FromErr(err)
 		}
 
-		// give sometime to proxmox to catchup
-		// time.Sleep(time.Duration(d.Get("additional_wait").(int)) * time.Second)
-
-		err = prepareDiskSize(client, vmr, qemuDisks, d)
-		if err != nil {
-			return diag.FromErr(err)
-		}
 	}
 	d.SetId(resourceId(targetNode, "qemu", vmr.VmId()))
 	logger.Debug().Int("vmid", vmr.VmId()).Msgf("Set this vm (resource Id) to '%v'", d.Id())
-
-	if d.Get("cloudinit_cdrom_storage").(string) != "" {
-		vmParams := map[string]interface{}{
-			"cdrom": fmt.Sprintf("%s:cloudinit", d.Get("cloudinit_cdrom_storage").(string)),
-		}
-
-		_, err := client.SetVmConfig(vmr, vmParams)
-		if err != nil {
-			return diag.FromErr(err)
-		}
-	}
 
 	// give sometime to proxmox to catchup
 	time.Sleep(time.Duration(d.Get("additional_wait").(int)) * time.Second)
@@ -1288,6 +1247,7 @@ func resourceVmQemuCreate(ctx context.Context, d *schema.ResourceData, meta inte
 		log.Print("[DEBUG][QemuVmCreate] vm_state != running, not starting VM")
 	}
 
+	d.Set("reboot_required", rebootRequired)
 	log.Print("[DEBUG][QemuVmCreate] vm creation done!")
 	lock.unlock()
 	return resourceVmQemuRead(ctx, d, meta)
@@ -1316,21 +1276,6 @@ func resourceVmQemuUpdate(ctx context.Context, d *schema.ResourceData, meta inte
 	}
 	vga := d.Get("vga").(*schema.Set)
 	qemuVgaList := vga.List()
-
-	// okay, so the proxmox-api-go library is a bit weird about the updates. we can only send certain
-	// parameters about the disk over otherwise a crash happens (if we send file), or it sends duplicate keys
-	// to proxmox (if we send media). this is a bit hacky.. but it should paper over these issues until a more
-	// robust solution can be found.
-	qemuDisks, _ := ExpandDevicesList(d.Get("disk").([]interface{}))
-	for _, diskParamMap := range qemuDisks {
-		if diskParamMap["format"] == "iso" {
-			delete(diskParamMap, "format") // removed; format=iso is not a valid option for proxmox
-		}
-		if diskParamMap["media"] != "cdrom" {
-			delete(diskParamMap, "media") // removed; results in a duplicate key issue causing a 400 from proxmox
-		}
-		delete(diskParamMap, "file") // removed; causes a crash in proxmox-api-go
-	}
 
 	qemuNetworks, err := ExpandDevicesList(d.Get("network").([]interface{}))
 	if err != nil {
@@ -1389,7 +1334,6 @@ func resourceVmQemuUpdate(ctx context.Context, d *schema.ResourceData, meta inte
 		Tags:           d.Get("tags").(string),
 		Args:           d.Get("args").(string),
 		QemuNetworks:   qemuNetworks,
-		QemuDisks:      qemuDisks,
 		QemuSerials:    qemuSerials,
 		QemuPCIDevices: qemuPCIDevices,
 		QemuUsbs:       qemuUsbs,
@@ -1424,35 +1368,19 @@ func resourceVmQemuUpdate(ctx context.Context, d *schema.ResourceData, meta inte
 		config.QemuVga = qemuVgaList[0].(map[string]interface{})
 	}
 
+	config.Disks = mapToStruct_QemuStorages(d)
+	setIso(d, &config)
+	setCloudInitDisk(d, &config)
+
 	logger.Debug().Int("vmid", vmID).Msgf("Updating VM with the following configuration: %+v", config)
 
-	err = config.UpdateConfig(vmr, client)
+	var rebootRequired bool
+	// don't let the update function hande the reboot as it can't deal with cloud init changes yet
+	rebootRequired, err = config.Update(false, vmr, client)
 	if err != nil {
 		return diag.FromErr(err)
 	}
-
-	// give sometime to proxmox to catchup
-	time.Sleep(time.Duration(d.Get("additional_wait").(int)) * time.Second)
-
-	prepareDiskSize(client, vmr, qemuDisks, d)
-
-	// give sometime to proxmox to catchup
-	time.Sleep(time.Duration(d.Get("additional_wait").(int)) * time.Second)
-
-	if d.HasChange("pool") {
-		oldPool, newPool := func() (string, string) {
-			a, b := d.GetChange("pool")
-			return a.(string), b.(string)
-		}()
-
-		vmr := pxapi.NewVmRef(vmID)
-		vmr.SetPool(oldPool)
-
-		_, err := client.UpdateVMPool(vmr, newPool)
-		if err != nil {
-			return diag.FromErr(err)
-		}
-	}
+	d.Set("reboot_required", rebootRequired)
 
 	// If any of the "critical" keys are changed then a reboot is required.
 	if d.HasChanges(
@@ -1534,57 +1462,6 @@ func resourceVmQemuUpdate(ctx context.Context, d *schema.ResourceData, meta inte
 		}
 	}
 
-	// some of the disk changes require reboot, even if hotplug is enabled
-	if d.HasChange("disk") {
-		oldValuesRaw, newValuesRaw := d.GetChange("disk")
-		oldValues := oldValuesRaw.([]interface{})
-		newValues := newValuesRaw.([]interface{})
-		if len(oldValues) != len(newValues) && !strings.Contains(d.Get("hotplug").(string), "disk") {
-			// disk added or removed AND there is no disk hot(un)plug
-			d.Set("reboot_required", true)
-		} else {
-			r := len(oldValues)
-
-			// we have have to check if the new configuration has fewer disks
-			// otherwise an index out of range panic occurs if we don't reduce the range
-			if rangeNV := len(newValues); rangeNV < r {
-				r = rangeNV
-			}
-
-			// some of the existing disk parameters have changed
-			for i := 0; i < r; i++ { // loop through the interfaces
-				if oldValues[i].(map[string]interface{})["ssd"] != newValues[i].(map[string]interface{})["ssd"] {
-					d.Set("reboot_required", true)
-				}
-				if oldValues[i].(map[string]interface{})["iothread"] != newValues[i].(map[string]interface{})["iothread"] {
-					d.Set("reboot_required", true)
-				}
-				if oldValues[i].(map[string]interface{})["discard"] != newValues[i].(map[string]interface{})["discard"] {
-					d.Set("reboot_required", true)
-				}
-				if oldValues[i].(map[string]interface{})["cache"] != newValues[i].(map[string]interface{})["cache"] {
-					d.Set("reboot_required", true)
-				}
-				if oldValues[i].(map[string]interface{})["size"] != newValues[i].(map[string]interface{})["size"] {
-					d.Set("reboot_required", true)
-				}
-				if oldValues[i].(map[string]interface{})["serial"] != newValues[i].(map[string]interface{})["serial"] {
-					d.Set("reboot_required", true)
-				}
-				if oldValues[i].(map[string]interface{})["wwn"] != newValues[i].(map[string]interface{})["wwn"] {
-					d.Set("reboot_required", true)
-				}
-				// these paramater changes only require reboot if disk hotplug is disabled
-				if !strings.Contains(d.Get("hotplug").(string), "disk") {
-					if oldValues[i].(map[string]interface{})["type"] != newValues[i].(map[string]interface{})["type"] {
-						// note: changing type does not remove the old disk
-						d.Set("reboot_required", true)
-					}
-				}
-			}
-		}
-	}
-
 	var diags diag.Diagnostics
 
 	// Try rebooting the VM is a reboot is required and automatic_reboot is
@@ -1612,6 +1489,8 @@ func resourceVmQemuUpdate(ctx context.Context, d *schema.ResourceData, meta inte
 				if err != nil {
 					return diag.FromErr(err)
 				}
+				// Set reboot_required to false if reboot was successfull
+				d.Set("reboot_required", false)
 			}
 		} else {
 			// Automatic reboots is not enabled, show the user a warning message that
@@ -1629,6 +1508,8 @@ func resourceVmQemuUpdate(ctx context.Context, d *schema.ResourceData, meta inte
 		if err != nil {
 			return diag.FromErr(err)
 		}
+		// Set reboot_required to false if vm was not running.
+		d.Set("reboot_required", false)
 	} else if err != nil {
 		diags = append(diags, diag.FromErr(err)...)
 		return diags
@@ -1758,6 +1639,10 @@ func resourceVmQemuRead(ctx context.Context, d *schema.ResourceData, meta interf
 	d.Set("ipconfig15", config.Ipconfig[15])
 
 	d.Set("smbios", ReadSmbiosArgs(config.Smbios1))
+	d.Set("linked_vmid", config.LinkedVmId)
+	d.Set("disks", mapFromStruct_ConfigQemu(config.Disks))
+	d.Set("iso", getIso(config.Disks))
+	d.Set("cloudinit_cdrom_storage", getCloudInitDisk(config.Disks))
 
 	// Some dirty hacks to populate undefined keys with default values.
 	// TODO: remove "oncreate" handling in next major release.
@@ -1947,59 +1832,6 @@ func resourceVmQemuDelete(ctx context.Context, d *schema.ResourceData, meta inte
 
 	_, err = client.DeleteVm(vmr)
 	return diag.FromErr(err)
-}
-
-// Increase disk size if original disk was smaller than new disk.
-func prepareDiskSize(
-	client *pxapi.Client,
-	vmr *pxapi.VmRef,
-	diskConfMap pxapi.QemuDevices,
-	d *schema.ResourceData,
-) error {
-	logger, _ := CreateSubLogger("prepareDiskSize")
-	clonedConfig, err := pxapi.NewConfigQemuFromApi(vmr, client)
-	if err != nil {
-		return err
-	}
-	// log.Printf("%s", clonedConfig)
-	for diskID, diskConf := range diskConfMap {
-		if diskConf["media"] == "cdrom" {
-			continue
-		}
-		diskName := fmt.Sprintf("%v%v", diskConf["type"], diskID)
-
-		diskSize := pxapi.DiskSizeGB(diskConf["size"])
-
-		if _, diskExists := clonedConfig.QemuDisks[diskID]; !diskExists {
-			return err
-		}
-
-		clonedDiskSize := pxapi.DiskSizeGB(clonedConfig.QemuDisks[diskID]["size"])
-
-		if err != nil {
-			return err
-		}
-
-		logger.Debug().Int("diskId", diskID).Msgf("Checking disk sizing. Original '%+v', New '%+v'", fmt.Sprintf("%vG", clonedDiskSize), fmt.Sprintf("%vG", diskSize))
-		if diskSize > clonedDiskSize {
-			logger.Debug().Int("diskId", diskID).Msgf("Resizing disk")
-			for ii := 0; ii < 5; ii++ {
-				_, err = client.ResizeQemuDiskRaw(vmr, diskName, fmt.Sprintf("%vG", diskSize))
-				if err == nil {
-					break
-				}
-				logger.Debug().Int("diskId", diskID).Msgf("Error returned from api: %+v", err)
-				// wait before next try
-				time.Sleep(time.Duration(d.Get("additional_wait").(int)) * time.Second)
-			}
-		} else if diskSize == clonedDiskSize || diskSize <= 0 {
-			logger.Debug().Int("diskId", diskID).Msgf("Disk is same size as before, skipping resize. Original '%+v', New '%+v'", fmt.Sprintf("%vG", clonedDiskSize), fmt.Sprintf("%vG", diskSize))
-		} else {
-			return fmt.Errorf("proxmox does not support decreasing disk size. Disk '%v' wanted to go from '%vG' to '%vG'", diskName, fmt.Sprintf("%vG", clonedDiskSize), fmt.Sprintf("%vG", diskSize))
-		}
-
-	}
-	return nil
 }
 
 // Converting from schema.TypeSet to map of id and conf for each device,

--- a/proxmox/resource_vm_qemu.go
+++ b/proxmox/resource_vm_qemu.go
@@ -616,10 +616,10 @@ func resourceVmQemu() *schema.Resource {
 							MaxItems: 1,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
-									"disk_0": schema_Ide("disk_0"),
-									"disk_1": schema_Ide("disk_1"),
-									// disk_2 reserved for cdrom
-									// disk_3 reserved for cloudinit
+									"ide0": schema_Ide("ide0"),
+									"ide1": schema_Ide("ide1"),
+									// ide2 reserved for cdrom
+									// ide3 reserved for cloudinit
 								},
 							},
 						},
@@ -629,12 +629,12 @@ func resourceVmQemu() *schema.Resource {
 							MaxItems: 1,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
-									"disk_0": schema_Sata("disk_0"),
-									"disk_1": schema_Sata("disk_1"),
-									"disk_2": schema_Sata("disk_2"),
-									"disk_3": schema_Sata("disk_3"),
-									"disk_4": schema_Sata("disk_4"),
-									"disk_5": schema_Sata("disk_5"),
+									"sata0": schema_Sata("sata0"),
+									"sata1": schema_Sata("sata1"),
+									"sata2": schema_Sata("sata2"),
+									"sata3": schema_Sata("sata3"),
+									"sata4": schema_Sata("sata4"),
+									"sata5": schema_Sata("sata5"),
 								},
 							},
 						},
@@ -644,37 +644,37 @@ func resourceVmQemu() *schema.Resource {
 							MaxItems: 1,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
-									"disk_0":  schema_Scsi("disk_0"),
-									"disk_1":  schema_Scsi("disk_1"),
-									"disk_2":  schema_Scsi("disk_2"),
-									"disk_3":  schema_Scsi("disk_3"),
-									"disk_4":  schema_Scsi("disk_4"),
-									"disk_5":  schema_Scsi("disk_5"),
-									"disk_6":  schema_Scsi("disk_6"),
-									"disk_7":  schema_Scsi("disk_7"),
-									"disk_8":  schema_Scsi("disk_8"),
-									"disk_9":  schema_Scsi("disk_9"),
-									"disk_10": schema_Scsi("disk_10"),
-									"disk_11": schema_Scsi("disk_11"),
-									"disk_12": schema_Scsi("disk_12"),
-									"disk_13": schema_Scsi("disk_13"),
-									"disk_14": schema_Scsi("disk_14"),
-									"disk_15": schema_Scsi("disk_15"),
-									"disk_16": schema_Scsi("disk_16"),
-									"disk_17": schema_Scsi("disk_17"),
-									"disk_18": schema_Scsi("disk_18"),
-									"disk_19": schema_Scsi("disk_19"),
-									"disk_20": schema_Scsi("disk_20"),
-									"disk_21": schema_Scsi("disk_21"),
-									"disk_22": schema_Scsi("disk_22"),
-									"disk_23": schema_Scsi("disk_23"),
-									"disk_24": schema_Scsi("disk_24"),
-									"disk_25": schema_Scsi("disk_25"),
-									"disk_26": schema_Scsi("disk_26"),
-									"disk_27": schema_Scsi("disk_27"),
-									"disk_28": schema_Scsi("disk_28"),
-									"disk_29": schema_Scsi("disk_29"),
-									"disk_30": schema_Scsi("disk_30"),
+									"scsi0":  schema_Scsi("scsi0"),
+									"scsi1":  schema_Scsi("scsi1"),
+									"scsi2":  schema_Scsi("scsi2"),
+									"scsi3":  schema_Scsi("scsi3"),
+									"scsi4":  schema_Scsi("scsi4"),
+									"scsi5":  schema_Scsi("scsi5"),
+									"scsi6":  schema_Scsi("scsi6"),
+									"scsi7":  schema_Scsi("scsi7"),
+									"scsi8":  schema_Scsi("scsi8"),
+									"scsi9":  schema_Scsi("scsi9"),
+									"scsi10": schema_Scsi("scsi10"),
+									"scsi11": schema_Scsi("scsi11"),
+									"scsi12": schema_Scsi("scsi12"),
+									"scsi13": schema_Scsi("scsi13"),
+									"scsi14": schema_Scsi("scsi14"),
+									"scsi15": schema_Scsi("scsi15"),
+									"scsi16": schema_Scsi("scsi16"),
+									"scsi17": schema_Scsi("scsi17"),
+									"scsi18": schema_Scsi("scsi18"),
+									"scsi19": schema_Scsi("scsi19"),
+									"scsi20": schema_Scsi("scsi20"),
+									"scsi21": schema_Scsi("scsi21"),
+									"scsi22": schema_Scsi("scsi22"),
+									"scsi23": schema_Scsi("scsi23"),
+									"scsi24": schema_Scsi("scsi24"),
+									"scsi25": schema_Scsi("scsi25"),
+									"scsi26": schema_Scsi("scsi26"),
+									"scsi27": schema_Scsi("scsi27"),
+									"scsi28": schema_Scsi("scsi28"),
+									"scsi29": schema_Scsi("scsi29"),
+									"scsi30": schema_Scsi("scsi30"),
 								},
 							},
 						},
@@ -684,22 +684,22 @@ func resourceVmQemu() *schema.Resource {
 							MaxItems: 1,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
-									"disk_0":  schema_Virtio("disk_0"),
-									"disk_1":  schema_Virtio("disk_1"),
-									"disk_2":  schema_Virtio("disk_2"),
-									"disk_3":  schema_Virtio("disk_3"),
-									"disk_4":  schema_Virtio("disk_4"),
-									"disk_5":  schema_Virtio("disk_5"),
-									"disk_6":  schema_Virtio("disk_6"),
-									"disk_7":  schema_Virtio("disk_7"),
-									"disk_8":  schema_Virtio("disk_8"),
-									"disk_9":  schema_Virtio("disk_9"),
-									"disk_10": schema_Virtio("disk_10"),
-									"disk_11": schema_Virtio("disk_11"),
-									"disk_12": schema_Virtio("disk_12"),
-									"disk_13": schema_Virtio("disk_13"),
-									"disk_14": schema_Virtio("disk_14"),
-									"disk_15": schema_Virtio("disk_15"),
+									"virtio0":  schema_Virtio("virtio0"),
+									"virtio1":  schema_Virtio("virtio1"),
+									"virtio2":  schema_Virtio("virtio2"),
+									"virtio3":  schema_Virtio("virtio3"),
+									"virtio4":  schema_Virtio("virtio4"),
+									"virtio5":  schema_Virtio("virtio5"),
+									"virtio6":  schema_Virtio("virtio6"),
+									"virtio7":  schema_Virtio("virtio7"),
+									"virtio8":  schema_Virtio("virtio8"),
+									"virtio9":  schema_Virtio("virtio9"),
+									"virtio10": schema_Virtio("virtio10"),
+									"virtio11": schema_Virtio("virtio11"),
+									"virtio12": schema_Virtio("virtio12"),
+									"virtio13": schema_Virtio("virtio13"),
+									"virtio14": schema_Virtio("virtio14"),
+									"virtio15": schema_Virtio("virtio15"),
 								},
 							},
 						},
@@ -2487,8 +2487,8 @@ func mapFromStruct_QemuIdeDisks(config *pxapi.QemuIdeDisks) []interface{} {
 	}
 	return []interface{}{
 		map[string]interface{}{
-			"disk_0": mapFromStruct_QemuIdeStorage(config.Disk_0, "disk_0"),
-			"disk_1": mapFromStruct_QemuIdeStorage(config.Disk_1, "disk_1"),
+			"ide0": mapFromStruct_QemuIdeStorage(config.Disk_0, "ide0"),
+			"ide1": mapFromStruct_QemuIdeStorage(config.Disk_1, "ide1"),
 		},
 	}
 }
@@ -2547,12 +2547,12 @@ func mapFromStruct_QemuSataDisks(config *pxapi.QemuSataDisks) []interface{} {
 	}
 	return []interface{}{
 		map[string]interface{}{
-			"disk_0": mapFromStruct_QemuSataStorage(config.Disk_0, "disk_0"),
-			"disk_1": mapFromStruct_QemuSataStorage(config.Disk_1, "disk_1"),
-			"disk_2": mapFromStruct_QemuSataStorage(config.Disk_2, "disk_2"),
-			"disk_3": mapFromStruct_QemuSataStorage(config.Disk_3, "disk_3"),
-			"disk_4": mapFromStruct_QemuSataStorage(config.Disk_4, "disk_4"),
-			"disk_5": mapFromStruct_QemuSataStorage(config.Disk_5, "disk_5"),
+			"sata0": mapFromStruct_QemuSataStorage(config.Disk_0, "sata0"),
+			"sata1": mapFromStruct_QemuSataStorage(config.Disk_1, "sata1"),
+			"sata2": mapFromStruct_QemuSataStorage(config.Disk_2, "sata2"),
+			"sata3": mapFromStruct_QemuSataStorage(config.Disk_3, "sata3"),
+			"sata4": mapFromStruct_QemuSataStorage(config.Disk_4, "sata4"),
+			"sata5": mapFromStruct_QemuSataStorage(config.Disk_5, "sata5"),
 		},
 	}
 }
@@ -2611,37 +2611,37 @@ func mapFromStruct_QemuScsiDisks(config *pxapi.QemuScsiDisks) []interface{} {
 	}
 	return []interface{}{
 		map[string]interface{}{
-			"disk_0":  mapFromStruct_QemuScsiStorage(config.Disk_0, "disk_0"),
-			"disk_1":  mapFromStruct_QemuScsiStorage(config.Disk_1, "disk_1"),
-			"disk_2":  mapFromStruct_QemuScsiStorage(config.Disk_2, "disk_2"),
-			"disk_3":  mapFromStruct_QemuScsiStorage(config.Disk_3, "disk_3"),
-			"disk_4":  mapFromStruct_QemuScsiStorage(config.Disk_4, "disk_4"),
-			"disk_5":  mapFromStruct_QemuScsiStorage(config.Disk_5, "disk_5"),
-			"disk_6":  mapFromStruct_QemuScsiStorage(config.Disk_6, "disk_6"),
-			"disk_7":  mapFromStruct_QemuScsiStorage(config.Disk_7, "disk_7"),
-			"disk_8":  mapFromStruct_QemuScsiStorage(config.Disk_8, "disk_8"),
-			"disk_9":  mapFromStruct_QemuScsiStorage(config.Disk_9, "disk_9"),
-			"disk_10": mapFromStruct_QemuScsiStorage(config.Disk_10, "disk_10"),
-			"disk_11": mapFromStruct_QemuScsiStorage(config.Disk_11, "disk_11"),
-			"disk_12": mapFromStruct_QemuScsiStorage(config.Disk_12, "disk_12"),
-			"disk_13": mapFromStruct_QemuScsiStorage(config.Disk_13, "disk_13"),
-			"disk_14": mapFromStruct_QemuScsiStorage(config.Disk_14, "disk_14"),
-			"disk_15": mapFromStruct_QemuScsiStorage(config.Disk_15, "disk_15"),
-			"disk_16": mapFromStruct_QemuScsiStorage(config.Disk_16, "disk_16"),
-			"disk_17": mapFromStruct_QemuScsiStorage(config.Disk_17, "disk_17"),
-			"disk_18": mapFromStruct_QemuScsiStorage(config.Disk_18, "disk_18"),
-			"disk_19": mapFromStruct_QemuScsiStorage(config.Disk_19, "disk_19"),
-			"disk_20": mapFromStruct_QemuScsiStorage(config.Disk_20, "disk_20"),
-			"disk_21": mapFromStruct_QemuScsiStorage(config.Disk_21, "disk_21"),
-			"disk_22": mapFromStruct_QemuScsiStorage(config.Disk_22, "disk_22"),
-			"disk_23": mapFromStruct_QemuScsiStorage(config.Disk_23, "disk_23"),
-			"disk_24": mapFromStruct_QemuScsiStorage(config.Disk_24, "disk_24"),
-			"disk_25": mapFromStruct_QemuScsiStorage(config.Disk_25, "disk_25"),
-			"disk_26": mapFromStruct_QemuScsiStorage(config.Disk_26, "disk_26"),
-			"disk_27": mapFromStruct_QemuScsiStorage(config.Disk_27, "disk_27"),
-			"disk_28": mapFromStruct_QemuScsiStorage(config.Disk_28, "disk_28"),
-			"disk_29": mapFromStruct_QemuScsiStorage(config.Disk_29, "disk_29"),
-			"disk_30": mapFromStruct_QemuScsiStorage(config.Disk_30, "disk_30"),
+			"scsi0":  mapFromStruct_QemuScsiStorage(config.Disk_0, "scsi0"),
+			"scsi1":  mapFromStruct_QemuScsiStorage(config.Disk_1, "scsi1"),
+			"scsi2":  mapFromStruct_QemuScsiStorage(config.Disk_2, "scsi2"),
+			"scsi3":  mapFromStruct_QemuScsiStorage(config.Disk_3, "scsi3"),
+			"scsi4":  mapFromStruct_QemuScsiStorage(config.Disk_4, "scsi4"),
+			"scsi5":  mapFromStruct_QemuScsiStorage(config.Disk_5, "scsi5"),
+			"scsi6":  mapFromStruct_QemuScsiStorage(config.Disk_6, "scsi6"),
+			"scsi7":  mapFromStruct_QemuScsiStorage(config.Disk_7, "scsi7"),
+			"scsi8":  mapFromStruct_QemuScsiStorage(config.Disk_8, "scsi8"),
+			"scsi9":  mapFromStruct_QemuScsiStorage(config.Disk_9, "scsi9"),
+			"scsi10": mapFromStruct_QemuScsiStorage(config.Disk_10, "scsi10"),
+			"scsi11": mapFromStruct_QemuScsiStorage(config.Disk_11, "scsi11"),
+			"scsi12": mapFromStruct_QemuScsiStorage(config.Disk_12, "scsi12"),
+			"scsi13": mapFromStruct_QemuScsiStorage(config.Disk_13, "scsi13"),
+			"scsi14": mapFromStruct_QemuScsiStorage(config.Disk_14, "scsi14"),
+			"scsi15": mapFromStruct_QemuScsiStorage(config.Disk_15, "scsi15"),
+			"scsi16": mapFromStruct_QemuScsiStorage(config.Disk_16, "scsi16"),
+			"scsi17": mapFromStruct_QemuScsiStorage(config.Disk_17, "scsi17"),
+			"scsi18": mapFromStruct_QemuScsiStorage(config.Disk_18, "scsi18"),
+			"scsi19": mapFromStruct_QemuScsiStorage(config.Disk_19, "scsi19"),
+			"scsi20": mapFromStruct_QemuScsiStorage(config.Disk_20, "scsi20"),
+			"scsi21": mapFromStruct_QemuScsiStorage(config.Disk_21, "scsi21"),
+			"scsi22": mapFromStruct_QemuScsiStorage(config.Disk_22, "scsi22"),
+			"scsi23": mapFromStruct_QemuScsiStorage(config.Disk_23, "scsi23"),
+			"scsi24": mapFromStruct_QemuScsiStorage(config.Disk_24, "scsi24"),
+			"scsi25": mapFromStruct_QemuScsiStorage(config.Disk_25, "scsi25"),
+			"scsi26": mapFromStruct_QemuScsiStorage(config.Disk_26, "scsi26"),
+			"scsi27": mapFromStruct_QemuScsiStorage(config.Disk_27, "scsi27"),
+			"scsi28": mapFromStruct_QemuScsiStorage(config.Disk_28, "scsi28"),
+			"scsi29": mapFromStruct_QemuScsiStorage(config.Disk_29, "scsi29"),
+			"scsi30": mapFromStruct_QemuScsiStorage(config.Disk_30, "scsi30"),
 		},
 	}
 }
@@ -2704,22 +2704,22 @@ func mapFromStruct_QemuVirtIODisks(config *pxapi.QemuVirtIODisks) []interface{} 
 	}
 	return []interface{}{
 		map[string]interface{}{
-			"disk_0":  mapFromStruct_QemuVirtIOStorage(config.Disk_0, "disk_0"),
-			"disk_1":  mapFromStruct_QemuVirtIOStorage(config.Disk_1, "disk_1"),
-			"disk_2":  mapFromStruct_QemuVirtIOStorage(config.Disk_2, "disk_2"),
-			"disk_3":  mapFromStruct_QemuVirtIOStorage(config.Disk_3, "disk_3"),
-			"disk_4":  mapFromStruct_QemuVirtIOStorage(config.Disk_4, "disk_4"),
-			"disk_5":  mapFromStruct_QemuVirtIOStorage(config.Disk_5, "disk_5"),
-			"disk_6":  mapFromStruct_QemuVirtIOStorage(config.Disk_6, "disk_6"),
-			"disk_7":  mapFromStruct_QemuVirtIOStorage(config.Disk_7, "disk_7"),
-			"disk_8":  mapFromStruct_QemuVirtIOStorage(config.Disk_8, "disk_8"),
-			"disk_9":  mapFromStruct_QemuVirtIOStorage(config.Disk_9, "disk_9"),
-			"disk_10": mapFromStruct_QemuVirtIOStorage(config.Disk_10, "disk_10"),
-			"disk_11": mapFromStruct_QemuVirtIOStorage(config.Disk_11, "disk_11"),
-			"disk_12": mapFromStruct_QemuVirtIOStorage(config.Disk_12, "disk_12"),
-			"disk_13": mapFromStruct_QemuVirtIOStorage(config.Disk_13, "disk_13"),
-			"disk_14": mapFromStruct_QemuVirtIOStorage(config.Disk_14, "disk_14"),
-			"disk_15": mapFromStruct_QemuVirtIOStorage(config.Disk_15, "disk_15"),
+			"virtio0":  mapFromStruct_QemuVirtIOStorage(config.Disk_0, "virtio0"),
+			"virtio1":  mapFromStruct_QemuVirtIOStorage(config.Disk_1, "virtio1"),
+			"virtio2":  mapFromStruct_QemuVirtIOStorage(config.Disk_2, "virtio2"),
+			"virtio3":  mapFromStruct_QemuVirtIOStorage(config.Disk_3, "virtio3"),
+			"virtio4":  mapFromStruct_QemuVirtIOStorage(config.Disk_4, "virtio4"),
+			"virtio5":  mapFromStruct_QemuVirtIOStorage(config.Disk_5, "virtio5"),
+			"virtio6":  mapFromStruct_QemuVirtIOStorage(config.Disk_6, "virtio6"),
+			"virtio7":  mapFromStruct_QemuVirtIOStorage(config.Disk_7, "virtio7"),
+			"virtio8":  mapFromStruct_QemuVirtIOStorage(config.Disk_8, "virtio8"),
+			"virtio9":  mapFromStruct_QemuVirtIOStorage(config.Disk_9, "virtio9"),
+			"virtio10": mapFromStruct_QemuVirtIOStorage(config.Disk_10, "virtio10"),
+			"virtio11": mapFromStruct_QemuVirtIOStorage(config.Disk_11, "virtio11"),
+			"virtio12": mapFromStruct_QemuVirtIOStorage(config.Disk_12, "virtio12"),
+			"virtio13": mapFromStruct_QemuVirtIOStorage(config.Disk_13, "virtio13"),
+			"virtio14": mapFromStruct_QemuVirtIOStorage(config.Disk_14, "virtio14"),
+			"virtio15": mapFromStruct_QemuVirtIOStorage(config.Disk_15, "virtio15"),
 		},
 	}
 }
@@ -2838,8 +2838,8 @@ func mapToStruct_QemuIdeDisks(ide *pxapi.QemuIdeDisks, schema map[string]interfa
 		return
 	}
 	disks := schemaItem[0].(map[string]interface{})
-	mapToStruct_QemuIdeStorage(ide.Disk_0, "disk_0", disks)
-	mapToStruct_QemuIdeStorage(ide.Disk_1, "disk_1", disks)
+	mapToStruct_QemuIdeStorage(ide.Disk_0, "ide0", disks)
+	mapToStruct_QemuIdeStorage(ide.Disk_1, "ide1", disks)
 }
 
 func mapToStruct_QemuIdeStorage(ide *pxapi.QemuIdeStorage, key string, schema map[string]interface{}) {
@@ -2903,12 +2903,12 @@ func mapToStruct_QemuSataDisks(sata *pxapi.QemuSataDisks, schema map[string]inte
 		return
 	}
 	disks := schemaItem[0].(map[string]interface{})
-	mapToStruct_QemuSataStorage(sata.Disk_0, "disk_0", disks)
-	mapToStruct_QemuSataStorage(sata.Disk_1, "disk_1", disks)
-	mapToStruct_QemuSataStorage(sata.Disk_2, "disk_2", disks)
-	mapToStruct_QemuSataStorage(sata.Disk_3, "disk_3", disks)
-	mapToStruct_QemuSataStorage(sata.Disk_4, "disk_4", disks)
-	mapToStruct_QemuSataStorage(sata.Disk_5, "disk_5", disks)
+	mapToStruct_QemuSataStorage(sata.Disk_0, "sata0", disks)
+	mapToStruct_QemuSataStorage(sata.Disk_1, "sata1", disks)
+	mapToStruct_QemuSataStorage(sata.Disk_2, "sata2", disks)
+	mapToStruct_QemuSataStorage(sata.Disk_3, "sata3", disks)
+	mapToStruct_QemuSataStorage(sata.Disk_4, "sata4", disks)
+	mapToStruct_QemuSataStorage(sata.Disk_5, "sata5", disks)
 }
 
 func mapToStruct_QemuSataStorage(sata *pxapi.QemuSataStorage, key string, schema map[string]interface{}) {
@@ -2972,37 +2972,37 @@ func mapToStruct_QemuScsiDisks(scsi *pxapi.QemuScsiDisks, schema map[string]inte
 		return
 	}
 	disks := schemaItem[0].(map[string]interface{})
-	mapToStruct_QemuScsiStorage(scsi.Disk_0, "disk_0", disks)
-	mapToStruct_QemuScsiStorage(scsi.Disk_1, "disk_1", disks)
-	mapToStruct_QemuScsiStorage(scsi.Disk_2, "disk_2", disks)
-	mapToStruct_QemuScsiStorage(scsi.Disk_3, "disk_3", disks)
-	mapToStruct_QemuScsiStorage(scsi.Disk_4, "disk_4", disks)
-	mapToStruct_QemuScsiStorage(scsi.Disk_5, "disk_5", disks)
-	mapToStruct_QemuScsiStorage(scsi.Disk_6, "disk_6", disks)
-	mapToStruct_QemuScsiStorage(scsi.Disk_7, "disk_7", disks)
-	mapToStruct_QemuScsiStorage(scsi.Disk_8, "disk_8", disks)
-	mapToStruct_QemuScsiStorage(scsi.Disk_9, "disk_9", disks)
-	mapToStruct_QemuScsiStorage(scsi.Disk_10, "disk_10", disks)
-	mapToStruct_QemuScsiStorage(scsi.Disk_11, "disk_11", disks)
-	mapToStruct_QemuScsiStorage(scsi.Disk_12, "disk_12", disks)
-	mapToStruct_QemuScsiStorage(scsi.Disk_13, "disk_13", disks)
-	mapToStruct_QemuScsiStorage(scsi.Disk_14, "disk_14", disks)
-	mapToStruct_QemuScsiStorage(scsi.Disk_15, "disk_15", disks)
-	mapToStruct_QemuScsiStorage(scsi.Disk_16, "disk_16", disks)
-	mapToStruct_QemuScsiStorage(scsi.Disk_17, "disk_17", disks)
-	mapToStruct_QemuScsiStorage(scsi.Disk_18, "disk_18", disks)
-	mapToStruct_QemuScsiStorage(scsi.Disk_19, "disk_19", disks)
-	mapToStruct_QemuScsiStorage(scsi.Disk_20, "disk_20", disks)
-	mapToStruct_QemuScsiStorage(scsi.Disk_21, "disk_21", disks)
-	mapToStruct_QemuScsiStorage(scsi.Disk_22, "disk_22", disks)
-	mapToStruct_QemuScsiStorage(scsi.Disk_23, "disk_23", disks)
-	mapToStruct_QemuScsiStorage(scsi.Disk_24, "disk_24", disks)
-	mapToStruct_QemuScsiStorage(scsi.Disk_25, "disk_25", disks)
-	mapToStruct_QemuScsiStorage(scsi.Disk_26, "disk_26", disks)
-	mapToStruct_QemuScsiStorage(scsi.Disk_27, "disk_27", disks)
-	mapToStruct_QemuScsiStorage(scsi.Disk_28, "disk_28", disks)
-	mapToStruct_QemuScsiStorage(scsi.Disk_29, "disk_29", disks)
-	mapToStruct_QemuScsiStorage(scsi.Disk_30, "disk_30", disks)
+	mapToStruct_QemuScsiStorage(scsi.Disk_0, "scsi0", disks)
+	mapToStruct_QemuScsiStorage(scsi.Disk_1, "scsi1", disks)
+	mapToStruct_QemuScsiStorage(scsi.Disk_2, "scsi2", disks)
+	mapToStruct_QemuScsiStorage(scsi.Disk_3, "scsi3", disks)
+	mapToStruct_QemuScsiStorage(scsi.Disk_4, "scsi4", disks)
+	mapToStruct_QemuScsiStorage(scsi.Disk_5, "scsi5", disks)
+	mapToStruct_QemuScsiStorage(scsi.Disk_6, "scsi6", disks)
+	mapToStruct_QemuScsiStorage(scsi.Disk_7, "scsi7", disks)
+	mapToStruct_QemuScsiStorage(scsi.Disk_8, "scsi8", disks)
+	mapToStruct_QemuScsiStorage(scsi.Disk_9, "scsi9", disks)
+	mapToStruct_QemuScsiStorage(scsi.Disk_10, "scsi10", disks)
+	mapToStruct_QemuScsiStorage(scsi.Disk_11, "scsi11", disks)
+	mapToStruct_QemuScsiStorage(scsi.Disk_12, "scsi12", disks)
+	mapToStruct_QemuScsiStorage(scsi.Disk_13, "scsi13", disks)
+	mapToStruct_QemuScsiStorage(scsi.Disk_14, "scsi14", disks)
+	mapToStruct_QemuScsiStorage(scsi.Disk_15, "scsi15", disks)
+	mapToStruct_QemuScsiStorage(scsi.Disk_16, "scsi16", disks)
+	mapToStruct_QemuScsiStorage(scsi.Disk_17, "scsi17", disks)
+	mapToStruct_QemuScsiStorage(scsi.Disk_18, "scsi18", disks)
+	mapToStruct_QemuScsiStorage(scsi.Disk_19, "scsi19", disks)
+	mapToStruct_QemuScsiStorage(scsi.Disk_20, "scsi20", disks)
+	mapToStruct_QemuScsiStorage(scsi.Disk_21, "scsi21", disks)
+	mapToStruct_QemuScsiStorage(scsi.Disk_22, "scsi22", disks)
+	mapToStruct_QemuScsiStorage(scsi.Disk_23, "scsi23", disks)
+	mapToStruct_QemuScsiStorage(scsi.Disk_24, "scsi24", disks)
+	mapToStruct_QemuScsiStorage(scsi.Disk_25, "scsi25", disks)
+	mapToStruct_QemuScsiStorage(scsi.Disk_26, "scsi26", disks)
+	mapToStruct_QemuScsiStorage(scsi.Disk_27, "scsi27", disks)
+	mapToStruct_QemuScsiStorage(scsi.Disk_28, "scsi28", disks)
+	mapToStruct_QemuScsiStorage(scsi.Disk_29, "scsi29", disks)
+	mapToStruct_QemuScsiStorage(scsi.Disk_30, "scsi30", disks)
 }
 
 func mapToStruct_QemuScsiStorage(scsi *pxapi.QemuScsiStorage, key string, schema map[string]interface{}) {
@@ -3150,22 +3150,22 @@ func mapToStruct_QemuVirtIODisks(virtio *pxapi.QemuVirtIODisks, schema map[strin
 		return
 	}
 	disks := schemaItem[0].(map[string]interface{})
-	mapToStruct_VirtIOStorage(virtio.Disk_0, "disk_0", disks)
-	mapToStruct_VirtIOStorage(virtio.Disk_1, "disk_1", disks)
-	mapToStruct_VirtIOStorage(virtio.Disk_2, "disk_2", disks)
-	mapToStruct_VirtIOStorage(virtio.Disk_3, "disk_3", disks)
-	mapToStruct_VirtIOStorage(virtio.Disk_4, "disk_4", disks)
-	mapToStruct_VirtIOStorage(virtio.Disk_5, "disk_5", disks)
-	mapToStruct_VirtIOStorage(virtio.Disk_6, "disk_6", disks)
-	mapToStruct_VirtIOStorage(virtio.Disk_7, "disk_7", disks)
-	mapToStruct_VirtIOStorage(virtio.Disk_8, "disk_8", disks)
-	mapToStruct_VirtIOStorage(virtio.Disk_9, "disk_9", disks)
-	mapToStruct_VirtIOStorage(virtio.Disk_10, "disk_10", disks)
-	mapToStruct_VirtIOStorage(virtio.Disk_11, "disk_11", disks)
-	mapToStruct_VirtIOStorage(virtio.Disk_12, "disk_12", disks)
-	mapToStruct_VirtIOStorage(virtio.Disk_13, "disk_13", disks)
-	mapToStruct_VirtIOStorage(virtio.Disk_14, "disk_14", disks)
-	mapToStruct_VirtIOStorage(virtio.Disk_15, "disk_15", disks)
+	mapToStruct_VirtIOStorage(virtio.Disk_0, "virtio0", disks)
+	mapToStruct_VirtIOStorage(virtio.Disk_1, "virtio1", disks)
+	mapToStruct_VirtIOStorage(virtio.Disk_2, "virtio2", disks)
+	mapToStruct_VirtIOStorage(virtio.Disk_3, "virtio3", disks)
+	mapToStruct_VirtIOStorage(virtio.Disk_4, "virtio4", disks)
+	mapToStruct_VirtIOStorage(virtio.Disk_5, "virtio5", disks)
+	mapToStruct_VirtIOStorage(virtio.Disk_6, "virtio6", disks)
+	mapToStruct_VirtIOStorage(virtio.Disk_7, "virtio7", disks)
+	mapToStruct_VirtIOStorage(virtio.Disk_8, "virtio8", disks)
+	mapToStruct_VirtIOStorage(virtio.Disk_9, "virtio9", disks)
+	mapToStruct_VirtIOStorage(virtio.Disk_10, "virtio10", disks)
+	mapToStruct_VirtIOStorage(virtio.Disk_11, "virtio11", disks)
+	mapToStruct_VirtIOStorage(virtio.Disk_12, "virtio12", disks)
+	mapToStruct_VirtIOStorage(virtio.Disk_13, "virtio13", disks)
+	mapToStruct_VirtIOStorage(virtio.Disk_14, "virtio14", disks)
+	mapToStruct_VirtIOStorage(virtio.Disk_15, "virtio15", disks)
 }
 
 func mapToStruct_VirtIOStorage(virtio *pxapi.QemuVirtIOStorage, key string, schema map[string]interface{}) {

--- a/proxmox/resource_vm_qemu.go
+++ b/proxmox/resource_vm_qemu.go
@@ -416,6 +416,7 @@ func resourceVmQemu() *schema.Resource {
 			"disk": {
 				Type:          schema.TypeList,
 				Optional:      true,
+				Deprecated:    "Use `disks` instead",
 				ConflictsWith: []string{"disk_gb", "storage", "storage_type"},
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{

--- a/proxmox/validators.go
+++ b/proxmox/validators.go
@@ -1,7 +1,6 @@
 package proxmox
 
 import (
-	"fmt"
 	"strconv"
 	"strings"
 
@@ -95,13 +94,12 @@ func VMStateValidator() schema.SchemaValidateDiagFunc {
 	}, false))
 }
 
-func uint_Validator() schema.SchemaValidateFunc {
-	return func(i interface{}, k string) (warnings []string, errors []error) {
+func uint_Validator() schema.SchemaValidateDiagFunc {
+	return func(i interface{}, k cty.Path) diag.Diagnostics {
 		v, ok := i.(int)
 		if !ok || v < 0 {
-			errors = append(errors, fmt.Errorf("expected type of %s to be a positive number (uint)", k))
-			return
+			return diag.Errorf("expected type of %s to be a positive number (uint)", k)
 		}
-		return
+		return nil
 	}
 }

--- a/proxmox/validators.go
+++ b/proxmox/validators.go
@@ -1,6 +1,7 @@
 package proxmox
 
 import (
+	"fmt"
 	"strconv"
 	"strings"
 
@@ -35,7 +36,7 @@ func MacAddressValidator() schema.SchemaValidateDiagFunc {
 			return diag.Errorf("expected type of %v to be string", k)
 		}
 		mac := strings.Replace(value, ":", "", -1)
-		
+
 		// Check if a MAC address has been provided. If not, proxmox will generate random one.
 		if len(mac) == 0 {
 			return nil
@@ -92,4 +93,15 @@ func VMStateValidator() schema.SchemaValidateDiagFunc {
 		"running",
 		"stopped",
 	}, false))
+}
+
+func uint_Validator() schema.SchemaValidateFunc {
+	return func(i interface{}, k string) (warnings []string, errors []error) {
+		v, ok := i.(int)
+		if !ok || v < 0 {
+			errors = append(errors, fmt.Errorf("expected type of %s to be a positive number (uint)", k))
+			return
+		}
+		return
+	}
 }


### PR DESCRIPTION
This change fully re-implements the way qemu disks are handled to be more in accordance with how proxmox handles qemu disks. as discussed in https://github.com/Telmate/terraform-provider-proxmox/issues/778 and https://github.com/Telmate/proxmox-api-go/issues/187
 
- feature has been implemented.
- documentation has been updated.
- examples have been updated.

sadly this pull undoes https://github.com/Telmate/terraform-provider-proxmox/pull/767 as the `wwn` is not yet supported in https://github.com/Telmate/proxmox-api-go


@mleone87 I did some manual testing and i think it would all work. But would it be an idea to create a release candidate and notify the users who where experiencing the issues?



