### PR TITLE
fix: VM not cloned into pool

### DIFF
--- a/proxmox/resource_vm_qemu.go
+++ b/proxmox/resource_vm_qemu.go
@@ -796,6 +796,8 @@ func resourceVmQemuCreate(ctx context.Context, d *schema.ResourceData, meta inte
 				return append(diags, diag.FromErr(err)...)
 			}
 
+			vmr.SetPool(d.Get(pool.Root).(string)) // This pool is used for clone
+
 			log.Print("[DEBUG][QemuVmCreate] cloning VM")
 			logger.Debug().Str(vmID.Root, d.Id()).Msgf("Cloning VM")
 			err = config.CloneVm(ctx, sourceVmr, vmr, client)


### PR DESCRIPTION
Issue caused by #1243

@maksimsamt found the issue you ran into during the testing of #1182, turns out it cloned into the global scope instead of the scope of the pool.