### PR TITLE
Feat: Full Qemu PCI support

### DIFF
--- a/docs/resources/vm_qemu.md
+++ b/docs/resources/vm_qemu.md
@@ -545,6 +545,81 @@ See the [docs about EFI disks](https://pve.proxmox.com/pve-docs/chapter-qm.html#
 | `efitype` | `str` | `"4m"`        | The type of efi disk device to add. Options: `2m`, `4m`               |
 | `storage` | `str` |               | **Required** The name of the storage pool on which to store the disk. |
 
+### PCI Block
+
+The `pci` block is used to configure PCI devices. It may be specified multiple times.
+Don't need it in a module? Use the [PCIs Block](#pcis-block) instead.
+
+| Argument        | Type   | Default Value | Description |
+| :-------------- | :----: | :-----------: | :---------- |
+| `id`            | `str`  |               | **Required** The id of the PCI device. Range `0` - `15`. |
+| `mapping_id`    | `str`  |               | **Required\*** The id of the mapping. Conflicts with `raw_id`.|
+| `raw_id`        | `str`  |               | **Required\*** The id of the raw device. Conflicts with `mapping_id`.|
+| `pcie`          | `bool` | `false`       | Whether this device is a `PCIe` device. |
+| `primary_gpu`   | `bool` | `false`       | Whether this PCI device is the primary GPU. |
+| `rombar`        | `bool` | `true`        | Whether to enable the ROM-BAR. |
+| `device_id`     | `str`  |               | The device id of the PCI device. |
+| `vendor_id`     | `str`  |               | The vendor id of the PCI device. |
+| `sub_device_id` | `str`  |               | The sub device id of the PCI device. |
+| `sub_vendor_id` | `str`  |               | The sub vendor id of the PCI device. |
+
+\* Either `mapping_id` or `raw_id` is required.
+
+### PCIs Block
+
+The `pcis` block is used to configure PCI devices.
+There are two types of PCI devices `mapping`, and `raw`. Each of these types has their own block with their own arguments.
+
+These types share the following arguments, with minor differences:
+
+| Argument        | Type   | Default Value | PCI types        |Description |
+| :-------------- | :----: | :-----------: | :--------------: | :--------- |
+| `mapping_id`    | `str`  |               | `mapping`        | **Required** The id of the mapping. |
+| `raw_id`        | `str`  |               | `raw`            | **Required** The id of the raw device. |
+| `pcie`          | `bool` | `false`       | `mapping`, `raw` | Whether this device is a `PCIe` device. |
+| `primary_gpu`   | `bool` | `false`       | `mapping`, `raw` | Whether this PCI device is the primary GPU. |
+| `rombar`        | `bool` | `true`        | `mapping`, `raw` | Whether to enable the ROM-BAR. |
+| `device_id`     | `str`  |               | `mapping`, `raw` | The device id of the PCI device. |
+| `vendor_id`     | `str`  |               | `mapping`, `raw` | The vendor id of the PCI device. |
+| `sub_device_id` | `str`  |               | `mapping`, `raw` | The sub device id of the PCI device. |
+| `sub_vendor_id` | `str`  |               | `mapping`, `raw` | The sub vendor id of the PCI device. |
+
+The range of pci devices is from `pci0` to `pci15`.
+
+Example:
+
+```hcl
+resource "proxmox_vm_qemu" "resource-name" {
+  // ...
+  pcis {
+    pci0 {
+      mapping {
+        mapping_id = "mapping-id"
+        pcie = true
+        primary_gpu = true
+        rombar = true
+        device_id = "device-id"
+        vendor_id = "vendor-id"
+        sub_device_id = "sub-device-id"
+        sub_vendor_id = "sub-vendor-id"
+      }
+    }
+    pci15 {
+      raw {
+        raw_id = "raw-id"
+        pcie = true
+        primary_gpu = true
+        rombar = true
+        device_id = "device-id"
+        vendor_id = "vendor-id"
+        sub_device_id = "sub-device-id"
+        sub_vendor_id = "sub-vendor-id"
+      }
+    }
+  }
+}
+```
+
 ### Serial Block
 
 Create a serial device inside the VM (up to a maximum of 4 can be specified), and either pass through a host serial device (i.e. /dev/ttyS0), or create a unix socket on the host side. The order in which `serial` blocks are declared does not matter.

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.21
 toolchain go1.21.0
 
 require (
-	github.com/Telmate/proxmox-api-go v0.0.0-20241109120634-0146e30e530a
+	github.com/Telmate/proxmox-api-go v0.0.0-20241121215203-222002bcb5bc
 	github.com/google/uuid v1.6.0
 	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.34.0

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,8 @@ github.com/Microsoft/go-winio v0.6.1 h1:9/kr64B9VUZrLm5YYwbGtUJnMgqWVOdUAXu6Migc
 github.com/Microsoft/go-winio v0.6.1/go.mod h1:LRdKpFKfdobln8UmuiYcKPot9D2v6svN5+sAH+4kjUM=
 github.com/ProtonMail/go-crypto v1.1.0-alpha.2-proton h1:HKz85FwoXx86kVtTvFke7rgHvq/HoloSUvW5semjFWs=
 github.com/ProtonMail/go-crypto v1.1.0-alpha.2-proton/go.mod h1:rA3QumHc/FZ8pAHreoekgiAbzpNsfQAosU5td4SnOrE=
-github.com/Telmate/proxmox-api-go v0.0.0-20241109120634-0146e30e530a h1:HLnjs22IoYtL3QBkOXiABuQhfg6WDJGbENV6+lzPgtQ=
-github.com/Telmate/proxmox-api-go v0.0.0-20241109120634-0146e30e530a/go.mod h1:Gu6n6vEn1hlyFUkjrvU+X1fdgaSXLoM9HKYYJqy1fsY=
+github.com/Telmate/proxmox-api-go v0.0.0-20241121215203-222002bcb5bc h1:gKm4H2rehb9iTWh4OW/Yt/SNJwoTLHTam+Trjkz2HHY=
+github.com/Telmate/proxmox-api-go v0.0.0-20241121215203-222002bcb5bc/go.mod h1:Gu6n6vEn1hlyFUkjrvU+X1fdgaSXLoM9HKYYJqy1fsY=
 github.com/agext/levenshtein v1.2.3 h1:YB2fHEn0UJagG8T1rrWknE3ZQzWM06O8AMAatNn7lmo=
 github.com/agext/levenshtein v1.2.3/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
 github.com/apparentlymart/go-textseg/v12 v12.0.0/go.mod h1:S/4uRK2UtaQttw1GenVJEynmyUenKwP++x/+DdGV/Ec=

--- a/proxmox/Internal/resource/guest/qemu/pci/schema.go
+++ b/proxmox/Internal/resource/guest/qemu/pci/schema.go
@@ -1,0 +1,325 @@
+package pci
+
+import (
+	"strconv"
+
+	pveAPI "github.com/Telmate/proxmox-api-go/proxmox"
+	"github.com/hashicorp/go-cty/cty"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+const (
+	RootLegacyPCI string = "hostpci" // DEPRECATED
+	RootPCI       string = "pci"
+	RootPCIs      string = "pcis"
+
+	amountPCIs  = int(pveAPI.QemuPciDevicesAmount)
+	maximumPCIs = int(pveAPI.QemuPciIDMaximum)
+
+	prefixSchemaID string = "pci"
+
+	schemaMapping string = "mapping"
+	schemaRaw     string = "raw"
+
+	schemaID string = "id"
+
+	schemaDeviceID    string = "device_id"
+	schemaMappingID   string = "mapping_id"
+	schemaPCIe        string = "pcie"
+	schemaPrimaryGPU  string = "primary_gpu"
+	schemaRawID       string = "raw_id"
+	schemaROMbar      string = "rombar"
+	schemaSubDeviceID string = "sub_device_id"
+	schemaSubVendorID string = "sub_vendor_id"
+	schemaVendorID    string = "vendor_id"
+
+	legacySchemaHost string = "host"
+)
+
+func SchemaLegacyPCI() *schema.Schema {
+	return &schema.Schema{
+		Type:          schema.TypeList,
+		Optional:      true,
+		MaxItems:      amountPCIs,
+		Deprecated:    "Use '" + RootPCI + "' instead",
+		ConflictsWith: []string{RootPCI, RootPCIs},
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				legacySchemaHost: subSchemaRawID(schema.Schema{Required: true}),
+				schemaPCIe: {
+					Type:     schema.TypeInt,
+					Optional: true},
+				schemaROMbar: {
+					Type:     schema.TypeInt,
+					Optional: true}}}}
+}
+
+func SchemaPCI() *schema.Schema {
+	return &schema.Schema{
+		Type:          schema.TypeList,
+		Optional:      true,
+		MaxItems:      amountPCIs,
+		ConflictsWith: []string{RootPCIs},
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				schemaID: {
+					Type:     schema.TypeInt,
+					Required: true,
+					ValidateDiagFunc: func(i interface{}, k cty.Path) diag.Diagnostics {
+						v, ok := i.(int)
+						if !ok || v < 0 {
+							return diag.Diagnostics{diag.Diagnostic{
+								Severity:      diag.Error,
+								Summary:       "Invalid " + schemaID,
+								Detail:        schemaID + " must be a positive integer",
+								AttributePath: k}}
+						}
+						if err := pveAPI.QemuPciID(v).Validate(); err != nil {
+							return diag.Diagnostics{diag.Diagnostic{
+								Severity:      diag.Error,
+								Summary:       schemaID + " must be in the range of 0 to " + strconv.Itoa(maximumPCIs),
+								AttributePath: k}}
+						}
+						return nil
+					}},
+				schemaDeviceID:    subSchemaDeviceID(),
+				schemaMappingID:   subSchemaMappingID(schema.Schema{Optional: true}),
+				schemaPCIe:        subSchemaPCIe(),
+				schemaPrimaryGPU:  subSchemaPrimaryGPU(),
+				schemaROMbar:      subSchemaRomBar(),
+				schemaSubDeviceID: subSchemaSubDeviceID(),
+				schemaSubVendorID: subSchemaSubVendorID(),
+				schemaVendorID:    subSchemaVendorID(),
+				schemaRawID:       subSchemaRawID(schema.Schema{Optional: true})}}}
+}
+
+func SchemaPCIs() *schema.Schema {
+	schemaItems := make(map[string]*schema.Schema)
+	for i := 0; i < maximumPCIs; i++ {
+		id := strconv.Itoa(i)
+		schemaItems[prefixSchemaID+id] = subSchemaPCIs(prefixSchemaID + id)
+	}
+	return &schema.Schema{
+		Type:          schema.TypeList,
+		Optional:      true,
+		MaxItems:      1,
+		ConflictsWith: []string{RootPCI},
+		Elem: &schema.Resource{
+			Schema: schemaItems}}
+}
+
+func subSchemaPCIs(slot string) *schema.Schema {
+	path := RootPCIs + ".0." + slot + ".0."
+	return &schema.Schema{
+		Type:     schema.TypeList,
+		Optional: true,
+		MaxItems: 1,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				schemaMapping: {
+					Type:          schema.TypeList,
+					Optional:      true,
+					MaxItems:      1,
+					ConflictsWith: []string{path + schemaRaw},
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							schemaDeviceID:    subSchemaDeviceID(),
+							schemaMappingID:   subSchemaMappingID(schema.Schema{Required: true}),
+							schemaPCIe:        subSchemaPCIe(),
+							schemaPrimaryGPU:  subSchemaPrimaryGPU(),
+							schemaROMbar:      subSchemaRomBar(),
+							schemaSubDeviceID: subSchemaSubDeviceID(),
+							schemaSubVendorID: subSchemaSubVendorID(),
+							schemaVendorID:    subSchemaVendorID(),
+						}}},
+				schemaRaw: {
+					Type:          schema.TypeList,
+					Optional:      true,
+					MaxItems:      1,
+					ConflictsWith: []string{path + schemaMapping},
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							schemaDeviceID:    subSchemaDeviceID(),
+							schemaPCIe:        subSchemaPCIe(),
+							schemaPrimaryGPU:  subSchemaPrimaryGPU(),
+							schemaRawID:       subSchemaRawID(schema.Schema{Required: true}),
+							schemaROMbar:      subSchemaRomBar(),
+							schemaSubDeviceID: subSchemaSubDeviceID(),
+							schemaSubVendorID: subSchemaSubVendorID(),
+							schemaVendorID:    subSchemaVendorID(),
+						}}}}}}
+}
+
+func subSchemaMappingID(s schema.Schema) *schema.Schema {
+	s.Type = schema.TypeString
+	s.ValidateDiagFunc = func(i interface{}, path cty.Path) diag.Diagnostics {
+		v, ok := i.(string)
+		if !ok {
+			return diag.Diagnostics{diag.Diagnostic{
+				Severity:      diag.Error,
+				Summary:       "Invalid " + schemaMappingID,
+				Detail:        schemaMappingID + " must be a string",
+				AttributePath: path}}
+		}
+		if err := pveAPI.ResourceMappingPciID(v).Validate(); err != nil {
+			return diag.Diagnostics{diag.Diagnostic{
+				Severity:      diag.Error,
+				Summary:       "Invalid " + schemaMappingID,
+				AttributePath: path}}
+		}
+		return nil
+	}
+	return &s
+}
+
+func subSchemaRawID(s schema.Schema) *schema.Schema {
+	s.Type = schema.TypeString
+
+	s.ValidateDiagFunc = func(i interface{}, path cty.Path) diag.Diagnostics {
+		v, ok := i.(string)
+		if !ok {
+			return diag.Diagnostics{diag.Diagnostic{
+				Severity:      diag.Error,
+				Summary:       "Invalid " + schemaRawID,
+				Detail:        schemaRawID + " must be a string",
+				AttributePath: path}}
+		}
+		if err := pveAPI.PciID(v).Validate(); err != nil {
+			return diag.Diagnostics{diag.Diagnostic{
+				Severity:      diag.Error,
+				Summary:       "Invalid " + schemaRawID,
+				AttributePath: path}}
+		}
+		return nil
+	}
+	return &s
+}
+
+func subSchemaPCIe() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeBool,
+		Optional: true}
+}
+
+func subSchemaRomBar() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeBool,
+		Default:  true,
+		Optional: true}
+}
+
+func subSchemaPrimaryGPU() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeBool,
+		Default:  false,
+		Optional: true}
+}
+
+func subSchemaVendorID() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeString,
+		Default:  "",
+		Optional: true,
+		DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+			return pveAPI.PciVendorID(old).String() == pveAPI.PciVendorID(new).String()
+		},
+		ValidateDiagFunc: func(i interface{}, path cty.Path) diag.Diagnostics {
+			v, ok := i.(string)
+			if !ok {
+				return diag.Diagnostics{diag.Diagnostic{
+					Severity:      diag.Error,
+					Summary:       "Invalid " + schemaVendorID,
+					Detail:        schemaVendorID + " must be a string",
+					AttributePath: path}}
+			}
+			if err := pveAPI.PciSubDeviceID(v).Validate(); err != nil {
+				return diag.Diagnostics{diag.Diagnostic{
+					Severity:      diag.Error,
+					Summary:       "Invalid " + schemaVendorID,
+					AttributePath: path}}
+			}
+			return nil
+		}}
+}
+
+func subSchemaDeviceID() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeString,
+		Default:  "",
+		Optional: true,
+		DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+			return pveAPI.PciDeviceID(old).String() == pveAPI.PciDeviceID(new).String()
+		},
+		ValidateDiagFunc: func(i interface{}, path cty.Path) diag.Diagnostics {
+			v, ok := i.(string)
+			if !ok {
+				return diag.Diagnostics{diag.Diagnostic{
+					Severity:      diag.Error,
+					Summary:       "Invalid " + schemaDeviceID,
+					Detail:        schemaDeviceID + " must be a string",
+					AttributePath: path}}
+			}
+			if err := pveAPI.PciDeviceID(v).Validate(); err != nil {
+				return diag.Diagnostics{diag.Diagnostic{
+					Severity:      diag.Error,
+					Summary:       "Invalid " + schemaDeviceID,
+					AttributePath: path}}
+			}
+			return nil
+		}}
+}
+
+func subSchemaSubVendorID() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeString,
+		Default:  "",
+		Optional: true,
+		DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+			return pveAPI.PciSubVendorID(old).String() == pveAPI.PciSubVendorID(new).String()
+		},
+		ValidateDiagFunc: func(i interface{}, path cty.Path) diag.Diagnostics {
+			v, ok := i.(string)
+			if !ok {
+				return diag.Diagnostics{diag.Diagnostic{
+					Severity:      diag.Error,
+					Summary:       "Invalid " + schemaSubVendorID,
+					Detail:        schemaSubVendorID + " must be a string",
+					AttributePath: path}}
+			}
+			if err := pveAPI.PciSubVendorID(v).Validate(); err != nil {
+				return diag.Diagnostics{diag.Diagnostic{
+					Severity:      diag.Error,
+					Summary:       "Invalid " + schemaSubVendorID,
+					AttributePath: path}}
+			}
+			return nil
+		}}
+}
+
+func subSchemaSubDeviceID() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeString,
+		Default:  "",
+		Optional: true,
+		DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+			return pveAPI.PciSubDeviceID(old).String() == pveAPI.PciSubDeviceID(new).String()
+		},
+		ValidateDiagFunc: func(i interface{}, path cty.Path) diag.Diagnostics {
+			v, ok := i.(string)
+			if !ok {
+				return diag.Diagnostics{diag.Diagnostic{
+					Severity:      diag.Error,
+					Summary:       "Invalid " + schemaSubDeviceID,
+					Detail:        schemaSubDeviceID + " must be a string",
+					AttributePath: path}}
+			}
+			if err := pveAPI.PciSubDeviceID(v).Validate(); err != nil {
+				return diag.Diagnostics{diag.Diagnostic{
+					Severity:      diag.Error,
+					Summary:       "Invalid " + schemaSubDeviceID,
+					AttributePath: path}}
+			}
+			return nil
+		}}
+}

--- a/proxmox/Internal/resource/guest/qemu/pci/sdk.go
+++ b/proxmox/Internal/resource/guest/qemu/pci/sdk.go
@@ -1,0 +1,126 @@
+package pci
+
+import (
+	"errors"
+	"strconv"
+
+	pveAPI "github.com/Telmate/proxmox-api-go/proxmox"
+	"github.com/Telmate/terraform-provider-proxmox/v2/proxmox/Internal/util"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+const (
+	errorMutualExclusive = schemaMappingID + " and " + schemaRawID + " are mutually exclusive"
+)
+
+// Converts the Terraform configuration to the SDK configuration
+func SDK(d *schema.ResourceData) (pveAPI.QemuPciDevices, diag.Diagnostics) {
+	pciDevices := make(pveAPI.QemuPciDevices, amountPCIs)
+	var diags diag.Diagnostics
+	if v, ok := d.GetOk(RootLegacyPCI); ok {
+		for i := pveAPI.QemuPciID(0); i < pveAPI.QemuPciID(amountPCIs); i++ {
+			pciDevices[i] = pveAPI.QemuPci{Delete: true}
+		}
+		for i, pci := range v.([]interface{}) {
+			pciDevices[pveAPI.QemuPciID(i)] = sdkLegacyPCI(pci.(map[string]interface{}))
+		}
+	} else if v, ok := d.GetOk(RootPCI); ok {
+		for i := pveAPI.QemuPciID(0); i < pveAPI.QemuPciID(amountPCIs); i++ {
+			pciDevices[i] = pveAPI.QemuPci{Delete: true}
+		}
+		var err error
+		var id pveAPI.QemuPciID
+		for _, pci := range v.([]interface{}) {
+			var tmpPCI pveAPI.QemuPci
+			id, tmpPCI, err = sdkPCI(pci.(map[string]interface{}))
+			pciDevices[id] = tmpPCI
+			diags = append(diags, diag.FromErr(err)...)
+		}
+	} else {
+		schemaItem := d.Get(RootPCIs).([]interface{})
+		if len(schemaItem) == 1 {
+			if subSchema, ok := schemaItem[0].(map[string]interface{}); ok {
+				for k, v := range subSchema {
+					tmpID, _ := strconv.ParseUint(k[len(prefixSchemaID):], 10, 64)
+					pciDevices[pveAPI.QemuPciID(tmpID)] = sdkPCIs_Unsafe(v.([]interface{}))
+				}
+			}
+		}
+	}
+	return pciDevices, diags
+}
+
+func sdkLegacyPCI(schema map[string]interface{}) pveAPI.QemuPci {
+	return pveAPI.QemuPci{
+		Raw: &pveAPI.QemuPciRaw{
+			ID:     util.Pointer(pveAPI.PciID(schema[legacySchemaHost].(string))),
+			PCIe:   util.Pointer(schema[schemaPCIe].(int) == 1),
+			ROMbar: util.Pointer(schema[schemaROMbar].(int) == 1)}}
+}
+
+func sdkPCI(schema map[string]interface{}) (pveAPI.QemuPciID, pveAPI.QemuPci, error) {
+	id := pveAPI.QemuPciID(schema[schemaID].(int))
+	if mapping := schema[schemaMappingID]; mapping != "" {
+		if raw := schema[schemaRawID]; raw != "" {
+			return id, pveAPI.QemuPci{}, errors.New(errorMutualExclusive)
+		}
+		return id, pveAPI.QemuPci{
+			Mapping: &pveAPI.QemuPciMapping{
+				DeviceID:    util.Pointer(pveAPI.PciDeviceID(schema[schemaDeviceID].(string))),
+				ID:          util.Pointer(pveAPI.ResourceMappingPciID(mapping.(string))),
+				PCIe:        util.Pointer(schema[schemaPCIe].(bool)),
+				PrimaryGPU:  util.Pointer(schema[schemaPrimaryGPU].(bool)),
+				ROMbar:      util.Pointer(schema[schemaROMbar].(bool)),
+				SubDeviceID: util.Pointer(pveAPI.PciSubDeviceID(schema[schemaSubDeviceID].(string))),
+				SubVendorID: util.Pointer(pveAPI.PciSubVendorID(schema[schemaSubVendorID].(string))),
+				VendorID:    util.Pointer(pveAPI.PciVendorID(schema[schemaVendorID].(string)))}}, nil
+	}
+	if raw := pveAPI.PciID(schema[schemaRawID].(string)); raw != "" {
+		return id, pveAPI.QemuPci{
+			Raw: &pveAPI.QemuPciRaw{
+				DeviceID:    util.Pointer(pveAPI.PciDeviceID(schema[schemaDeviceID].(string))),
+				ID:          util.Pointer(raw),
+				PCIe:        util.Pointer(schema[schemaPCIe].(bool)),
+				PrimaryGPU:  util.Pointer(schema[schemaPrimaryGPU].(bool)),
+				ROMbar:      util.Pointer(schema[schemaROMbar].(bool)),
+				SubDeviceID: util.Pointer(pveAPI.PciSubDeviceID(schema[schemaSubDeviceID].(string))),
+				SubVendorID: util.Pointer(pveAPI.PciSubVendorID(schema[schemaSubVendorID].(string))),
+				VendorID:    util.Pointer(pveAPI.PciVendorID(schema[schemaVendorID].(string)))}}, nil
+	}
+	return id, pveAPI.QemuPci{Delete: true}, nil
+}
+
+func sdkPCIs_Unsafe(schema []interface{}) pveAPI.QemuPci {
+	if len(schema) == 0 {
+		return pveAPI.QemuPci{Delete: true}
+	}
+	usedSchema := schema[0].(map[string]interface{})
+	if v, ok := usedSchema[schemaMapping].([]interface{}); ok && len(v) == 1 && v[0] != nil {
+		subSchema := v[0].(map[string]interface{})
+		return pveAPI.QemuPci{
+			Mapping: &pveAPI.QemuPciMapping{
+				DeviceID:    util.Pointer(pveAPI.PciDeviceID(subSchema[schemaDeviceID].(string))),
+				ID:          util.Pointer(pveAPI.ResourceMappingPciID(subSchema[schemaMappingID].(string))),
+				PCIe:        util.Pointer(subSchema[schemaPCIe].(bool)),
+				PrimaryGPU:  util.Pointer(subSchema[schemaPrimaryGPU].(bool)),
+				ROMbar:      util.Pointer(subSchema[schemaROMbar].(bool)),
+				SubDeviceID: util.Pointer(pveAPI.PciSubDeviceID(subSchema[schemaSubDeviceID].(string))),
+				SubVendorID: util.Pointer(pveAPI.PciSubVendorID(subSchema[schemaSubVendorID].(string))),
+				VendorID:    util.Pointer(pveAPI.PciVendorID(subSchema[schemaVendorID].(string)))}}
+	}
+	if v, ok := usedSchema[schemaRaw].([]interface{}); ok && len(v) == 1 && v[0] != nil {
+		subSchema := v[0].(map[string]interface{})
+		return pveAPI.QemuPci{
+			Raw: &pveAPI.QemuPciRaw{
+				DeviceID:    util.Pointer(pveAPI.PciDeviceID(subSchema[schemaDeviceID].(string))),
+				ID:          util.Pointer(pveAPI.PciID(subSchema[schemaRawID].(string))),
+				PCIe:        util.Pointer(subSchema[schemaPCIe].(bool)),
+				PrimaryGPU:  util.Pointer(subSchema[schemaPrimaryGPU].(bool)),
+				ROMbar:      util.Pointer(subSchema[schemaROMbar].(bool)),
+				SubDeviceID: util.Pointer(pveAPI.PciSubDeviceID(subSchema[schemaSubDeviceID].(string))),
+				SubVendorID: util.Pointer(pveAPI.PciSubVendorID(subSchema[schemaSubVendorID].(string))),
+				VendorID:    util.Pointer(pveAPI.PciVendorID(subSchema[schemaVendorID].(string)))}}
+	}
+	return pveAPI.QemuPci{Delete: true}
+}

--- a/proxmox/Internal/resource/guest/qemu/pci/terraform.go
+++ b/proxmox/Internal/resource/guest/qemu/pci/terraform.go
@@ -1,0 +1,213 @@
+package pci
+
+import (
+	"strconv"
+
+	pveAPI "github.com/Telmate/proxmox-api-go/proxmox"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+// Converts the SDK configuration to the Terraform configuration
+func Terraform(config pveAPI.QemuPciDevices, d *schema.ResourceData) {
+	if _, ok := d.GetOk(RootLegacyPCI); ok {
+		d.Set(RootLegacyPCI, terraformLegacyPCI(config))
+	} else if _, ok := d.GetOk(RootPCI); ok {
+		d.Set(RootPCI, terraformPCI(config))
+	} else {
+		d.Set(RootPCIs, terraformPCIs(config))
+	}
+}
+
+func terraformLegacyPCI(config pveAPI.QemuPciDevices) []map[string]interface{} {
+	pciDevices := make([]map[string]interface{}, len(config))
+	var index int
+	for i := 0; i < amountPCIs; i++ {
+		v, ok := config[pveAPI.QemuPciID(i)]
+		if !ok {
+			continue
+		}
+		pciDevices[index] = terraformLegacySubroutinePCI(v)
+		index++
+	}
+	return pciDevices
+}
+
+func terraformPCI(config pveAPI.QemuPciDevices) []map[string]interface{} {
+	pciDevices := make([]map[string]interface{}, len(config))
+	var index int
+	for i := 0; i < amountPCIs; i++ {
+		v, ok := config[pveAPI.QemuPciID(i)]
+		if !ok {
+			continue
+		}
+		pciDevices[index] = terraformSubroutinePCI(pveAPI.QemuPciID(i), v)
+		index++
+	}
+	return pciDevices
+}
+
+func terraformLegacySubroutinePCI(config pveAPI.QemuPci) map[string]interface{} {
+	var ROMbar, PCIe int
+	var host string
+	if config.Raw != nil {
+		if config.Raw.ID != nil {
+			host = config.Raw.ID.String()
+		}
+		if config.Raw.PCIe != nil {
+			if *config.Raw.PCIe {
+				PCIe = 1
+			} else {
+				PCIe = 0
+			}
+		}
+		if config.Raw.ROMbar != nil {
+			if *config.Raw.ROMbar {
+				ROMbar = 1
+			} else {
+				ROMbar = 0
+			}
+		}
+	}
+	return map[string]interface{}{
+		legacySchemaHost: host,
+		schemaPCIe:       PCIe,
+		schemaROMbar:     ROMbar}
+}
+
+func terraformSubroutinePCI(id pveAPI.QemuPciID, config pveAPI.QemuPci) map[string]interface{} {
+	var PrimaryGPU, ROMbar, PCIe bool
+	var mappedID, rawID, deviceID, subDeviceID, subVendorID, vendorID string
+	if config.Mapping != nil {
+		if config.Mapping.ID != nil {
+			mappedID = config.Mapping.ID.String()
+		}
+		if config.Mapping.DeviceID != nil {
+			deviceID = config.Mapping.DeviceID.String()
+		}
+		if config.Mapping.PCIe != nil {
+			PCIe = *config.Mapping.PCIe
+		}
+		if config.Mapping.PrimaryGPU != nil {
+			PrimaryGPU = *config.Mapping.PrimaryGPU
+		}
+		if config.Mapping.ROMbar != nil {
+			ROMbar = *config.Mapping.ROMbar
+		}
+		if config.Mapping.SubDeviceID != nil {
+			subDeviceID = config.Mapping.SubDeviceID.String()
+		}
+		if config.Mapping.SubVendorID != nil {
+			subVendorID = config.Mapping.SubVendorID.String()
+		}
+		if config.Mapping.VendorID != nil {
+			vendorID = config.Mapping.VendorID.String()
+		}
+	} else if config.Raw != nil {
+		if config.Raw.ID != nil {
+			rawID = config.Raw.ID.String()
+		}
+		if config.Raw.DeviceID != nil {
+			deviceID = config.Raw.DeviceID.String()
+		}
+		if config.Raw.PCIe != nil {
+			PCIe = *config.Raw.PCIe
+		}
+		if config.Raw.PrimaryGPU != nil {
+			PrimaryGPU = *config.Raw.PrimaryGPU
+		}
+		if config.Raw.ROMbar != nil {
+			ROMbar = *config.Raw.ROMbar
+		}
+		if config.Raw.SubDeviceID != nil {
+			subDeviceID = config.Raw.SubDeviceID.String()
+		}
+		if config.Raw.SubVendorID != nil {
+			subVendorID = config.Raw.SubVendorID.String()
+		}
+		if config.Raw.VendorID != nil {
+			vendorID = config.Raw.VendorID.String()
+		}
+	}
+	return map[string]interface{}{
+		schemaID:          int(id),
+		schemaMappingID:   mappedID,
+		schemaRawID:       rawID,
+		schemaPCIe:        PCIe,
+		schemaPrimaryGPU:  PrimaryGPU,
+		schemaROMbar:      ROMbar,
+		schemaDeviceID:    deviceID,
+		schemaSubDeviceID: subDeviceID,
+		schemaVendorID:    vendorID,
+		schemaSubVendorID: subVendorID}
+}
+
+func terraformPCIs(config pveAPI.QemuPciDevices) []interface{} {
+	mapParams := make(map[string]interface{}, amountPCIs)
+	for k, v := range config {
+		mapParams[prefixSchemaID+strconv.Itoa(int(k))] = terraformSubroutinePCIs(v)
+	}
+	return []interface{}{mapParams}
+}
+
+func terraformSubroutinePCIs(config pveAPI.QemuPci) []interface{} {
+	params := make(map[string]interface{}, 8)
+	if config.Mapping != nil {
+		if config.Mapping.ID != nil {
+			params[schemaMappingID] = config.Mapping.ID.String()
+		}
+		if config.Mapping.DeviceID != nil {
+			params[schemaDeviceID] = config.Mapping.DeviceID.String()
+		}
+		if config.Mapping.PCIe != nil {
+			params[schemaPCIe] = *config.Mapping.PCIe
+		}
+		if config.Mapping.PrimaryGPU != nil {
+			params[schemaPrimaryGPU] = *config.Mapping.PrimaryGPU
+		}
+		if config.Mapping.ROMbar != nil {
+			params[schemaROMbar] = *config.Mapping.ROMbar
+		}
+		if config.Mapping.SubDeviceID != nil {
+			params[schemaSubDeviceID] = config.Mapping.SubDeviceID.String()
+		}
+		if config.Mapping.SubVendorID != nil {
+			params[schemaSubVendorID] = config.Mapping.SubVendorID.String()
+		}
+		if config.Mapping.VendorID != nil {
+			params[schemaVendorID] = config.Mapping.VendorID.String()
+		}
+		return []interface{}{
+			map[string]interface{}{
+				schemaMapping: []interface{}{params}}}
+	}
+	if config.Raw != nil {
+		if config.Raw.ID != nil {
+			params[schemaRawID] = config.Raw.ID.String()
+		}
+		if config.Raw.DeviceID != nil {
+			params[schemaDeviceID] = config.Raw.DeviceID.String()
+		}
+		if config.Raw.PCIe != nil {
+			params[schemaPCIe] = *config.Raw.PCIe
+		}
+		if config.Raw.PrimaryGPU != nil {
+			params[schemaPrimaryGPU] = *config.Raw.PrimaryGPU
+		}
+		if config.Raw.ROMbar != nil {
+			params[schemaROMbar] = *config.Raw.ROMbar
+		}
+		if config.Raw.SubDeviceID != nil {
+			params[schemaSubDeviceID] = config.Raw.SubDeviceID.String()
+		}
+		if config.Raw.SubVendorID != nil {
+			params[schemaSubVendorID] = config.Raw.SubVendorID.String()
+		}
+		if config.Raw.VendorID != nil {
+			params[schemaVendorID] = config.Raw.VendorID.String()
+		}
+		return []interface{}{
+			map[string]interface{}{
+				schemaMapping: []interface{}{params}}}
+	}
+	return nil
+}

--- a/proxmox/resource_vm_qemu.go
+++ b/proxmox/resource_vm_qemu.go
@@ -29,6 +29,7 @@ import (
 	"github.com/Telmate/terraform-provider-proxmox/v2/proxmox/Internal/pxapi/guest/tags"
 	"github.com/Telmate/terraform-provider-proxmox/v2/proxmox/Internal/resource/guest/qemu/disk"
 	"github.com/Telmate/terraform-provider-proxmox/v2/proxmox/Internal/resource/guest/qemu/network"
+	"github.com/Telmate/terraform-provider-proxmox/v2/proxmox/Internal/resource/guest/qemu/pci"
 	"github.com/Telmate/terraform-provider-proxmox/v2/proxmox/Internal/resource/guest/qemu/serial"
 	"github.com/Telmate/terraform-provider-proxmox/v2/proxmox/Internal/resource/guest/qemu/usb"
 	"github.com/Telmate/terraform-provider-proxmox/v2/proxmox/Internal/util"
@@ -398,26 +399,9 @@ func resourceVmQemu() *schema.Resource {
 					},
 				},
 			},
-			"hostpci": {
-				Type:     schema.TypeList,
-				Optional: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"host": {
-							Type:     schema.TypeString,
-							Optional: true,
-						},
-						"rombar": {
-							Type:     schema.TypeInt,
-							Optional: true,
-						},
-						"pcie": {
-							Type:     schema.TypeInt,
-							Optional: true,
-						},
-					},
-				},
-			},
+			pci.RootLegacyPCI: pci.SchemaLegacyPCI(),
+			pci.RootPCI:       pci.SchemaPCI(),
+			pci.RootPCIs:      pci.SchemaPCIs(),
 			"efidisk": {
 				Type:     schema.TypeList,
 				Optional: true,
@@ -720,35 +704,32 @@ func resourceVmQemuCreate(ctx context.Context, d *schema.ResourceData, meta inte
 
 	qemuEfiDisks, _ := ExpandDevicesList(d.Get("efidisk").([]interface{}))
 
-	qemuPCIDevices, _ := ExpandDevicesList(d.Get("hostpci").([]interface{}))
-
 	config := pxapi.ConfigQemu{
-		Name:           vmName,
-		CPU:            mapToSDK_CPU(d),
-		Description:    util.Pointer(d.Get("desc").(string)),
-		Pool:           util.Pointer(pxapi.PoolName(d.Get("pool").(string))),
-		Bios:           d.Get("bios").(string),
-		Onboot:         util.Pointer(d.Get("onboot").(bool)),
-		Startup:        d.Get("startup").(string),
-		Protection:     util.Pointer(d.Get("protection").(bool)),
-		Tablet:         util.Pointer(d.Get("tablet").(bool)),
-		Boot:           d.Get("boot").(string),
-		BootDisk:       d.Get("bootdisk").(string),
-		Agent:          mapToSDK_QemuGuestAgent(d),
-		Memory:         mapToSDK_Memory(d),
-		Machine:        d.Get("machine").(string),
-		QemuKVM:        util.Pointer(d.Get("kvm").(bool)),
-		Hotplug:        d.Get("hotplug").(string),
-		Scsihw:         d.Get("scsihw").(string),
-		HaState:        d.Get("hastate").(string),
-		HaGroup:        d.Get("hagroup").(string),
-		QemuOs:         d.Get("qemu_os").(string),
-		Tags:           tags.RemoveDuplicates(tags.Split(d.Get("tags").(string))),
-		Args:           d.Get("args").(string),
-		Serials:        serial.SDK(d),
-		QemuPCIDevices: qemuPCIDevices,
-		Smbios1:        BuildSmbiosArgs(d.Get("smbios").([]interface{})),
-		CloudInit:      mapToSDK_CloudInit(d),
+		Name:        vmName,
+		CPU:         mapToSDK_CPU(d),
+		Description: util.Pointer(d.Get("desc").(string)),
+		Pool:        util.Pointer(pxapi.PoolName(d.Get("pool").(string))),
+		Bios:        d.Get("bios").(string),
+		Onboot:      util.Pointer(d.Get("onboot").(bool)),
+		Startup:     d.Get("startup").(string),
+		Protection:  util.Pointer(d.Get("protection").(bool)),
+		Tablet:      util.Pointer(d.Get("tablet").(bool)),
+		Boot:        d.Get("boot").(string),
+		BootDisk:    d.Get("bootdisk").(string),
+		Agent:       mapToSDK_QemuGuestAgent(d),
+		Memory:      mapToSDK_Memory(d),
+		Machine:     d.Get("machine").(string),
+		QemuKVM:     util.Pointer(d.Get("kvm").(bool)),
+		Hotplug:     d.Get("hotplug").(string),
+		Scsihw:      d.Get("scsihw").(string),
+		HaState:     d.Get("hastate").(string),
+		HaGroup:     d.Get("hagroup").(string),
+		QemuOs:      d.Get("qemu_os").(string),
+		Tags:        tags.RemoveDuplicates(tags.Split(d.Get("tags").(string))),
+		Args:        d.Get("args").(string),
+		Serials:     serial.SDK(d),
+		Smbios1:     BuildSmbiosArgs(d.Get("smbios").([]interface{})),
+		CloudInit:   mapToSDK_CloudInit(d),
 	}
 
 	var diags, tmpDiags diag.Diagnostics
@@ -757,6 +738,11 @@ func resourceVmQemuCreate(ctx context.Context, d *schema.ResourceData, meta inte
 		return diags
 	}
 	config.Networks, tmpDiags = network.SDK(d)
+	diags = append(diags, tmpDiags...)
+	if tmpDiags.HasError() {
+		return diags
+	}
+	config.PciDevices, tmpDiags = pci.SDK(d)
 	diags = append(diags, tmpDiags...)
 	if tmpDiags.HasError() {
 		return diags
@@ -957,11 +943,6 @@ func resourceVmQemuUpdate(ctx context.Context, d *schema.ResourceData, meta inte
 	vga := d.Get("vga").(*schema.Set)
 	qemuVgaList := vga.List()
 
-	qemuPCIDevices, err := ExpandDevicesList(d.Get("hostpci").([]interface{}))
-	if err != nil {
-		return diag.FromErr(fmt.Errorf("error while processing HostPCI configuration: %v", err))
-	}
-
 	d.Partial(true)
 	if d.HasChange("target_node") {
 		// Update target node when it must be migrated manually. Don't if it has been migrated by the proxmox high availability system.
@@ -970,32 +951,31 @@ func resourceVmQemuUpdate(ctx context.Context, d *schema.ResourceData, meta inte
 	d.Partial(false)
 
 	config := pxapi.ConfigQemu{
-		Name:           d.Get("name").(string),
-		CPU:            mapToSDK_CPU(d),
-		Description:    util.Pointer(d.Get("desc").(string)),
-		Pool:           util.Pointer(pxapi.PoolName(d.Get("pool").(string))),
-		Bios:           d.Get("bios").(string),
-		Onboot:         util.Pointer(d.Get("onboot").(bool)),
-		Startup:        d.Get("startup").(string),
-		Protection:     util.Pointer(d.Get("protection").(bool)),
-		Tablet:         util.Pointer(d.Get("tablet").(bool)),
-		Boot:           d.Get("boot").(string),
-		BootDisk:       d.Get("bootdisk").(string),
-		Agent:          mapToSDK_QemuGuestAgent(d),
-		Memory:         mapToSDK_Memory(d),
-		Machine:        d.Get("machine").(string),
-		QemuKVM:        util.Pointer(d.Get("kvm").(bool)),
-		Hotplug:        d.Get("hotplug").(string),
-		Scsihw:         d.Get("scsihw").(string),
-		HaState:        d.Get("hastate").(string),
-		HaGroup:        d.Get("hagroup").(string),
-		QemuOs:         d.Get("qemu_os").(string),
-		Tags:           tags.RemoveDuplicates(tags.Split(d.Get("tags").(string))),
-		Args:           d.Get("args").(string),
-		Serials:        serial.SDK(d),
-		QemuPCIDevices: qemuPCIDevices,
-		Smbios1:        BuildSmbiosArgs(d.Get("smbios").([]interface{})),
-		CloudInit:      mapToSDK_CloudInit(d),
+		Name:        d.Get("name").(string),
+		CPU:         mapToSDK_CPU(d),
+		Description: util.Pointer(d.Get("desc").(string)),
+		Pool:        util.Pointer(pxapi.PoolName(d.Get("pool").(string))),
+		Bios:        d.Get("bios").(string),
+		Onboot:      util.Pointer(d.Get("onboot").(bool)),
+		Startup:     d.Get("startup").(string),
+		Protection:  util.Pointer(d.Get("protection").(bool)),
+		Tablet:      util.Pointer(d.Get("tablet").(bool)),
+		Boot:        d.Get("boot").(string),
+		BootDisk:    d.Get("bootdisk").(string),
+		Agent:       mapToSDK_QemuGuestAgent(d),
+		Memory:      mapToSDK_Memory(d),
+		Machine:     d.Get("machine").(string),
+		QemuKVM:     util.Pointer(d.Get("kvm").(bool)),
+		Hotplug:     d.Get("hotplug").(string),
+		Scsihw:      d.Get("scsihw").(string),
+		HaState:     d.Get("hastate").(string),
+		HaGroup:     d.Get("hagroup").(string),
+		QemuOs:      d.Get("qemu_os").(string),
+		Tags:        tags.RemoveDuplicates(tags.Split(d.Get("tags").(string))),
+		Args:        d.Get("args").(string),
+		Serials:     serial.SDK(d),
+		Smbios1:     BuildSmbiosArgs(d.Get("smbios").([]interface{})),
+		CloudInit:   mapToSDK_CloudInit(d),
 	}
 	if len(qemuVgaList) > 0 {
 		config.QemuVga = qemuVgaList[0].(map[string]interface{})
@@ -1007,6 +987,11 @@ func resourceVmQemuUpdate(ctx context.Context, d *schema.ResourceData, meta inte
 		return diags
 	}
 	config.Networks, tmpDiags = network.SDK(d)
+	diags = append(diags, tmpDiags...)
+	if tmpDiags.HasError() {
+		return diags
+	}
+	config.PciDevices, tmpDiags = pci.SDK(d)
 	diags = append(diags, tmpDiags...)
 	if tmpDiags.HasError() {
 		return diags
@@ -1291,6 +1276,9 @@ func resourceVmQemuRead(ctx context.Context, d *schema.ResourceData, meta interf
 	if len(config.Networks) != 0 {
 		network.Terraform(config.Networks, d)
 	}
+	if len(config.PciDevices) != 0 {
+		pci.Terraform(config.PciDevices, d)
+	}
 	if len(config.Serials) != 0 {
 		serial.Terraform(config.Serials, d)
 	}
@@ -1312,17 +1300,6 @@ func resourceVmQemuRead(ctx context.Context, d *schema.ResourceData, meta interf
 	// Check "full_clone" separately, as it causes issues in loop above due to how GetOk returns values on false booleans.
 	// Since "full_clone" has a default of true, it will always be in the configuration, so no need to verify.
 	d.Set("full_clone", d.Get("full_clone"))
-
-	// read in the qemu hostpci
-	qemuPCIDevices, err := FlattenDevicesList(config.QemuPCIDevices)
-	if err != nil {
-		return diag.FromErr(fmt.Errorf("unable to flatten QEMU PCI devices: %w", err))
-	}
-	qemuPCIDevices, _ = DropElementsFromMap([]string{"id"}, qemuPCIDevices)
-	logger.Debug().Int("vmid", vmID).Msgf("Hostpci Block Processed '%v'", config.QemuPCIDevices)
-	if err = d.Set("hostpci", qemuPCIDevices); err != nil {
-		return diag.FromErr(fmt.Errorf("unable to set hostpci: %w", err))
-	}
 
 	// read in the unused disks
 	flatUnusedDisks, _ := FlattenDevicesList(config.QemuUnusedDisks)


### PR DESCRIPTION
Full Qemu PCI support.

- Adds `pci` setting for use in modules.
- Adds `pcis` setting.
- Deprecates `hostpci`.


Closes #1157 as it supersedes it.
Resolves #1029
Resolves #1107