### PR TITLE
Fix: v3.0.1-rc2: Stuck on still creating

### DIFF
--- a/docs/resources/vm_qemu.md
+++ b/docs/resources/vm_qemu.md
@@ -141,6 +141,7 @@ The following arguments are supported in the top level resource block.
 | `automatic_reboot`            | `bool`   | `true`               | Automatically reboot the VM when parameter changes require this. If disabled the provider will emit a warning when the VM needs to be rebooted. |
 | `skip_ipv4`                   | `bool`   | `false`              | Tells proxmox that acquiring an IPv4 address from the qemu guest agent isn't required, it will still return an ipv4 address if it could obtain one. Useful for reducing retries in environments without ipv4.|
 | `skip_ipv6`                   | `bool`   | `false`              | Tells proxmox that acquiring an IPv6 address from the qemu guest agent isn't required, it will still return an ipv6 address if it could obtain one. Useful for reducing retries in environments without ipv6.|
+| `agent_timeout`               | `int`    | `60`                 | Timeout in seconds to keep trying to obtain an IP address from the guest agent one we have a connection. |
 
 ### VGA Block
 

--- a/proxmox/heper_qemu_test.go
+++ b/proxmox/heper_qemu_test.go
@@ -23,6 +23,11 @@ func Test_HasRequiredIP(t *testing.T) {
 				IPv4: "192.168.1.1"},
 				SkipIPv4: true},
 			output: false},
+		{name: `IPv4 SkipIPv6`,
+			input: connectionInfo{IPs: primaryIPs{
+				IPv4: "192.168.1.1"},
+				SkipIPv6: true},
+			output: true},
 		{name: `SkipIPv4`,
 			input:  connectionInfo{},
 			output: false},
@@ -30,6 +35,11 @@ func Test_HasRequiredIP(t *testing.T) {
 			input: connectionInfo{IPs: primaryIPs{
 				IPv6: "2001:0db8:85a3:0000:0000:8a2e:0370:7334"}},
 			output: false},
+		{name: `IPv6 SkipIPv4`,
+			input: connectionInfo{IPs: primaryIPs{
+				IPv6: "2001:0db8:85a3:0000:0000:8a2e:0370:7334"},
+				SkipIPv4: true},
+			output: true},
 		{name: `IPv6 SkipIPv6`,
 			input: connectionInfo{IPs: primaryIPs{
 				IPv6: "2001:0db8:85a3:0000:0000:8a2e:0370:7334"},

--- a/proxmox/resource_vm_qemu.go
+++ b/proxmox/resource_vm_qemu.go
@@ -1918,6 +1918,7 @@ func getPrimaryIP(config *pxapi.ConfigQemu, vmr *pxapi.VmRef, client *pxapi.Clie
 	}
 	// check if cloud init is enabled
 	if config.HasCloudInit() {
+		log.Print("[INFO][getPrimaryIP] vm has a cloud-init configuration")
 		logger.Debug().Int("vmid", vmr.VmId()).Msgf(" vm has a cloud-init configuration")
 		CiInterface := d.Get("ipconfig0")
 		conn = parseCloudInitInterface(CiInterface.(string), conn.SkipIPv4, conn.SkipIPv6)
@@ -1948,11 +1949,13 @@ func getPrimaryIP(config *pxapi.ConfigQemu, vmr *pxapi.VmRef, client *pxapi.Clie
 				if !strings.Contains(err.Error(), ErrorGuestAgentNotRunning) {
 					return primaryIPs{}, diag.FromErr(err)
 				}
+				log.Printf("[INFO][getPrimaryIP] check ip result error %s", err.Error())
 				logger.Debug().Int("vmid", vmr.VmId()).Msgf("check ip result error %s", err.Error())
 			} else { // vm is running and reachable
 				if len(interfaces) > 0 { // agent returned some information
 					logger.Info().Int("vmid", vmr.VmId()).Msgf("found working QEMU Agent")
-					logger.Debug().Int("vmid", vmr.VmId()).Msgf("interfaces found: %v", interfaces)
+					log.Printf("[INFO][getPrimaryIP] QEMU Agent interfaces found: %v", interfaces)
+					logger.Debug().Int("vmid", vmr.VmId()).Msgf("QEMU Agent interfaces found: %v", interfaces)
 					conn = conn.parsePrimaryIPs(interfaces, net0MacAddress)
 					if conn.hasRequiredIP() {
 						return conn.IPs, diag.Diagnostics{}

--- a/proxmox/resource_vm_qemu.go
+++ b/proxmox/resource_vm_qemu.go
@@ -1965,7 +1965,7 @@ func getPrimaryIP(config *pxapi.ConfigQemu, vmr *pxapi.VmRef, client *pxapi.Clie
 				if len(interfaces) > 0 { // agent returned some information
 					logger.Info().Int("vmid", vmr.VmId()).Msgf("found working QEMU Agent")
 					logger.Debug().Int("vmid", vmr.VmId()).Msgf("interfaces found: %v", interfaces)
-					conn := conn.parsePrimaryIPs(interfaces, net0MacAddress)
+					conn = conn.parsePrimaryIPs(interfaces, net0MacAddress)
 					if conn.hasRequiredIP() {
 						return conn.IPs, diag.Diagnostics{}
 					}

--- a/proxmox/resource_vm_qemu.go
+++ b/proxmox/resource_vm_qemu.go
@@ -1987,12 +1987,15 @@ func getPrimaryIP(config *pxapi.ConfigQemu, vmr *pxapi.VmRef, client *pxapi.Clie
 					Summary:  "Qemu Guest Agent is enabled but no IP config is found",
 					Detail:   "Qemu Guest Agent is enabled in your configuration but no IP address was found before the time ran out, increasing 'agent_timeout' could resolve this issue."}}
 			}
-			return conn.IPs, diag.Diagnostics{diag.Diagnostic{
-				Severity: diag.Warning,
-				Summary:  "Qemu Guest Agent is enabled but no IPv4 address is found",
-				Detail:   "Qemu Guest Agent is enabled in your configuration but no IPv4 address was found before the time ran out, increasing 'agent_timeout' could resolve this issue. To suppress this warning set 'skip_ipv4' to true."}}
+			if !conn.SkipIPv4 {
+				return conn.IPs, diag.Diagnostics{diag.Diagnostic{
+					Severity: diag.Warning,
+					Summary:  "Qemu Guest Agent is enabled but no IPv4 address is found",
+					Detail:   "Qemu Guest Agent is enabled in your configuration but no IPv4 address was found before the time ran out, increasing 'agent_timeout' could resolve this issue. To suppress this warning set 'skip_ipv4' to true."}}
+			}
+			return conn.IPs, diag.Diagnostics{}
 		}
-		if conn.IPs.IPv6 == "" {
+		if conn.IPs.IPv6 == "" && !conn.SkipIPv6 {
 			return conn.IPs, diag.Diagnostics{diag.Diagnostic{
 				Severity: diag.Warning,
 				Summary:  "Qemu Guest Agent is enabled but no IPv6 address is found",

--- a/proxmox/resource_vm_qemu.go
+++ b/proxmox/resource_vm_qemu.go
@@ -1974,27 +1974,7 @@ func getPrimaryIP(config *pxapi.ConfigQemu, vmr *pxapi.VmRef, client *pxapi.Clie
 			}
 			return primaryIPs{}, diag.FromErr(err)
 		}
-		if conn.IPs.IPv4 == "" {
-			if conn.IPs.IPv6 == "" {
-				return primaryIPs{}, diag.Diagnostics{diag.Diagnostic{
-					Severity: diag.Warning,
-					Summary:  "Qemu Guest Agent is enabled but no IP config is found",
-					Detail:   "Qemu Guest Agent is enabled in your configuration but no IP address was found before the time ran out, increasing 'agent_timeout' could resolve this issue."}}
-			}
-			if !conn.SkipIPv4 {
-				return conn.IPs, diag.Diagnostics{diag.Diagnostic{
-					Severity: diag.Warning,
-					Summary:  "Qemu Guest Agent is enabled but no IPv4 address is found",
-					Detail:   "Qemu Guest Agent is enabled in your configuration but no IPv4 address was found before the time ran out, increasing 'agent_timeout' could resolve this issue. To suppress this warning set 'skip_ipv4' to true."}}
-			}
-			return conn.IPs, diag.Diagnostics{}
-		}
-		if conn.IPs.IPv6 == "" && !conn.SkipIPv6 {
-			return conn.IPs, diag.Diagnostics{diag.Diagnostic{
-				Severity: diag.Warning,
-				Summary:  "Qemu Guest Agent is enabled but no IPv6 address is found",
-				Detail:   "Qemu Guest Agent is enabled in your configuration but no IPv6 address was found before the time ran out, increasing 'agent_timeout' could resolve this issue. To suppress this warning set 'skip_ipv6' to true."}}
-		}
+		return conn.IPs, conn.agentDiagnostics()
 	}
 	return conn.IPs, diag.Diagnostics{}
 }

--- a/proxmox/resource_vm_qemu.go
+++ b/proxmox/resource_vm_qemu.go
@@ -1894,8 +1894,8 @@ func initConnInfo(ctx context.Context,
 	logger.Debug().Int("vmid", vmr.VmId()).Msgf("this is the vm configuration: %s %s", sshHost, sshPort)
 
 	// Optional convenience attributes for provisioners
-	_ = d.Set("default_ipv4_address", sshHost)
-	_ = d.Set("default_ipv6_address", sshHost)
+	_ = d.Set("default_ipv4_address", IPs.IPv4)
+	_ = d.Set("default_ipv6_address", IPs.IPv6)
 	_ = d.Set("ssh_host", sshHost)
 	_ = d.Set("ssh_port", sshPort)
 

--- a/proxmox/resource_vm_qemu.go
+++ b/proxmox/resource_vm_qemu.go
@@ -1953,7 +1953,6 @@ func getPrimaryIP(config *pxapi.ConfigQemu, vmr *pxapi.VmRef, client *pxapi.Clie
 				logger.Debug().Int("vmid", vmr.VmId()).Msgf("check ip result error %s", err.Error())
 			} else { // vm is running and reachable
 				if len(interfaces) > 0 { // agent returned some information
-					logger.Info().Int("vmid", vmr.VmId()).Msgf("found working QEMU Agent")
 					log.Printf("[INFO][getPrimaryIP] QEMU Agent interfaces found: %v", interfaces)
 					logger.Debug().Int("vmid", vmr.VmId()).Msgf("QEMU Agent interfaces found: %v", interfaces)
 					conn = conn.parsePrimaryIPs(interfaces, net0MacAddress)

--- a/proxmox/resource_vm_qemu.go
+++ b/proxmox/resource_vm_qemu.go
@@ -1880,7 +1880,9 @@ func initConnInfo(ctx context.Context,
 	} else {
 		log.Print("[DEBUG][initConnInfo] Cannot find any IP address")
 		logger.Debug().Int("vmid", vmr.VmId()).Msgf("Cannot find any IP address")
-		return diag.FromErr(fmt.Errorf("cannot find any IP address"))
+		return append(diags, diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  "Cannot find any IP address"})
 	}
 
 	sshPort := "22"

--- a/proxmox/resource_vm_qemu.go
+++ b/proxmox/resource_vm_qemu.go
@@ -1858,8 +1858,6 @@ func initConnInfo(ctx context.Context,
 
 	log.Print("[INFO][initConnInfo] trying to get vm ip address for provisioner")
 	logger.Info().Int("vmid", vmr.VmId()).Msgf("trying to get vm ip address for provisioner")
-	sshPort := "22"
-	var sshHost string
 
 	// wait until the os has started the guest agent
 	guestAgentTimeout := d.Timeout(schema.TimeoutCreate)
@@ -1874,18 +1872,18 @@ func initConnInfo(ctx context.Context,
 		return append(diags, agentDiags...)
 	}
 
+	var sshHost string
 	if IPs.IPv4 != "" {
 		sshHost = IPs.IPv4
 	} else if IPs.IPv6 != "" {
 		sshHost = IPs.IPv6
-	}
-
-	if sshHost == "" {
+	} else {
 		log.Print("[DEBUG][initConnInfo] Cannot find any IP address")
 		logger.Debug().Int("vmid", vmr.VmId()).Msgf("Cannot find any IP address")
 		return diag.FromErr(fmt.Errorf("cannot find any IP address"))
 	}
 
+	sshPort := "22"
 	log.Printf("[DEBUG][initConnInfo] this is the vm configuration: %s %s", sshHost, sshPort)
 	logger.Debug().Int("vmid", vmr.VmId()).Msgf("this is the vm configuration: %s %s", sshHost, sshPort)
 

--- a/proxmox/resource_vm_qemu.go
+++ b/proxmox/resource_vm_qemu.go
@@ -796,18 +796,12 @@ func resourceVmQemu() *schema.Resource {
 				Optional:      true,
 				Default:       false,
 				ConflictsWith: []string{"skip_ipv6"},
-				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-					return true
-				},
 			},
 			"skip_ipv6": {
 				Type:          schema.TypeBool,
 				Optional:      true,
 				Default:       false,
 				ConflictsWith: []string{"skip_ipv4"},
-				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-					return true
-				},
 			},
 			"reboot_required": {
 				Type:        schema.TypeBool,


### PR DESCRIPTION
fixes #1015

- Introduced `agent_timeout` to configure for how long we will try to get an IP address from the qemu guest agent before throwing a warning.
- Added test cases to `connectionInfo.hasRequiredIP()`.
- Improved explicitness of control flow.


Haven't tested yet.