### PR TITLE
Patch for VM ID where a VM might be overwritten

### DIFF
--- a/proxmox/provider.go
+++ b/proxmox/provider.go
@@ -102,7 +102,7 @@ func Provider() *schema.Provider {
 			"pm_tls_insecure": {
 				Type:        schema.TypeBool,
 				Optional:    true,
-				DefaultFunc: schema.EnvDefaultFunc("PM_TLS_INSECURE", true), //we assume it's a lab!
+				DefaultFunc: schema.EnvDefaultFunc("PM_TLS_INSECURE", true), // we assume it's a lab!
 				Description: "By default, every TLS connection is verified to be secure. This option allows terraform to proceed and operate on servers considered insecure. For example if you're connecting to a remote host and you do not have the CA cert that issued the proxmox api url's certificate.",
 			},
 			"pm_http_headers": {
@@ -192,7 +192,7 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 		return nil, err
 	}
 
-	//permission check
+	// permission check
 	minimumPermissions := []string{
 		"Datastore.AllocateSpace",
 		"Datastore.Audit",
@@ -328,11 +328,12 @@ func getClient(pm_api_url string,
 func nextVmId(pconf *providerConfiguration) (nextId int, err error) {
 	pconf.Mutex.Lock()
 	defer pconf.Mutex.Unlock()
-	pconf.MaxVMID, err = pconf.Client.GetNextID(pconf.MaxVMID + 1)
+	nextId, err = pconf.Client.GetNextID(0)
 	if err != nil {
 		return 0, err
 	}
-	nextId = pconf.MaxVMID
+	pconf.MaxVMID = nextId
+
 	return nextId, nil
 }
 

--- a/proxmox/resource_vm_qemu.go
+++ b/proxmox/resource_vm_qemu.go
@@ -15,15 +15,17 @@ import (
 	"time"
 
 	pxapi "github.com/Telmate/proxmox-api-go/proxmox"
-	"github.com/Telmate/terraform-provider-proxmox/v2/proxmox/Internal/pxapi/dns/nameservers"
-	"github.com/Telmate/terraform-provider-proxmox/v2/proxmox/Internal/pxapi/guest/sshkeys"
-	"github.com/Telmate/terraform-provider-proxmox/v2/proxmox/Internal/pxapi/guest/tags"
+
 	"github.com/google/uuid"
 	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/Telmate/terraform-provider-proxmox/v2/proxmox/Internal/pxapi/dns/nameservers"
+	"github.com/Telmate/terraform-provider-proxmox/v2/proxmox/Internal/pxapi/guest/sshkeys"
+	"github.com/Telmate/terraform-provider-proxmox/v2/proxmox/Internal/pxapi/guest/tags"
 )
 
 // using a global variable here so that we have an internally accessible
@@ -1469,10 +1471,14 @@ func resourceVmQemuRead(ctx context.Context, d *schema.ResourceData, meta interf
 	d.Set("full_clone", d.Get("full_clone"))
 
 	// read in the qemu hostpci
-	qemuPCIDevices, _ := FlattenDevicesList(config.QemuPCIDevices)
+	qemuPCIDevices, err := FlattenDevicesList(config.QemuPCIDevices)
+	if err != nil {
+		return diag.FromErr(fmt.Errorf("unable to flatten QEMU PCI devices: %w", err))
+	}
+	qemuPCIDevices, _ = DropElementsFromMap([]string{"id"}, qemuPCIDevices)
 	logger.Debug().Int("vmid", vmID).Msgf("Hostpci Block Processed '%v'", config.QemuPCIDevices)
 	if err = d.Set("hostpci", qemuPCIDevices); err != nil {
-		return diag.FromErr(err)
+		return diag.FromErr(fmt.Errorf("unable to set hostpci: %w", err))
 	}
 
 	// read in the qemu hostpci


### PR DESCRIPTION
Fix: force an API call to retrieve the next VM id from Proxmox API rather than relying on local state.

We've found in our day to day operations that an **existing** VM was being overwritten. This patch should fix it.