### PR TITLE
Doc fix: proxmox_cloud_init_disk

### DIFF
--- a/docs/resources/cloud_init_disk.md
+++ b/docs/resources/cloud_init_disk.md
@@ -26,13 +26,13 @@ resource "proxmox_cloud_init_disk" "ci" {
     local-hostname = local.vm_name
   })
 
-  user_data = <<EOT
-#cloud-config
-users:
-  - default
-ssh_authorized_keys:
-  - ssh-rsa AAAAB3N......
-EOT
+  user_data = <<-EOT
+  #cloud-config
+  users:
+    - default
+  ssh_authorized_keys:
+    - ssh-rsa AAAAB3N......
+  EOT
 
   network_config = yamlencode({
     version = 1
@@ -43,27 +43,29 @@ EOT
         type            = "static"
         address         = "192.168.1.100/24"
         gateway         = "192.168.1.1"
-        dns_nameservers = ["1.1.1.1", "8.8.8.8"]
+        dns_nameservers = [
+          "1.1.1.1", 
+          "8.8.8.8"
+          ]
       }]
     }]
   })
 }
 
 resource "proxmox_vm_qemu" "vm" {
-....
+...
   // Define a disk block with media type cdrom which reference the generated cloud-init disk
   disks {
     scsi {
       scsi0 {
-        cd {
-          iso = "${local.iso_storage_pool}:${proxmox_cloud_init_disk.ci.id}"
+        cdrom {
+          iso = "${proxmox_cloud_init_disk.ci.id}"
         }
       }
     }
   }
 ...
 }
-
 ```
 
 ## Argument reference


### PR DESCRIPTION
Fix cdrom part
- [`cd => cdrom`](https://github.com/Telmate/terraform-provider-proxmox/blob/master/docs/resources/vm_qemu.md#disksxcdrom-block)
- extra variable `${local.iso_storage_pool}` fails and updates causes this issue:

`iso         = "cephfs:iso/tf-ci-***.iso" -> "cephfs:cephfs:iso/tf-ci-***.iso"`

```log
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # proxmox_vm_qemu.cloud_vm_from_packer_template will be updated in-place
  ~ resource "proxmox_vm_qemu" "cloud_vm_from_packer_template" {
        id                     = "***/qemu/***"
        name                   = "***"
        tags                   = "***"
        # (67 unchanged attributes hidden)

      ~ disks {
          ~ scsi {
              ~ scsi11 {
                  ~ cdrom {
                      ~ iso         = "cephfs:iso/tf-ci-***.iso" -> "cephfs:cephfs:iso/tf-ci-***.iso"
                        # (1 unchanged attribute hidden)
                    }
                }

                # (1 unchanged block hidden)
            }
        }

        # (3 unchanged blocks hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
```