### PR TITLE
Fix invalid address to set for usb config

### DIFF
--- a/proxmox/resource_vm_qemu.go
+++ b/proxmox/resource_vm_qemu.go
@@ -1471,6 +1471,7 @@ func resourceVmQemuRead(ctx context.Context, d *schema.ResourceData, meta interf
 
 	// read in the qemu hostpci
 	qemuUsbsDevices, _ := FlattenDevicesList(config.QemuUsbs)
+	qemuUsbsDevices, _ = DropElementsFromMap([]string{"id"}, qemuUsbsDevices)
 	logger.Debug().Int("vmid", vmID).Msgf("Usb Block Processed '%v'", config.QemuUsbs)
 	if err = d.Set("usb", qemuUsbsDevices); err != nil {
 		return diag.FromErr(err)


### PR DESCRIPTION
Configuring usb devices currenlty does not work and leads to an error #1032.

` Error: Invalid address to set: []string{"usb", "0", "id"} `

@lucian-tx fixed a similar issue for the hostpci config (#1029), which also works for the usb config.