### PR TITLE
Make cores not default to 1 to allow for "unlimited" cores on containers

### DIFF
--- a/proxmox/resource_lxc.go
+++ b/proxmox/resource_lxc.go
@@ -61,7 +61,6 @@ func resourceLxc() *schema.Resource {
 			"cores": {
 				Type:     schema.TypeInt,
 				Optional: true,
-				Default:  1,
 			},
 			"cpulimit": {
 				Type:     schema.TypeInt,


### PR DESCRIPTION
In Proxmox, if you provide no value to the "cores" option, the container will be allowed to use as many cores as it needs.

The current implementation of this provider defaults the cores to 1, and provides no way to override this to the "unlimited" mode. The default cores should be null to allow for unlimited, and provide the value for cores if you need to limit them