### PR TITLE
Move ID generation to SDK

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -25,10 +25,13 @@ After the role is in use, if there is a need to modify the privileges, simply is
 removing privileges as needed.
 
 Proxmox > 8:
+
 ```bash
 pveum role modify TerraformProv -privs "Datastore.AllocateSpace Datastore.AllocateTemplate Datastore.Audit Pool.Allocate Sys.Audit Sys.Console Sys.Modify VM.Allocate VM.Audit VM.Clone VM.Config.CDROM VM.Config.Cloudinit VM.Config.CPU VM.Config.Disk VM.Config.HWType VM.Config.Memory VM.Config.Network VM.Config.Options VM.Migrate VM.Monitor VM.PowerMgmt SDN.Use"
 ```
+
 Proxmox < 8:
+
 ```bash
 pveum role modify TerraformProv -privs "Datastore.AllocateSpace Datastore.AllocateTemplate Datastore.Audit Pool.Allocate Sys.Audit Sys.Console Sys.Modify VM.Allocate VM.Audit VM.Clone VM.Config.CDROM VM.Config.Cloudinit VM.Config.CPU VM.Config.Disk VM.Config.HWType VM.Config.Memory VM.Config.Network VM.Config.Options VM.Migrate VM.Monitor VM.PowerMgmt"
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -111,7 +111,7 @@ The following arguments are supported in the provider block:
 | `pm_api_token_secret` | `PM_API_TOKEN`       | `string` |                                | **Sensitive** This uuid is only available when the token was initially created. |
 | `pm_otp`              | `PM_OTP`             | `string` |                                | The 2FA OTP code. |
 | `pm_tls_insecure`     |                      | `bool`   | `false`                        | Disable TLS verification while connecting to the proxmox server. |
-| `pm_parallel`         |                      | `uint`   | `1`                            | Allowed simultaneous Proxmox processes (e.g. creating resources). Setting this greater than 1 is currently not recommended when using dynamic guest id allocation. |
+| `pm_parallel`         |                      | `uint`   | `1`                            | Allowed simultaneous Proxmox processes (e.g. creating resources). Setting this greater than 1 is currently not recommended when creating LXC containers with dynamic id allocation. For Qemu the threading issue has been resolved.|
 | `pm_log_enable`       |                      | `bool`   | `false`                        | Enable debug logging, see the section below for logging details. |
 | `pm_log_levels`       |                      | `map`    |                                | A map of log sources and levels. |
 | `pm_log_file`         |                      | `string` | `terraform-plugin-proxmox.log` | The log file the provider will write logs to. |

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.21
 toolchain go1.21.0
 
 require (
-	github.com/Telmate/proxmox-api-go v0.0.0-20250206210631-04cb05ca863f
+	github.com/Telmate/proxmox-api-go v0.0.0-20250301154022-c19968ff06eb
 	github.com/google/uuid v1.6.0
 	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.34.0

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,8 @@ github.com/Microsoft/go-winio v0.6.1 h1:9/kr64B9VUZrLm5YYwbGtUJnMgqWVOdUAXu6Migc
 github.com/Microsoft/go-winio v0.6.1/go.mod h1:LRdKpFKfdobln8UmuiYcKPot9D2v6svN5+sAH+4kjUM=
 github.com/ProtonMail/go-crypto v1.1.0-alpha.2-proton h1:HKz85FwoXx86kVtTvFke7rgHvq/HoloSUvW5semjFWs=
 github.com/ProtonMail/go-crypto v1.1.0-alpha.2-proton/go.mod h1:rA3QumHc/FZ8pAHreoekgiAbzpNsfQAosU5td4SnOrE=
-github.com/Telmate/proxmox-api-go v0.0.0-20250206210631-04cb05ca863f h1:NQ2Hm3jRC/wHmDBAgTEMniUHmQ8JRtozo+9wxaY2gU4=
-github.com/Telmate/proxmox-api-go v0.0.0-20250206210631-04cb05ca863f/go.mod h1:6qNnkqdMB+22ytC/5qGAIIqtdK9egN1b/Sqs9tB/i1Y=
+github.com/Telmate/proxmox-api-go v0.0.0-20250301154022-c19968ff06eb h1:TOvQgWR9N6PORA1jcaPLJsemiZarHVbONrSNnkwhi4Q=
+github.com/Telmate/proxmox-api-go v0.0.0-20250301154022-c19968ff06eb/go.mod h1:6qNnkqdMB+22ytC/5qGAIIqtdK9egN1b/Sqs9tB/i1Y=
 github.com/agext/levenshtein v1.2.3 h1:YB2fHEn0UJagG8T1rrWknE3ZQzWM06O8AMAatNn7lmo=
 github.com/agext/levenshtein v1.2.3/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
 github.com/apparentlymart/go-textseg/v12 v12.0.0/go.mod h1:S/4uRK2UtaQttw1GenVJEynmyUenKwP++x/+DdGV/Ec=

--- a/proxmox/provider.go
+++ b/proxmox/provider.go
@@ -129,12 +129,6 @@ func Provider() *schema.Provider {
 					if v < 1 {
 						return diag.Errorf(schemaPmParallel + " must be greater than 0")
 					}
-					if v > 1 { // TODO actually fix the parallelism! workaround for #1136
-						return diag.Diagnostics{
-							diag.Diagnostic{
-								Severity: diag.Warning,
-								Summary:  "setting " + schemaPmParallel + " greater than 1 is currently not recommended when using dynamic guest id allocation"}}
-					}
 					return nil
 				},
 			},
@@ -368,7 +362,7 @@ func getClient(pm_api_url string,
 func nextVmId(pconf *providerConfiguration) (nextId pveSDK.GuestID, err error) {
 	pconf.Mutex.Lock()
 	defer pconf.Mutex.Unlock()
-	nextId, err = pconf.Client.GetNextID(context.Background(), 0)
+	nextId, err = pconf.Client.GetNextID(context.Background(), nil)
 	if err != nil {
 		return 0, err
 	}


### PR DESCRIPTION
Terraform half of https://github.com/Telmate/proxmox-api-go/pull/400

The logic for generating new guest ids has move to the SDK.
This remediates most of the treading issues discussed in #1136.
For Qemu all treading issues are fixed.
For LXC the treading issue is fixed when cloning templates, when creating a guest from scratch the issue persists (will be fixed by the LXC rework).




