### PR TITLE
allow using dynamic list for ipconfig instead of hardcoding the index in the key

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ bin
 .vscode
 *.log
 *env
+vendor/*
+

--- a/docs/resources/vm_qemu.md
+++ b/docs/resources/vm_qemu.md
@@ -39,7 +39,7 @@ parameter to create based
 on [a Cloud-init configuration file](https://cloudinit.readthedocs.io/en/latest/topics/examples.html) or use the Proxmox
 variable `ciuser`, `cipassword`, `ipconfig0`, `ipconfig1`, `ipconfig2`, `ipconfig3`, `ipconfig4`, `ipconfig5`,
 `ipconfig6`, `ipconfig7`, `ipconfig8`, `ipconfig9`, `ipconfig10`, `ipconfig11`, `ipconfig12`, `ipconfig13`,
-`ipconfig14`,`ipconfig15`, `searchdomain`, `nameserver` and `sshkeys`.
+`ipconfig14`,`ipconfig15`, `searchdomain`, `nameserver` and `sshkeys`. A variable amount of static IPs can be configured using the dynamic [`ipconfig` block](#ipconfig-block) to list multiple IP addresses.
 
 For more information, see the [Cloud-init guide](../guides/cloud_init.md).
 
@@ -163,6 +163,12 @@ details.
 | `rate`      | `int`  | `0`           | Network device rate limit in mbps (megabytes per second) as floating point number. Set to `0` to disable rate limiting.                                                                                                                                                                                                                                         |
 | `queues`    | `int`  | `1`           | Number of packet queues to be used on the device. Requires `virtio` model to have an effect.                                                                                                                                                                                                                                                                    |
 | `link_down` | `bool` | `false`       | Whether this interface should be disconnected (like pulling the plug).                                                                                                                                                                                                                                                                                          |
+
+### Ipconfig Block
+
+The `ipconfig` block is used to configure multiple static IP addresses. It may be specified multiple times.
+| Argument | Type  | Default Value | Description |
+| `config` | `str` |               | IP address to assign to the guest. Format: [gw=<GatewayIPv4>] [,gw6=<GatewayIPv6>] [,ip=<IPv4Format/CIDR>] [,ip6=<IPv6Format/CIDR>]. |
 
 ### Disk Block
 


### PR DESCRIPTION
When trying to use this provider it is difficult to create a variable amount of static IP addresses which are unknown until install time. The quantity of network interfaces can be handled variably but the accompanying static IP addresses does not work to go along with that. 
I have modified this to allow dynamic IP addresses to be created while maintaining backwards compatibility for the current way of explicitly setting ipconfig0, ipconfig1, etc. 

To give an example of my desired usage:

variables.tf:
```
variable "networks" {
  description = "defines NICs for the vm"
  type = list(object({
    model           = optional(string)
    bridge          = optional(string)
    vlan_tag        = optional(number)
    gateway         = optional(string)
    ip_address      = optional(string)
    cidr_annotation = optional(string)
  }))
  default = [{
    model           = "virtio"
    bridge          = "vmbr0"
    vlan_tag        = null
    gateway         = "10.0.0.1"
    cidr_annotation = "20"
    ip_address      = null
  }]
}
```

main.tf
```
dynamic "network" {
    for_each = var.networks
    content {
      model  = network.value.model
      bridge = network.value.bridge
      tag    = network.value.vlan_tag
    }
  }

  dynamic "ipconfig" {
    for_each = var.networks
    content {
      config = "ip=${network.value.ip_address}/${network.value.cidr_annotation},gw=${network.value.gateway}"
    }
  }
  ```