### PR TITLE
Update cloud-init getting started.md

### DIFF
--- a/docs/guides/cloud-init getting started.md
+++ b/docs/guides/cloud-init getting started.md
@@ -115,6 +115,7 @@ resource "proxmox_vm_qemu" "cloudinit-example" {
   }
 
   network {
+    id = 0
     bridge = "vmbr0"
     model  = "virtio"
   }


### PR DESCRIPTION
"id" is now required in network block:

$ tofu plan
│ Error: Missing required argument
│ 
│   on main.tf line 51, in resource "proxmox_vm_qemu" "cloudinit-example":
│   51:   network {
│ 
│ The argument "id" is required, but no definition was found.