### PR TITLE
Allow the creation of bind mounts for lxc containers

### DIFF
--- a/proxmox/resource_lxc.go
+++ b/proxmox/resource_lxc.go
@@ -166,13 +166,13 @@ func resourceLxc() *schema.Resource {
 							Type:     schema.TypeInt,
 							Required: true,
 						},
-						"storage": {
-							Type:     schema.TypeString,
-							Required: true,
-						},
 						"mp": {
 							Type:     schema.TypeString,
 							Required: true,
+						},
+						"storage": {
+							Type:     schema.TypeString,
+							Optional: true,
 						},
 						"acl": {
 							Type:     schema.TypeBool,
@@ -201,7 +201,7 @@ func resourceLxc() *schema.Resource {
 						},
 						"size": {
 							Type:     schema.TypeString,
-							Required: true,
+							Optional: true,
 							ValidateFunc: func(val interface{}, key string) (warns []string, errs []error) {
 								v := val.(string)
 								if !(strings.Contains(v, "T") || strings.Contains(v, "G") || strings.Contains(v, "M") || strings.Contains(v, "n")) {


### PR DESCRIPTION
This PR essentially makes storage and size optional

I have tested this for my use cases and it seems to work well but I realize it's a bit naive. Where might I change docs or add a test? Size is required when storage is specified. Any advice on how might I inform the user of that misconfiguration?

⚠️ *The API PR must be merged before this one*

### Further reading:
Issue: https://github.com/Telmate/terraform-provider-proxmox/issues/277
API PR: https://github.com/Telmate/proxmox-api-go/pull/271
Bind mount docs: https://pve.proxmox.com/pve-docs/pve-admin-guide.html#_bind_mount_points