### PR TITLE
Move `cloudinit` disk to `disks` schema

### DIFF
--- a/docs/guides/cloud_init.md
+++ b/docs/guides/cloud_init.md
@@ -157,7 +157,15 @@ EOF
   */
   cicustom                = "user=local:snippets/user_data_vm-${count.index}.yml"
   /* Create the Cloud-Init drive on the "local-lvm" storage */
-  cloudinit_cdrom_storage = "local-lvm"
+  disks {
+    ide {
+      ide3 {
+        cloudinit {
+          storage = "local-lvm"
+        }
+      }
+    }
+  }
 
   provisioner "remote-exec" {
     inline = [

--- a/docs/resources/vm_qemu.md
+++ b/docs/resources/vm_qemu.md
@@ -133,7 +133,6 @@ The following arguments are supported in the top level resource block.
 | `ciuser`                      | `str`    |                      | Override the default cloud-init user for provisioning. |
 | `cipassword`                  | `str`    |                      | Override the default cloud-init user's password. Sensitive. |
 | `cicustom`                    | `str`    |                      | Instead specifying ciuser, cipasword, etc... you can specify the path to a custom cloud-init config file here. Grants more flexibility in configuring cloud-init. |
-| `cloudinit_cdrom_storage`     | `str`    |                      | Set the storage location for the cloud-init drive. Required when using cloud-init. |
 | `searchdomain`                | `str`    |                      | Sets default DNS search domain suffix. |
 | `nameserver`                  | `str`    |                      | Sets default DNS server for guest. |
 | `sshkeys`                     | `str`    |                      | Newline delimited list of SSH public keys to add to authorized keys file for the cloud-init user. |
@@ -206,9 +205,10 @@ resource "proxmox_vm_qemu" "resource-name" {
 
 ### Disks.Ide Block
 
-The `disks.ide` block is used to configure disks of type ide. It may only be specified once. It has the options `ide0` through `ide2`. Each disk can have only one of the following mutually exclusive sub types `cdrom`, `disk`, `passthrough`. Configuration for these sub types can be found in their respective chapters:
+The `disks.ide` block is used to configure disks of type ide. It may only be specified once. It has the options `ide0` through `ide3`. Each disk can have only one of the following mutually exclusive sub types `cdrom`, `cloudinit`, `disk`, `passthrough`. Configuration for these sub types can be found in their respective chapters:
 
 * `cdrom`: [Disks.x.Cdrom Block](#disksxcdrom-block).
+* `cloudinit`: [Disks.x.Cloudinit Block](#disksxcloudinit-block).
 * `disk`: [Disks.x.Disk Block](#disksxdisk-block).
 * `passthrough`: [Disks.x.Passthrough Block](#disksxpassthrough-block).
 
@@ -219,11 +219,21 @@ resource "proxmox_vm_qemu" "resource-name" {
   disks {
     ide {
       ide0 {
-        disk {
+        cdrom {
+          //<arguments omitted for brevity...>
+        }
+      }
+      ide1 {
+        cloudinit {
           //<arguments omitted for brevity...>
         }
       }
       ide2 {
+        disk {
+          //<arguments omitted for brevity...>
+        }
+      }
+      ide3 {
         passthrough {
           //<arguments omitted for brevity...>
         }
@@ -236,9 +246,10 @@ resource "proxmox_vm_qemu" "resource-name" {
 
 ### Disks.Sata Block
 
-The `disks.sata` block is used to configure disks of type sata. It may only be specified once. It has the options `sata0` through `sata5`. Each disk can have only one of the following mutually exclusive sub types `cdrom`, `disk`, `passthrough`. Configuration for these sub types can be found in their respective chapters:
+The `disks.sata` block is used to configure disks of type sata. It may only be specified once. It has the options `sata0` through `sata5`. Each disk can have only one of the following mutually exclusive sub types `cdrom`, `cloudinit`, `disk`, `passthrough`. Configuration for these sub types can be found in their respective chapters:
 
 * `cdrom`: [Disks.x.Cdrom Block](#disksxcdrom-block).
+* `cloudinit`: [Disks.x.Cloudinit Block](#disksxcloudinit-block).
 * `disk`: [Disks.x.Disk Block](#disksxdisk-block).
 * `passthrough`: [Disks.x.Passthrough Block](#disksxpassthrough-block).
 
@@ -254,11 +265,16 @@ resource "proxmox_vm_qemu" "resource-name" {
         }
       }
       sata1 {
-        disk {
+        cloudinit {
           //<arguments omitted for brevity...>
         }
       }
       sata2 {
+        disk {
+          //<arguments omitted for brevity...>
+        }
+      }
+      sata3 {
         passthrough {
           //<arguments omitted for brevity...>
         }
@@ -272,9 +288,10 @@ resource "proxmox_vm_qemu" "resource-name" {
 
 ### Disks.Scsi Block
 
-The `disks.scsi` block is used to configure disks of type scsi. It may only be specified once. It has the options `scsi0` through `scsi30`. Each disk can have only one of the following mutually exclusive sub types `cdrom`, `disk`, `passthrough`. Configuration for these sub types can be found in their respective chapters:
+The `disks.scsi` block is used to configure disks of type scsi. It may only be specified once. It has the options `scsi0` through `scsi30`. Each disk can have only one of the following mutually exclusive sub types `cdrom`, `cloudinit`, `disk`, `passthrough`. Configuration for these sub types can be found in their respective chapters:
 
 * `cdrom`: [Disks.x.Cdrom Block](#disksxcdrom-block).
+* `cloudinit`: [Disks.x.Cloudinit Block](#disksxcloudinit-block).
 * `disk`: [Disks.x.Disk Block](#disksxdisk-block).
 * `passthrough`: [Disks.x.Passthrough Block](#disksxpassthrough-block).
 
@@ -290,11 +307,16 @@ resource "proxmox_vm_qemu" "resource-name" {
         }
       }
       scsi1 {
-        disk {
+        cloudinit {
           //<arguments omitted for brevity...>
         }
       }
       scsi2 {
+        disk {
+          //<arguments omitted for brevity...>
+        }
+      }
+      scsi3 {
         passthrough {
           //<arguments omitted for brevity...>
         }
@@ -350,6 +372,13 @@ resource "proxmox_vm_qemu" "resource-name" {
 | `passthrough` | `bool` |    `false`    | Wether the physical cdrom drive should be passed through.                                                                                                    |
 
 When `iso` and `passthrough` are omitted an empty cdrom drive will be created.
+
+### Disks.x.Cloudinit Block
+
+Only **one** `cloudinit` block can be specified globally. This block is used to configure the cloud-init drive.
+
+| Argument                  | Type  | Default Value | Description|
+| `cloudinit_cdrom_storage` | `str` |               | Set the storage location for the cloud-init drive. Required when using cloud-init.|
 
 ### Disks.x.Disk Block
 

--- a/examples/cloudinit_example.tf
+++ b/examples/cloudinit_example.tf
@@ -33,6 +33,13 @@ resource "proxmox_vm_qemu" "cloudinit-test" {
 
     # Setup the disk
     disks {
+        ide {
+            ide3 {
+                cloudinit {
+                    storage = "local-lvm"
+                }
+            }
+        }
         virtio {
             virtio0 {
                 disk {
@@ -55,8 +62,7 @@ resource "proxmox_vm_qemu" "cloudinit-test" {
     }
 
     # Setup the ip address using cloud-init.
-    cloudinit_cdrom_storage = "local-lvm"
-    boot = "order=virtio0;ide3"
+    boot = "order=virtio0"
     # Keep in mind to use the CIDR notation for the ip.
     ipconfig0 = "ip=192.168.10.20/24,gw=192.168.10.1"
 

--- a/proxmox/resource_vm_qemu.go
+++ b/proxmox/resource_vm_qemu.go
@@ -2088,9 +2088,9 @@ func mapFromStruct_QemuIdeDisks(config *pxapi.QemuIdeDisks) []interface{} {
 	if config == nil {
 		return nil
 	}
-	ide_0 := mapFromStruct_QemuIdeStorage(config.Disk_0, "ide0")
-	ide_1 := mapFromStruct_QemuIdeStorage(config.Disk_1, "ide1")
-	ide_2 := mapFromStruct_QemuIdeStorage(config.Disk_2, "ide2")
+	ide_0 := mapFromStruct_QemuIdeStorage(config.Disk_0)
+	ide_1 := mapFromStruct_QemuIdeStorage(config.Disk_1)
+	ide_2 := mapFromStruct_QemuIdeStorage(config.Disk_2)
 	if ide_0 == nil && ide_1 == nil && ide_2 == nil {
 		return nil
 	}
@@ -2103,7 +2103,7 @@ func mapFromStruct_QemuIdeDisks(config *pxapi.QemuIdeDisks) []interface{} {
 	}
 }
 
-func mapFromStruct_QemuIdeStorage(config *pxapi.QemuIdeStorage, setting string) []interface{} {
+func mapFromStruct_QemuIdeStorage(config *pxapi.QemuIdeStorage) []interface{} {
 	if config == nil {
 		return nil
 	}
@@ -2157,17 +2157,17 @@ func mapFromStruct_QemuSataDisks(config *pxapi.QemuSataDisks) []interface{} {
 	}
 	return []interface{}{
 		map[string]interface{}{
-			"sata0": mapFromStruct_QemuSataStorage(config.Disk_0, "sata0"),
-			"sata1": mapFromStruct_QemuSataStorage(config.Disk_1, "sata1"),
-			"sata2": mapFromStruct_QemuSataStorage(config.Disk_2, "sata2"),
-			"sata3": mapFromStruct_QemuSataStorage(config.Disk_3, "sata3"),
-			"sata4": mapFromStruct_QemuSataStorage(config.Disk_4, "sata4"),
-			"sata5": mapFromStruct_QemuSataStorage(config.Disk_5, "sata5"),
+			"sata0": mapFromStruct_QemuSataStorage(config.Disk_0),
+			"sata1": mapFromStruct_QemuSataStorage(config.Disk_1),
+			"sata2": mapFromStruct_QemuSataStorage(config.Disk_2),
+			"sata3": mapFromStruct_QemuSataStorage(config.Disk_3),
+			"sata4": mapFromStruct_QemuSataStorage(config.Disk_4),
+			"sata5": mapFromStruct_QemuSataStorage(config.Disk_5),
 		},
 	}
 }
 
-func mapFromStruct_QemuSataStorage(config *pxapi.QemuSataStorage, setting string) []interface{} {
+func mapFromStruct_QemuSataStorage(config *pxapi.QemuSataStorage) []interface{} {
 	if config == nil {
 		return nil
 	}
@@ -2221,42 +2221,42 @@ func mapFromStruct_QemuScsiDisks(config *pxapi.QemuScsiDisks) []interface{} {
 	}
 	return []interface{}{
 		map[string]interface{}{
-			"scsi0":  mapFromStruct_QemuScsiStorage(config.Disk_0, "scsi0"),
-			"scsi1":  mapFromStruct_QemuScsiStorage(config.Disk_1, "scsi1"),
-			"scsi2":  mapFromStruct_QemuScsiStorage(config.Disk_2, "scsi2"),
-			"scsi3":  mapFromStruct_QemuScsiStorage(config.Disk_3, "scsi3"),
-			"scsi4":  mapFromStruct_QemuScsiStorage(config.Disk_4, "scsi4"),
-			"scsi5":  mapFromStruct_QemuScsiStorage(config.Disk_5, "scsi5"),
-			"scsi6":  mapFromStruct_QemuScsiStorage(config.Disk_6, "scsi6"),
-			"scsi7":  mapFromStruct_QemuScsiStorage(config.Disk_7, "scsi7"),
-			"scsi8":  mapFromStruct_QemuScsiStorage(config.Disk_8, "scsi8"),
-			"scsi9":  mapFromStruct_QemuScsiStorage(config.Disk_9, "scsi9"),
-			"scsi10": mapFromStruct_QemuScsiStorage(config.Disk_10, "scsi10"),
-			"scsi11": mapFromStruct_QemuScsiStorage(config.Disk_11, "scsi11"),
-			"scsi12": mapFromStruct_QemuScsiStorage(config.Disk_12, "scsi12"),
-			"scsi13": mapFromStruct_QemuScsiStorage(config.Disk_13, "scsi13"),
-			"scsi14": mapFromStruct_QemuScsiStorage(config.Disk_14, "scsi14"),
-			"scsi15": mapFromStruct_QemuScsiStorage(config.Disk_15, "scsi15"),
-			"scsi16": mapFromStruct_QemuScsiStorage(config.Disk_16, "scsi16"),
-			"scsi17": mapFromStruct_QemuScsiStorage(config.Disk_17, "scsi17"),
-			"scsi18": mapFromStruct_QemuScsiStorage(config.Disk_18, "scsi18"),
-			"scsi19": mapFromStruct_QemuScsiStorage(config.Disk_19, "scsi19"),
-			"scsi20": mapFromStruct_QemuScsiStorage(config.Disk_20, "scsi20"),
-			"scsi21": mapFromStruct_QemuScsiStorage(config.Disk_21, "scsi21"),
-			"scsi22": mapFromStruct_QemuScsiStorage(config.Disk_22, "scsi22"),
-			"scsi23": mapFromStruct_QemuScsiStorage(config.Disk_23, "scsi23"),
-			"scsi24": mapFromStruct_QemuScsiStorage(config.Disk_24, "scsi24"),
-			"scsi25": mapFromStruct_QemuScsiStorage(config.Disk_25, "scsi25"),
-			"scsi26": mapFromStruct_QemuScsiStorage(config.Disk_26, "scsi26"),
-			"scsi27": mapFromStruct_QemuScsiStorage(config.Disk_27, "scsi27"),
-			"scsi28": mapFromStruct_QemuScsiStorage(config.Disk_28, "scsi28"),
-			"scsi29": mapFromStruct_QemuScsiStorage(config.Disk_29, "scsi29"),
-			"scsi30": mapFromStruct_QemuScsiStorage(config.Disk_30, "scsi30"),
+			"scsi0":  mapFromStruct_QemuScsiStorage(config.Disk_0),
+			"scsi1":  mapFromStruct_QemuScsiStorage(config.Disk_1),
+			"scsi2":  mapFromStruct_QemuScsiStorage(config.Disk_2),
+			"scsi3":  mapFromStruct_QemuScsiStorage(config.Disk_3),
+			"scsi4":  mapFromStruct_QemuScsiStorage(config.Disk_4),
+			"scsi5":  mapFromStruct_QemuScsiStorage(config.Disk_5),
+			"scsi6":  mapFromStruct_QemuScsiStorage(config.Disk_6),
+			"scsi7":  mapFromStruct_QemuScsiStorage(config.Disk_7),
+			"scsi8":  mapFromStruct_QemuScsiStorage(config.Disk_8),
+			"scsi9":  mapFromStruct_QemuScsiStorage(config.Disk_9),
+			"scsi10": mapFromStruct_QemuScsiStorage(config.Disk_10),
+			"scsi11": mapFromStruct_QemuScsiStorage(config.Disk_11),
+			"scsi12": mapFromStruct_QemuScsiStorage(config.Disk_12),
+			"scsi13": mapFromStruct_QemuScsiStorage(config.Disk_13),
+			"scsi14": mapFromStruct_QemuScsiStorage(config.Disk_14),
+			"scsi15": mapFromStruct_QemuScsiStorage(config.Disk_15),
+			"scsi16": mapFromStruct_QemuScsiStorage(config.Disk_16),
+			"scsi17": mapFromStruct_QemuScsiStorage(config.Disk_17),
+			"scsi18": mapFromStruct_QemuScsiStorage(config.Disk_18),
+			"scsi19": mapFromStruct_QemuScsiStorage(config.Disk_19),
+			"scsi20": mapFromStruct_QemuScsiStorage(config.Disk_20),
+			"scsi21": mapFromStruct_QemuScsiStorage(config.Disk_21),
+			"scsi22": mapFromStruct_QemuScsiStorage(config.Disk_22),
+			"scsi23": mapFromStruct_QemuScsiStorage(config.Disk_23),
+			"scsi24": mapFromStruct_QemuScsiStorage(config.Disk_24),
+			"scsi25": mapFromStruct_QemuScsiStorage(config.Disk_25),
+			"scsi26": mapFromStruct_QemuScsiStorage(config.Disk_26),
+			"scsi27": mapFromStruct_QemuScsiStorage(config.Disk_27),
+			"scsi28": mapFromStruct_QemuScsiStorage(config.Disk_28),
+			"scsi29": mapFromStruct_QemuScsiStorage(config.Disk_29),
+			"scsi30": mapFromStruct_QemuScsiStorage(config.Disk_30),
 		},
 	}
 }
 
-func mapFromStruct_QemuScsiStorage(config *pxapi.QemuScsiStorage, setting string) []interface{} {
+func mapFromStruct_QemuScsiStorage(config *pxapi.QemuScsiStorage) []interface{} {
 	if config == nil {
 		return nil
 	}
@@ -2314,27 +2314,27 @@ func mapFromStruct_QemuVirtIODisks(config *pxapi.QemuVirtIODisks) []interface{} 
 	}
 	return []interface{}{
 		map[string]interface{}{
-			"virtio0":  mapFromStruct_QemuVirtIOStorage(config.Disk_0, "virtio0"),
-			"virtio1":  mapFromStruct_QemuVirtIOStorage(config.Disk_1, "virtio1"),
-			"virtio2":  mapFromStruct_QemuVirtIOStorage(config.Disk_2, "virtio2"),
-			"virtio3":  mapFromStruct_QemuVirtIOStorage(config.Disk_3, "virtio3"),
-			"virtio4":  mapFromStruct_QemuVirtIOStorage(config.Disk_4, "virtio4"),
-			"virtio5":  mapFromStruct_QemuVirtIOStorage(config.Disk_5, "virtio5"),
-			"virtio6":  mapFromStruct_QemuVirtIOStorage(config.Disk_6, "virtio6"),
-			"virtio7":  mapFromStruct_QemuVirtIOStorage(config.Disk_7, "virtio7"),
-			"virtio8":  mapFromStruct_QemuVirtIOStorage(config.Disk_8, "virtio8"),
-			"virtio9":  mapFromStruct_QemuVirtIOStorage(config.Disk_9, "virtio9"),
-			"virtio10": mapFromStruct_QemuVirtIOStorage(config.Disk_10, "virtio10"),
-			"virtio11": mapFromStruct_QemuVirtIOStorage(config.Disk_11, "virtio11"),
-			"virtio12": mapFromStruct_QemuVirtIOStorage(config.Disk_12, "virtio12"),
-			"virtio13": mapFromStruct_QemuVirtIOStorage(config.Disk_13, "virtio13"),
-			"virtio14": mapFromStruct_QemuVirtIOStorage(config.Disk_14, "virtio14"),
-			"virtio15": mapFromStruct_QemuVirtIOStorage(config.Disk_15, "virtio15"),
+			"virtio0":  mapFromStruct_QemuVirtIOStorage(config.Disk_0),
+			"virtio1":  mapFromStruct_QemuVirtIOStorage(config.Disk_1),
+			"virtio2":  mapFromStruct_QemuVirtIOStorage(config.Disk_2),
+			"virtio3":  mapFromStruct_QemuVirtIOStorage(config.Disk_3),
+			"virtio4":  mapFromStruct_QemuVirtIOStorage(config.Disk_4),
+			"virtio5":  mapFromStruct_QemuVirtIOStorage(config.Disk_5),
+			"virtio6":  mapFromStruct_QemuVirtIOStorage(config.Disk_6),
+			"virtio7":  mapFromStruct_QemuVirtIOStorage(config.Disk_7),
+			"virtio8":  mapFromStruct_QemuVirtIOStorage(config.Disk_8),
+			"virtio9":  mapFromStruct_QemuVirtIOStorage(config.Disk_9),
+			"virtio10": mapFromStruct_QemuVirtIOStorage(config.Disk_10),
+			"virtio11": mapFromStruct_QemuVirtIOStorage(config.Disk_11),
+			"virtio12": mapFromStruct_QemuVirtIOStorage(config.Disk_12),
+			"virtio13": mapFromStruct_QemuVirtIOStorage(config.Disk_13),
+			"virtio14": mapFromStruct_QemuVirtIOStorage(config.Disk_14),
+			"virtio15": mapFromStruct_QemuVirtIOStorage(config.Disk_15),
 		},
 	}
 }
 
-func mapFromStruct_QemuVirtIOStorage(config *pxapi.QemuVirtIOStorage, setting string) []interface{} {
+func mapFromStruct_QemuVirtIOStorage(config *pxapi.QemuVirtIOStorage) []interface{} {
 	if config == nil {
 		return nil
 	}

--- a/proxmox/resource_vm_qemu.go
+++ b/proxmox/resource_vm_qemu.go
@@ -479,7 +479,7 @@ func resourceVmQemu() *schema.Resource {
 									"ide0": schema_Ide("ide0"),
 									"ide1": schema_Ide("ide1"),
 									"ide2": schema_Ide("ide2"),
-									// ide3 reserved for cloudinit
+									"ide3": schema_Ide("ide3"),
 								},
 							},
 						},
@@ -2088,19 +2088,12 @@ func mapFromStruct_QemuIdeDisks(config *pxapi.QemuIdeDisks) []interface{} {
 	if config == nil {
 		return nil
 	}
-	ide_0 := mapFromStruct_QemuIdeStorage(config.Disk_0)
-	ide_1 := mapFromStruct_QemuIdeStorage(config.Disk_1)
-	ide_2 := mapFromStruct_QemuIdeStorage(config.Disk_2)
-	if ide_0 == nil && ide_1 == nil && ide_2 == nil {
-		return nil
-	}
 	return []interface{}{
 		map[string]interface{}{
-			"ide0": ide_0,
-			"ide1": ide_1,
-			"ide2": ide_2,
-		},
-	}
+			"ide0": mapFromStruct_QemuIdeStorage(config.Disk_0),
+			"ide1": mapFromStruct_QemuIdeStorage(config.Disk_1),
+			"ide2": mapFromStruct_QemuIdeStorage(config.Disk_2),
+			"ide3": mapFromStruct_QemuIdeStorage(config.Disk_3)}}
 }
 
 func mapFromStruct_QemuIdeStorage(config *pxapi.QemuIdeStorage) []interface{} {
@@ -2462,6 +2455,7 @@ func mapToStruct_QemuIdeDisks(ide *pxapi.QemuIdeDisks, schema map[string]interfa
 	mapToStruct_QemuIdeStorage(ide.Disk_0, "ide0", disks)
 	mapToStruct_QemuIdeStorage(ide.Disk_1, "ide1", disks)
 	mapToStruct_QemuIdeStorage(ide.Disk_2, "ide2", disks)
+	mapToStruct_QemuIdeStorage(ide.Disk_3, "ide3", disks)
 }
 
 func mapToStruct_QemuIdeStorage(ide *pxapi.QemuIdeStorage, key string, schema map[string]interface{}) {

--- a/proxmox/resource_vm_qemu.go
+++ b/proxmox/resource_vm_qemu.go
@@ -1352,14 +1352,7 @@ func resourceVmQemuUpdate(ctx context.Context, d *schema.ResourceData, meta inte
 	lock.unlock()
 
 	d.Set("reboot_required", rebootRequired)
-	// err = resourceVmQemuRead(ctx, d, meta)
-	// if err != nil {
-	// 	diags = append(diags, diag.FromErr(err)...)
-	// 	return diags
-	// }
-	diags = append(diags, resourceVmQemuRead(ctx, d, meta)...)
-	return diags
-	// return resourceVmQemuRead(ctx, d, meta)
+	return append(diags, resourceVmQemuRead(ctx, d, meta)...)
 }
 
 func resourceVmQemuRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {

--- a/proxmox/resource_vm_qemu.go
+++ b/proxmox/resource_vm_qemu.go
@@ -1202,8 +1202,9 @@ func resourceVmQemuUpdate(ctx context.Context, d *schema.ResourceData, meta inte
 	logger.Debug().Int("vmid", vmID).Msgf("Updating VM with the following configuration: %+v", config)
 
 	var rebootRequired bool
+	automaticReboot := d.Get("automatic_reboot").(bool)
 	// don't let the update function handel the reboot as it can't deal with cloud init changes yet
-	rebootRequired, err = config.Update(false, vmr, client)
+	rebootRequired, err = config.Update(automaticReboot, vmr, client)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -1319,7 +1320,7 @@ func resourceVmQemuUpdate(ctx context.Context, d *schema.ResourceData, meta inte
 				}
 			}
 		} else if d.Get("reboot_required").(bool) { // reboot the VM
-			if d.Get("automatic_reboot").(bool) { // automatic reboots is enabled
+			if automaticReboot { // automatic reboots is enabled
 				log.Print("[DEBUG][QemuVmUpdate] rebooting the VM to match the configuration changes")
 				_, err = client.RebootVm(vmr)
 				// note: the default timeout is 3 min, configurable per VM: Options/Start-Shutdown Order/Shutdown timeout


### PR DESCRIPTION

- Make disk slot `ide3` usable.
- Remove `cloudinit_cdrom_storage` (unable to keep as deprecated due to complexity).
- Added `cloudinit` disk to the `disks` block.
- Minor code optimizations c585fa22a9ebb018c6e8705f2e7aeaa9498d6e8b 548c3ddc75cb471ec1a730a999e4aaa5ad20bb45.

closes #992
fixes #973