### PR TITLE
Add minimal example for reporting issues

### DIFF
--- a/examples/bug_reporting/README.md
+++ b/examples/bug_reporting/README.md
@@ -1,0 +1,19 @@
+The files in this folder are here to help you troubleshoot issues by taking a
+minimal example, which should work fine, and adding things from the terraform
+file where you're having an issue.
+
+These are also very helpful in reporting issues on the
+[issue tracker](https://github.com/Telmate/terraform-provider-proxmox/issues)
+so others can quickly reproduce your problem. When posting an issue, please
+include the provider.tf file that you are using, and the smallest possible
+issue.tf that recreates your problem. You don't need to include vars.tf, as
+that's going to be different for everyone anyway.
+
+In addition to providing terraform that reproduces the issue, please make sure
+to mention what you are trying to accomplish, how you expected it to work, and
+how it worked in practice. If you get any error messages, include those too.
+
+Many times a debug log is not needed, but if you want to proactively create a
+debug log and include that in your report, it may enable someone to answer your
+question more quickly. To do so, uncomment the relevant lines of provider.tf and
+include the .log file that is generated when you run `terraform apply`.

--- a/examples/bug_reporting/issue.tf
+++ b/examples/bug_reporting/issue.tf
@@ -1,0 +1,39 @@
+resource "proxmox_vm_qemu" "server" {
+  name              = var.name
+  target_node       = var.target_node
+  clone             = "debian-12"
+  os_type           = "cloud-init"
+  scsihw            = "virtio-scsi-pci"
+# Pre-3.0 format for disks
+#  disk {
+#    size            = "20G"
+#    type            = "virtio"
+#    cache           = "writeback"
+#    storage         = var.storage_backend
+#  }
+# New & improved disk format (3.0 and later)
+  disks {
+    virtio {
+      virtio0 {
+        disk {
+          size            = 20
+          cache           = "writeback"
+          storage         = var.storage_backend
+        }
+      }
+    }
+  }
+  network {
+    model           = "virtio"
+    bridge          = "vmbr0"
+  }
+
+  # Cloud Init Settings
+  # Reference: https://pve.proxmox.com/wiki/Cloud-Init_Support
+  cloudinit_cdrom_storage = var.storage_backend
+  boot = "order=virtio0;ide3"
+  ipconfig0 = "ip=${var.ip_address}/${var.cidr},gw=${var.gateway}"
+  nameserver = var.nameservers
+  # If your SSH public key is named differently, change the path below
+  sshkeys = file("${path.root}/test.pub")
+}

--- a/examples/bug_reporting/provider.tf
+++ b/examples/bug_reporting/provider.tf
@@ -1,0 +1,32 @@
+# Define the usual provider things
+terraform {
+  required_providers {
+    proxmox = {
+      # Use these two lines to run a locally compiled version of the provider
+      #source = "registry.example.com/telmate/proxmox"
+      #version = ">=1.0.0"
+
+      # Normally we want the provider from the registry
+      source = "Telmate/proxmox"
+      # We can specificy a specific version. If we do not, terraform will use
+      # the latest official release.
+      #version = "=2.9.11"
+      #version = "=3.0.1-rc1"
+    }
+  }
+  required_version = ">= 0.14"
+}
+
+# To enable debugging, uncomment the following block. This will create a log
+# file that is helpful in understanding what happened and getting help from
+# others.
+#provider "proxmox" {
+#  pm_log_enable = true
+#  pm_log_file   = "terraform-plugin-proxmox.log"
+#  pm_debug      = true
+#  pm_log_levels = {
+#    _default    = "debug"
+#    _capturelog = ""
+#  }
+#}
+

--- a/examples/bug_reporting/vars.tf
+++ b/examples/bug_reporting/vars.tf
@@ -1,0 +1,8 @@
+# You will need to customize these variables to suit your environment
+variable "target_node" { default = "larry" }
+variable "ip_address" { default = "192.168.73.57" }
+variable "cidr" { default = "24" }
+variable "gateway" { default = "192.168.73.1" }
+variable "nameservers" { default = "192.168.73.100 192.168.73.200" }
+variable "name" { default = "test.example.com" }
+variable "storage_backend" { default = "local-zfs" }


### PR DESCRIPTION
Added terraform templates to guide people in creating tickets that make it easier for others to reproduce. If people use this, it will likely result in fewer issues because it will give people the tools to figure out how to resolve many of their own issues.

Related to #913