### PR TITLE
Fix parallel execution handling when returning early

### DIFF
--- a/proxmox/resource_vm_qemu.go
+++ b/proxmox/resource_vm_qemu.go
@@ -805,7 +805,8 @@ func resourceVmQemuCreate(ctx context.Context, d *schema.ResourceData, meta inte
 
 	pconf := meta.(*providerConfiguration)
 	lock := pmParallelBegin(pconf)
-	// defer lock.unlock()
+	defer lock.unlock()
+
 	client := pconf.Client
 	vmName := d.Get("name").(string)
 	vga := d.Get("vga").(*schema.Set)
@@ -1054,6 +1055,7 @@ func resourceVmQemuUpdate(ctx context.Context, d *schema.ResourceData, meta inte
 	pconf := meta.(*providerConfiguration)
 	client := pconf.Client
 	lock := pmParallelBegin(pconf)
+	defer lock.unlock()
 
 	// create a logger for this function
 	logger, _ := CreateSubLogger("resource_vm_update")
@@ -1327,6 +1329,7 @@ func resourceVmQemuRead(ctx context.Context, d *schema.ResourceData, meta interf
 	pconf := meta.(*providerConfiguration)
 	lock := pmParallelBegin(pconf)
 	defer lock.unlock()
+
 	client := pconf.Client
 	// create a logger for this function
 	var diags diag.Diagnostics


### PR DESCRIPTION
resourceVmQemuCreate and resourceVmQemuUpdate can both return early due to errors. When this happens, we must ensure that we "unlock" the slot we have claimed for parallel execution. This is safe to do in a defer action because even if we manually "unlock" prior to the function return, the unlock action checks to ensure that the "lock" is held prior to attempting to return a slot to the pool.

Fixes #922 