### PR TITLE
Revert "fix: enable new versions of providers to run on old tfstate files"

### DIFF
--- a/proxmox/resource_vm_qemu.go
+++ b/proxmox/resource_vm_qemu.go
@@ -3094,12 +3094,6 @@ func schema_DiskBackup() *schema.Schema {
 		Type:     schema.TypeBool,
 		Optional: true,
 		Default:  true,
-		// Convert previous integer values of 0/1 to booleans
-		StateFunc: func(val interface{}) string {
-			if val.(string) == "0" {return "false"}
-			if val.(string) == "1" {return "true"}
-			return val.(string)
-		},
 	}
 }
 


### PR DESCRIPTION
Reverts Telmate/terraform-provider-proxmox#923

I've confirmed that removing this patch does not revert issue #702. In other words, you can deploy a VM with 2.9.11, switch your provider to version f9a1c063b978caa3a346d9278de146910758021b and do a `terraform apply` without having to manually change any tfstate files.