### PR TITLE
feat: added unlink of disks when removing disk blocks

### DIFF
--- a/proxmox/disk_detach_util.go
+++ b/proxmox/disk_detach_util.go
@@ -1,0 +1,57 @@
+package proxmox
+
+import (
+	"fmt"
+)
+
+// Create a Device Identifier given a disk object from
+// Proxmox. We need this to identify a device attached
+// to a VM when detaching a disk from a VM
+//
+// Parameters:
+//
+//	disk (interface{}): Disk to create identifier for
+//
+// Returns:
+//
+//	string: the Disk identifier for provided disk
+func CreateDeviceIdentifier(disk interface{}) string {
+	deviceSlot := disk.(map[string]interface{})["slot"].(int)
+	diskType := disk.(map[string]interface{})["type"].(string)
+	return fmt.Sprintf("%s%d", diskType, deviceSlot)
+}
+
+// Find all disks that was present in the old configuration which
+// is no longer present in the new configuration.
+//
+// Parameters:
+//
+//	oldSetOfDisks ([]interface{}): Disks from the old configuration
+//	newSetOfDisks ([]interface{}): Disks from the new configuration
+//
+// Returns:
+//
+//	[]interface{}: disks to detach and delete
+func FindDisksToDelete(oldSetOfDisks []interface{}, newSetOfDisks []interface{}) []interface{} {
+	diff := []interface{}{}
+
+	for _, oldValue := range oldSetOfDisks {
+		oldDeviceId := CreateDeviceIdentifier(oldValue)
+
+		keepDisk := false
+		for _, newValue := range newSetOfDisks {
+			newDeviceId := CreateDeviceIdentifier(newValue)
+
+			if oldDeviceId == newDeviceId {
+				keepDisk = true
+				break
+			}
+		}
+
+		if !keepDisk {
+			diff = append(diff, oldValue)
+		}
+	}
+
+	return diff
+}

--- a/proxmox/disk_detach_util_test.go
+++ b/proxmox/disk_detach_util_test.go
@@ -1,0 +1,74 @@
+package proxmox
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestFindDisksToDelete_ReturnsCorrectSetOfDisks(t *testing.T) {
+	oldValues := []interface{}{
+		map[string]interface{}{
+			"slot": 1,
+			"type": "scsi",
+		},
+		map[string]interface{}{
+			"slot": 2,
+			"type": "scsi",
+		},
+	}
+	newValues := []interface{}{
+		map[string]interface{}{
+			"slot": 1,
+			"type": "scsi",
+		},
+	}
+	expected := []interface{}{
+		map[string]interface{}{
+			"slot": 2,
+			"type": "scsi",
+		},
+	}
+	actual := FindDisksToDelete(oldValues, newValues)
+
+	if !reflect.DeepEqual(expected, actual) {
+		t.Fatalf("DisksToDelete does not match, expected %v, got %v", expected, actual)
+	}
+}
+
+func TestFindDisksToDelete_ReturnsEmptyIfAllOldValuesAreInNewValues(t *testing.T) {
+	oldValues := []interface{}{
+		map[string]interface{}{
+			"slot": 1,
+			"type": "scsi",
+		},
+	}
+	newValues := []interface{}{
+		map[string]interface{}{
+			"slot": 1,
+			"type": "scsi",
+		},
+		map[string]interface{}{
+			"slot": 2,
+			"type": "scsi",
+		},
+	}
+	actual := FindDisksToDelete(oldValues, newValues)
+
+	if len(actual) > 0 {
+		t.Fatalf("DisksToDelete should be empty since all disks in old config exists in new config, got %v", actual)
+	}
+}
+
+func TestCreateDeviceIdentifier_ReturnsCorrectIdForProvidedDisk(t *testing.T) {
+	disk := map[string]interface{}{
+		"slot": 1,
+		"type": "scsi",
+	}
+
+	expected := "scsi1"
+	actual := CreateDeviceIdentifier(disk)
+
+	if expected != actual {
+		t.Fatalf("DeviceIdentifier was invalid, expected: %s, got %s", expected, actual)
+	}
+}


### PR DESCRIPTION
**Requires https://github.com/Telmate/proxmox-api-go/pull/279**

During an update, the provider will check for
disks previously attached to the VM which has
now been removed from the HCL. The provider
unlinks and detaches the disks if the disks are
no longer a part of the configuration.
