### PR TITLE
add MTU documentation for qemu vm

### DIFF
--- a/docs/resources/vm_qemu.md
+++ b/docs/resources/vm_qemu.md
@@ -172,7 +172,7 @@ details.
 | `bridge`    | `str`  | `"nat"`       | Bridge to which the network device should be attached. The Proxmox VE standard bridge is called `vmbr0`. |
 | `tag`       | `int`  | `-1`          | The VLAN tag to apply to packets on this device. `-1` disables VLAN tagging. |
 | `firewall`  | `bool` | `false`       | Whether to enable the Proxmox firewall on this network device. |
-| `mtu`       | `int`  |               | The MTU value for the network device. On ``virtio`` models, set to ``1`` to inherit the MTU value from the underlying bridge.
+| `mtu`       | `int`  |               | The MTU value for the network device. On ``virtio`` models, set to ``1`` to inherit the MTU value from the underlying bridge. |
 | `rate`      | `int`  | `0`           | Network device rate limit in mbps (megabytes per second) as floating point number. Set to `0` to disable rate limiting. |
 | `queues`    | `int`  | `1`           | Number of packet queues to be used on the device. Requires `virtio` model to have an effect. |
 | `link_down` | `bool` | `false`       | Whether this interface should be disconnected (like pulling the plug). |

--- a/docs/resources/vm_qemu.md
+++ b/docs/resources/vm_qemu.md
@@ -172,6 +172,7 @@ details.
 | `bridge`    | `str`  | `"nat"`       | Bridge to which the network device should be attached. The Proxmox VE standard bridge is called `vmbr0`. |
 | `tag`       | `int`  | `-1`          | The VLAN tag to apply to packets on this device. `-1` disables VLAN tagging. |
 | `firewall`  | `bool` | `false`       | Whether to enable the Proxmox firewall on this network device. |
+| `mtu`       | `int`  |               | The MTU value for the network device. On ``virtio`` models, set to ``1`` to inherit the MTU value from the underlying bridge.
 | `rate`      | `int`  | `0`           | Network device rate limit in mbps (megabytes per second) as floating point number. Set to `0` to disable rate limiting. |
 | `queues`    | `int`  | `1`           | Number of packet queues to be used on the device. Requires `virtio` model to have an effect. |
 | `link_down` | `bool` | `false`       | Whether this interface should be disconnected (like pulling the plug). |


### PR DESCRIPTION
Configuring the MTU for a qemu vm is already implemented, but is it not currently documented.

added in #498 

https://github.com/Telmate/terraform-provider-proxmox/blob/master/proxmox/resource_vm_qemu.go#L364