### PR TITLE
Feat: Gracefully shutdown VM on deletion.

### DIFF
--- a/proxmox/resource_vm_qemu.go
+++ b/proxmox/resource_vm_qemu.go
@@ -1816,7 +1816,12 @@ func resourceVmQemuDelete(ctx context.Context, d *schema.ResourceData, meta inte
 		return diag.FromErr(err)
 	}
 	if vmState["status"] != "stopped" {
-		_, err := client.ShutdownVm(vmr)
+		var err error
+		if d.Get("agent") == 1 {
+			_, err = client.ShutdownVm(vmr)
+		} else {
+			_, err = client.StopVm(vmr)
+		}
 		if err != nil {
 			return diag.FromErr(err)
 		}

--- a/proxmox/resource_vm_qemu.go
+++ b/proxmox/resource_vm_qemu.go
@@ -1816,7 +1816,7 @@ func resourceVmQemuDelete(ctx context.Context, d *schema.ResourceData, meta inte
 		return diag.FromErr(err)
 	}
 	if vmState["status"] != "stopped" {
-		_, err := client.StopVm(vmr)
+		_, err := client.ShutdownVm(vmr)
 		if err != nil {
 			return diag.FromErr(err)
 		}


### PR DESCRIPTION
This PR alters `resourceVmQemuDelete` to attempt a graceful VM shutdown prior deletion (as opposed to the current method which performs a hard stop).  With the current behavior, DHCP reservations are left hanging until a timeout (which can take quite some time), leading to potentially lots of unavailable IP addresses.