### PR TITLE
refactor: move cpu code to package & deprecate `cpu`

### DIFF
--- a/docs/guides/cloud_init.md
+++ b/docs/guides/cloud_init.md
@@ -189,7 +189,7 @@ resource "proxmox_vm_qemu" "preprovision-test" {
   sockets  = 1
   # Same CPU as the Physical host, possible to add cpu flags
   # Ex: "host,flags=+md-clear;+pcid;+spec-ctrl;+ssbd;+pdpe1gb"
-  cpu      = "host"
+  cpu_type = "host"
   numa     = false
   memory   = 2560
   scsihw   = "lsi"

--- a/docs/resources/vm_qemu.md
+++ b/docs/resources/vm_qemu.md
@@ -118,7 +118,7 @@ The following arguments are supported in the top level resource block.
 | `sockets`                     | `int`    | `1`                  | The number of CPU sockets to allocate to the VM. |
 | `cores`                       | `int`    | `1`                  | The number of CPU cores per CPU socket to allocate to the VM. |
 | `vcpus`                       | `int`    | `0`                  | The number of vCPUs plugged into the VM when it starts. If `0`, this is set automatically by Proxmox to `sockets * cores`. |
-| `cpu`                         | `str`    | `"host"`             | The type of CPU to emulate in the Guest. See the [docs about CPU Types](https://pve.proxmox.com/pve-docs/chapter-qm.html#qm_cpu) for more info. |
+| `cpu_type`                    | `str`    | `"host"`             | The type of CPU to emulate in the Guest. See the [docs about CPU Types](https://pve.proxmox.com/pve-docs/chapter-qm.html#qm_cpu) for more info. |
 | `numa`                        | `bool`   | `false`              | Whether to enable [Non-Uniform Memory Access](https://pve.proxmox.com/pve-docs/chapter-qm.html#qm_cpu) in the guest. |
 | `hotplug`                     | `str`    | `"network,disk,usb"` | Comma delimited list of hotplug features to enable. Options: `network`, `disk`, `cpu`, `memory`, `usb`. Set to `0` to disable hotplug. |
 | `scsihw`                      | `str`    | `"lsi"`              | The SCSI controller to emulate. Options: `lsi`, `lsi53c810`, `megasas`, `pvscsi`, `virtio-scsi-pci`, `virtio-scsi-single`. |

--- a/examples/cloudinit_example.tf
+++ b/examples/cloudinit_example.tf
@@ -27,7 +27,7 @@ resource "proxmox_vm_qemu" "cloudinit-test" {
     cores = 2
     sockets = 1
     vcpus = 0
-    cpu = "host"
+    cpu_type = "host"
     memory = 2048
     scsihw = "lsi"
 

--- a/examples/pxe_example.tf
+++ b/examples/pxe_example.tf
@@ -32,7 +32,7 @@ resource "proxmox_vm_qemu" "pxe-example" {
 # and future boots will run off the disk
     boot                      = "order=scsi0;net0"
     cores                     = 2
-    cpu                       = "host"
+    cpu_type                  = "host"
     define_connection_info    = true
     force_create              = false
     hotplug                   = "network,disk,usb"

--- a/proxmox/Internal/resource/guest/qemu/cpu/schema.go
+++ b/proxmox/Internal/resource/guest/qemu/cpu/schema.go
@@ -1,0 +1,82 @@
+package cpu
+
+import (
+	pveAPI "github.com/Telmate/proxmox-api-go/proxmox"
+	"github.com/hashicorp/go-cty/cty"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+const (
+	Root             string = "cpu"
+	RootCores        string = "cores"
+	RootCpuType      string = "cpu_type"
+	RootNuma         string = "numa"
+	RootSockets      string = "sockets"
+	RootVirtualCores string = "vcpus"
+)
+
+func SchemaCores() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeInt,
+		Optional: true,
+		Default:  1,
+		ValidateDiagFunc: func(i interface{}, p cty.Path) diag.Diagnostics {
+			v, ok := i.(int)
+			if !ok {
+				return diag.Errorf(RootCores + " must be an integer")
+			}
+			if v < 1 {
+				return diag.Errorf(RootCores + " must be greater than 0")
+			}
+			return diag.FromErr(pveAPI.QemuCpuCores(v).Validate())
+		}}
+}
+
+func SchemaType(s schema.Schema) *schema.Schema {
+	s.Type = schema.TypeString
+	s.Optional = true
+	return &s
+}
+
+func SchemaNuma() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeBool,
+		Optional: true,
+	}
+}
+
+func SchemaSockets() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeInt,
+		Optional: true,
+		Default:  1,
+		ValidateDiagFunc: func(i interface{}, p cty.Path) diag.Diagnostics {
+			v, ok := i.(int)
+			if !ok {
+				return diag.Errorf(RootSockets + " must be an integer")
+			}
+			if v < 1 {
+				return diag.Errorf(RootSockets + " must be greater than 0")
+			}
+			return diag.FromErr(pveAPI.QemuCpuSockets(v).Validate())
+		}}
+}
+
+func SchemaVirtualCores() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeInt,
+		Optional: true,
+		Default:  0,
+		ValidateDiagFunc: func(i interface{}, p cty.Path) diag.Diagnostics {
+			v, ok := i.(int)
+			if !ok {
+				return diag.Errorf(RootVirtualCores + " must be an integer")
+			}
+			if v < 0 {
+				return diag.Errorf(RootVirtualCores + " must be greater than or equal to 0")
+			}
+			return nil
+		},
+	}
+}

--- a/proxmox/Internal/resource/guest/qemu/cpu/sdk.go
+++ b/proxmox/Internal/resource/guest/qemu/cpu/sdk.go
@@ -1,0 +1,23 @@
+package cpu
+
+import (
+	pveAPI "github.com/Telmate/proxmox-api-go/proxmox"
+	"github.com/Telmate/terraform-provider-proxmox/v2/proxmox/Internal/util"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func SDK(d *schema.ResourceData) *pveAPI.QemuCPU {
+	var cpuType pveAPI.CpuType
+	if v, ok := d.GetOk(Root); ok {
+		cpuType = pveAPI.CpuType(v.(string))
+	} else {
+		v := d.Get(RootCpuType)
+		cpuType = pveAPI.CpuType(v.(string))
+	}
+	return &pveAPI.QemuCPU{
+		Cores:        util.Pointer(pveAPI.QemuCpuCores(d.Get(RootCores).(int))),
+		Numa:         util.Pointer(d.Get(RootNuma).(bool)),
+		Sockets:      util.Pointer(pveAPI.QemuCpuSockets(d.Get(RootSockets).(int))),
+		Type:         util.Pointer(cpuType),
+		VirtualCores: util.Pointer(pveAPI.CpuVirtualCores(d.Get(RootVirtualCores).(int)))}
+}

--- a/proxmox/Internal/resource/guest/qemu/cpu/terraform.go
+++ b/proxmox/Internal/resource/guest/qemu/cpu/terraform.go
@@ -1,0 +1,26 @@
+package cpu
+
+import (
+	pveAPI "github.com/Telmate/proxmox-api-go/proxmox"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func Terraform(config pveAPI.QemuCPU, d *schema.ResourceData) {
+	if config.Cores != nil {
+		d.Set(RootCores, int(*config.Cores))
+	}
+	if config.Numa != nil {
+		d.Set(RootNuma, *config.Numa)
+	}
+	if config.Sockets != nil {
+		d.Set(RootSockets, int(*config.Sockets))
+	}
+	if _, ok := d.GetOk(Root); ok {
+		d.Set(Root, string(*config.Type))
+	} else {
+		d.Set(RootCpuType, string(*config.Type))
+	}
+	if config.VirtualCores != nil {
+		d.Set(RootVirtualCores, int(*config.VirtualCores))
+	}
+}


### PR DESCRIPTION
Moved all CPU related code to it's own package.
The `cpu` key has been deprecated in favor of `cpu_type` to allow for the continuation of #1149.
