### PR TITLE
Move guest `pool` to package

### DIFF
--- a/proxmox/Internal/resource/guest/pool/schema.go
+++ b/proxmox/Internal/resource/guest/pool/schema.go
@@ -1,0 +1,15 @@
+package pool
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+const (
+	Root string = "pool"
+)
+
+func Schema() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeString,
+		Optional: true}
+}


### PR DESCRIPTION
Use config for pool instead of vmref.
Move pool of guests to seperate package

Related to #1117