### PR TITLE
feat: return same case for MAC

### DIFF
--- a/proxmox/Internal/resource/guest/qemu/network/schema.go
+++ b/proxmox/Internal/resource/guest/qemu/network/schema.go
@@ -65,11 +65,6 @@ func Schema() *schema.Schema {
 					Type:     schema.TypeString,
 					Optional: true,
 					Computed: true,
-					DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-						oldMAC, _ := net.ParseMAC(old)
-						newMAC, _ := net.ParseMAC(new)
-						return oldMAC.String() == newMAC.String()
-					},
 					ValidateDiagFunc: func(i interface{}, p cty.Path) diag.Diagnostics {
 						v := i.(string)
 						if _, err := net.ParseMAC(v); err != nil {


### PR DESCRIPTION
Ensures that the return value for MAC is in the same case as the input in the .tf file, regardless of it's case in PVE.
Removes the diffsuppression for MAC.

resolves #1182 