### PR TITLE
feat: add `context`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.21
 toolchain go1.21.0
 
 require (
-	github.com/Telmate/proxmox-api-go v0.0.0-20241121215203-222002bcb5bc
+	github.com/Telmate/proxmox-api-go v0.0.0-20241205214358-976ef5098918
 	github.com/google/uuid v1.6.0
 	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.34.0

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,8 @@ github.com/Microsoft/go-winio v0.6.1 h1:9/kr64B9VUZrLm5YYwbGtUJnMgqWVOdUAXu6Migc
 github.com/Microsoft/go-winio v0.6.1/go.mod h1:LRdKpFKfdobln8UmuiYcKPot9D2v6svN5+sAH+4kjUM=
 github.com/ProtonMail/go-crypto v1.1.0-alpha.2-proton h1:HKz85FwoXx86kVtTvFke7rgHvq/HoloSUvW5semjFWs=
 github.com/ProtonMail/go-crypto v1.1.0-alpha.2-proton/go.mod h1:rA3QumHc/FZ8pAHreoekgiAbzpNsfQAosU5td4SnOrE=
-github.com/Telmate/proxmox-api-go v0.0.0-20241121215203-222002bcb5bc h1:gKm4H2rehb9iTWh4OW/Yt/SNJwoTLHTam+Trjkz2HHY=
-github.com/Telmate/proxmox-api-go v0.0.0-20241121215203-222002bcb5bc/go.mod h1:Gu6n6vEn1hlyFUkjrvU+X1fdgaSXLoM9HKYYJqy1fsY=
+github.com/Telmate/proxmox-api-go v0.0.0-20241205214358-976ef5098918 h1:dfs2cVaIHtia0uq/Vo6y8pF0McWadzFPW7mAB46d1JI=
+github.com/Telmate/proxmox-api-go v0.0.0-20241205214358-976ef5098918/go.mod h1:Gu6n6vEn1hlyFUkjrvU+X1fdgaSXLoM9HKYYJqy1fsY=
 github.com/agext/levenshtein v1.2.3 h1:YB2fHEn0UJagG8T1rrWknE3ZQzWM06O8AMAatNn7lmo=
 github.com/agext/levenshtein v1.2.3/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
 github.com/apparentlymart/go-textseg/v12 v12.0.0/go.mod h1:S/4uRK2UtaQttw1GenVJEynmyUenKwP++x/+DdGV/Ec=

--- a/proxmox/data_ha_group.go
+++ b/proxmox/data_ha_group.go
@@ -1,15 +1,16 @@
 package proxmox
 
 import (
+	"context"
 	"sort"
 
-	"github.com/Telmate/proxmox-api-go/proxmox"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 func DataHAGroup() *schema.Resource {
 	return &schema.Resource{
-		Read: dataReadHAGroup,
+		ReadContext: dataReadHAGroup,
 		Schema: map[string]*schema.Schema{
 			"group_name": {
 				Type:     schema.TypeString,
@@ -42,17 +43,17 @@ func DataHAGroup() *schema.Resource {
 	}
 }
 
-func dataReadHAGroup(data *schema.ResourceData, meta interface{}) (err error) {
+func dataReadHAGroup(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
+
 	pconf := meta.(*providerConfiguration)
 	lock := pmParallelBegin(pconf)
 	defer lock.unlock()
 
 	client := pconf.Client
 
-	var group *proxmox.HAGroup
-	group, err = client.GetHAGroupByName(data.Get("group_name").(string))
+	group, err := client.GetHAGroupByName(ctx, data.Get("group_name").(string))
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	nodes := group.Nodes

--- a/proxmox/provider.go
+++ b/proxmox/provider.go
@@ -1,6 +1,7 @@
 package proxmox
 
 import (
+	"context"
 	"crypto/tls"
 	"fmt"
 	"net/url"
@@ -264,7 +265,8 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 	if err != nil {
 		return nil, err
 	}
-	permlist, err := client.GetUserPermissions(userID, "/")
+	ctx := context.Background()
+	permlist, err := client.GetUserPermissions(ctx, userID, "/")
 	if err != nil {
 		return nil, err
 	}
@@ -348,7 +350,7 @@ func getClient(pm_api_url string,
 
 	// User+Pass authentication
 	if pm_user != "" && pm_password != "" {
-		err = client.Login(pm_user, pm_password, pm_otp)
+		err = client.Login(context.Background(), pm_user, pm_password, pm_otp)
 	}
 
 	// API authentication
@@ -366,7 +368,7 @@ func getClient(pm_api_url string,
 func nextVmId(pconf *providerConfiguration) (nextId int, err error) {
 	pconf.Mutex.Lock()
 	defer pconf.Mutex.Unlock()
-	nextId, err = pconf.Client.GetNextID(0)
+	nextId, err = pconf.Client.GetNextID(context.Background(), 0)
 	if err != nil {
 		return 0, err
 	}

--- a/proxmox/resource_cloud_init_disk.go
+++ b/proxmox/resource_cloud_init_disk.go
@@ -131,7 +131,7 @@ func resourceCloudInitDiskCreate(ctx context.Context, d *schema.ResourceData, m 
 	}
 
 	fileName := fmt.Sprintf("tf-ci-%s.iso", d.Get("name").(string))
-	err = client.Upload(d.Get("pve_node").(string), d.Get("storage").(string), isoContentType, fileName, r)
+	err = client.Upload(ctx, d.Get("pve_node").(string), d.Get("storage").(string), isoContentType, fileName, r)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -154,7 +154,7 @@ func resourceCloudInitDiskRead(ctx context.Context, d *schema.ResourceData, m in
 	vmRef := &proxmox.VmRef{}
 	vmRef.SetNode(pveNode)
 	vmRef.SetVmType("qemu")
-	storageContent, err := client.GetStorageContent(vmRef, d.Get("storage").(string))
+	storageContent, err := client.GetStorageContent(ctx, vmRef, d.Get("storage").(string))
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -182,7 +182,7 @@ func resourceCloudInitDiskDelete(ctx context.Context, d *schema.ResourceData, m 
 
 	storage := strings.SplitN(d.Id(), ":", 2)[0]
 	isoURL := fmt.Sprintf("/nodes/%s/storage/%s/content/%s", d.Get("pve_node").(string), storage, d.Id())
-	err := client.Delete(isoURL)
+	err := client.Delete(ctx, isoURL)
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/proxmox/resource_pool.go
+++ b/proxmox/resource_pool.go
@@ -1,10 +1,12 @@
 package proxmox
 
 import (
+	"context"
 	"fmt"
 
 	pxapi "github.com/Telmate/proxmox-api-go/proxmox"
 	"github.com/Telmate/terraform-provider-proxmox/v2/proxmox/Internal/util"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
@@ -14,10 +16,10 @@ var poolResourceDef *schema.Resource
 
 func resourcePool() *schema.Resource {
 	poolResourceDef = &schema.Resource{
-		Create: resourcePoolCreate,
-		Read:   resourcePoolRead,
-		Update: resourcePoolUpdate,
-		Delete: resourcePoolDelete,
+		CreateContext: resourcePoolCreate,
+		ReadContext:   resourcePoolRead,
+		UpdateContext: resourcePoolUpdate,
+		DeleteContext: resourcePoolDelete,
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
@@ -40,7 +42,7 @@ func resourcePool() *schema.Resource {
 	return poolResourceDef
 }
 
-func resourcePoolCreate(d *schema.ResourceData, meta interface{}) error {
+func resourcePoolCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	pconf := meta.(*providerConfiguration)
 	client := pconf.Client
 	lock := pmParallelBegin(pconf)
@@ -51,24 +53,24 @@ func resourcePoolCreate(d *schema.ResourceData, meta interface{}) error {
 	err := pxapi.ConfigPool{
 		Name:    pxapi.PoolName(poolid),
 		Comment: util.Pointer(d.Get("comment").(string)),
-	}.Create(client)
+	}.Create(ctx, client)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	d.SetId(clusterResourceId("pools", poolid))
 
-	return _resourcePoolRead(d, meta)
+	return diag.FromErr(_resourcePoolRead(ctx, d, meta))
 }
 
-func resourcePoolRead(d *schema.ResourceData, meta interface{}) error {
+func resourcePoolRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	pconf := meta.(*providerConfiguration)
 	lock := pmParallelBegin(pconf)
 	defer lock.unlock()
-	return _resourcePoolRead(d, meta)
+	return diag.FromErr(_resourcePoolRead(ctx, d, meta))
 }
 
-func _resourcePoolRead(d *schema.ResourceData, meta interface{}) error {
+func _resourcePoolRead(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
 	pconf := meta.(*providerConfiguration)
 	client := pconf.Client
 
@@ -83,7 +85,7 @@ func _resourcePoolRead(d *schema.ResourceData, meta interface{}) error {
 	logger, _ := CreateSubLogger("resource_pool_read")
 	logger.Info().Str("poolid", poolID).Msg("Reading configuration for poolid")
 
-	poolInfo, err := pool.Get(client)
+	poolInfo, err := pool.Get(ctx, client)
 	if err != nil {
 		d.SetId("")
 		return nil
@@ -100,7 +102,7 @@ func _resourcePoolRead(d *schema.ResourceData, meta interface{}) error {
 	return nil
 }
 
-func resourcePoolUpdate(d *schema.ResourceData, meta interface{}) error {
+func resourcePoolUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	pconf := meta.(*providerConfiguration)
 	lock := pmParallelBegin(pconf)
 	defer lock.unlock()
@@ -110,7 +112,7 @@ func resourcePoolUpdate(d *schema.ResourceData, meta interface{}) error {
 	client := pconf.Client
 	_, poolID, err := parseClusterResourceId(d.Id())
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	logger.Info().Str("poolid", poolID).Msg("Starting update of the Pool resource")
@@ -119,16 +121,16 @@ func resourcePoolUpdate(d *schema.ResourceData, meta interface{}) error {
 		err := pxapi.ConfigPool{
 			Name:    pxapi.PoolName(poolID),
 			Comment: util.Pointer(d.Get("comment").(string)),
-		}.Update(client)
+		}.Update(ctx, client)
 		if err != nil {
-			return err
+			return diag.FromErr(err)
 		}
 	}
 
-	return _resourcePoolRead(d, meta)
+	return diag.FromErr(_resourcePoolRead(ctx, d, meta))
 }
 
-func resourcePoolDelete(d *schema.ResourceData, meta interface{}) error {
+func resourcePoolDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	pconf := meta.(*providerConfiguration)
 	lock := pmParallelBegin(pconf)
 	defer lock.unlock()
@@ -137,10 +139,10 @@ func resourcePoolDelete(d *schema.ResourceData, meta interface{}) error {
 	_, poolID, err := parseClusterResourceId(d.Id())
 
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
-	if err = pxapi.PoolName(poolID).Delete(client); err != nil {
-		return err
+	if err = pxapi.PoolName(poolID).Delete(ctx, client); err != nil {
+		return diag.FromErr(err)
 	}
 
 	return nil


### PR DESCRIPTION
Other half of https://github.com/Telmate/proxmox-api-go/pull/387

The provider can now be canceled with `^c` instead of having to forcefully kill it.