### PR TITLE
Stale-bot exlusions

### DIFF
--- a/.github/workflows/manage_issues.yml
+++ b/.github/workflows/manage_issues.yml
@@ -10,7 +10,7 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-      - uses: actions/stale@v7
+      - uses: actions/stale@v9
         with:
           days-before-issue-stale: 60
           days-before-issue-close: 5

--- a/.github/workflows/manage_issues.yml
+++ b/.github/workflows/manage_issues.yml
@@ -19,3 +19,6 @@ jobs:
           close-issue-message: "This issue was closed because it has been inactive for 5 days since being marked as stale."
           days-before-pr-stale: -1
           days-before-pr-close: -1
+          exempt-all-assignees: true
+          exempt-issue-labels: 'bug,community feedback,documentation,enhancement,help wanted,need investigation,question,workflow'
+          exempt-pr-labels: 'bug,community feedback,documentation,enhancement,help wanted,need investigation,question,workflow'


### PR DESCRIPTION
Changing the settings of stale-bot to never mark an pull requests and issue as stale that have someone assigned to it, or has one of the following labels: `bug` `community feedback` `documentation` `enhancement` `help need` `investigation` `question` `workflow`