### PR TITLE
Fix lxc container size: Accept K

### DIFF
--- a/proxmox/resource_lxc.go
+++ b/proxmox/resource_lxc.go
@@ -204,7 +204,7 @@ func resourceLxc() *schema.Resource {
 							Required: true,
 							ValidateFunc: func(val interface{}, key string) (warns []string, errs []error) {
 								v := val.(string)
-								if !(strings.Contains(v, "T") || strings.Contains(v, "G") || strings.Contains(v, "M") || strings.Contains(v, "n")) {
+								if !(strings.Contains(v, "T") || strings.Contains(v, "G") || strings.Contains(v, "M") || strings.Contains(v, "K")) {
 									errs = append(errs, fmt.Errorf("disk size must end in T, G, M, or K, got %s", v))
 								}
 								return
@@ -360,7 +360,7 @@ func resourceLxc() *schema.Resource {
 							Required: true,
 							ValidateFunc: func(val interface{}, key string) (warns []string, errs []error) {
 								v := val.(string)
-								if !(strings.Contains(v, "T") || strings.Contains(v, "G") || strings.Contains(v, "M") || strings.Contains(v, "n")) {
+								if !(strings.Contains(v, "T") || strings.Contains(v, "G") || strings.Contains(v, "M") || strings.Contains(v, "K")) {
 									errs = append(errs, fmt.Errorf("disk size must end in T, G, M, or K, got %s", v))
 								}
 								return


### PR DESCRIPTION
When I was reading the code for the code that handles the sizes of the lxc containers I found a small oversight. The comparison for the sizes letters checks for n instead of K.