### PR TITLE
Feat tpmstate efi secureboot

### DIFF
--- a/proxmox/Internal/resource/guest/qemu/tpm/schema.go
+++ b/proxmox/Internal/resource/guest/qemu/tpm/schema.go
@@ -1,0 +1,42 @@
+package tpm
+
+import (
+	pveAPI "github.com/Telmate/proxmox-api-go/proxmox"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+)
+
+const (
+	Root       = "tpm_state"
+	storageKey = "storage"
+	versionKey = "version"
+
+	versionValueTpmV12 = string(pveAPI.TpmVersion_1_2) // v1.2
+	versionValueTpmV20 = string(pveAPI.TpmVersion_2_0) // v2.0
+)
+
+func Schema() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeList,
+		Optional: true,
+		MaxItems: 1,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				storageKey: {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+				versionKey: {
+					Type:     schema.TypeString,
+					Optional: true,
+					Default:  versionValueTpmV20,
+					ValidateFunc: validation.StringInSlice([]string{
+						versionValueTpmV20,
+						versionValueTpmV12,
+					}, false),
+					ForceNew: true,
+				},
+			},
+		}}
+}

--- a/proxmox/Internal/resource/guest/qemu/tpm/sdk.go
+++ b/proxmox/Internal/resource/guest/qemu/tpm/sdk.go
@@ -1,0 +1,21 @@
+package tpm
+
+import (
+	pveAPI "github.com/Telmate/proxmox-api-go/proxmox"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func SDK(d *schema.ResourceData) *pveAPI.TpmState {
+	tmpList := d.Get("tpm_state").([]interface{})
+	if len(tmpList) == 0 {
+		return nil
+	}
+	tpmState := &pveAPI.TpmState{}
+	thisTpmMap := tmpList[0].(map[string]interface{})
+	tpmState.Storage = thisTpmMap[storageKey].(string)
+	if v, ok := thisTpmMap[versionKey].(string); ok {
+		tv := pveAPI.TpmVersion(v)
+		tpmState.Version = &tv
+	}
+	return tpmState
+}

--- a/proxmox/Internal/resource/guest/qemu/tpm/terraform.go
+++ b/proxmox/Internal/resource/guest/qemu/tpm/terraform.go
@@ -1,0 +1,19 @@
+package tpm
+
+import (
+	pveAPI "github.com/Telmate/proxmox-api-go/proxmox"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func Terraform(config *pveAPI.TpmState, d *schema.ResourceData) {
+	if config == nil {
+		d.Set(Root, nil)
+		return
+	}
+	answer := map[string]interface{}{}
+	answer[storageKey] = config.Storage
+	answer[versionKey] = config.Version
+	tpms := make([]interface{}, 1)
+	tpms[0] = answer
+	d.Set(Root, tpms)
+}

--- a/proxmox/resource_vm_qemu.go
+++ b/proxmox/resource_vm_qemu.go
@@ -394,6 +394,12 @@ func resourceVmQemu() *schema.Resource {
 							Required: true,
 							ForceNew: true,
 						},
+						"pre_enrolled_keys": {
+							Type:     schema.TypeBool,
+							Optional: true,
+							Default:  false,
+							ForceNew: true,
+						},
 						"efitype": {
 							Type:     schema.TypeString,
 							Optional: true,
@@ -1506,6 +1512,10 @@ func ExpandDevicesList(deviceList []interface{}) (pveSDK.QemuDevices, error) {
 		// this is a map of string->interface, loop over it and move it into
 		// the qemuDevices struct
 		for configuration, value := range thisDeviceMap {
+			// XXX: Not sure where to put these
+			if configuration == "pre_enrolled_keys" {
+				configuration = "pre-enrolled-keys"
+			}
 			thisExpandedDevice[configuration] = value
 		}
 

--- a/proxmox/resource_vm_qemu.go
+++ b/proxmox/resource_vm_qemu.go
@@ -34,6 +34,7 @@ import (
 	"github.com/Telmate/terraform-provider-proxmox/v2/proxmox/Internal/resource/guest/qemu/network"
 	"github.com/Telmate/terraform-provider-proxmox/v2/proxmox/Internal/resource/guest/qemu/pci"
 	"github.com/Telmate/terraform-provider-proxmox/v2/proxmox/Internal/resource/guest/qemu/serial"
+	"github.com/Telmate/terraform-provider-proxmox/v2/proxmox/Internal/resource/guest/qemu/tpm"
 	"github.com/Telmate/terraform-provider-proxmox/v2/proxmox/Internal/resource/guest/qemu/usb"
 	"github.com/Telmate/terraform-provider-proxmox/v2/proxmox/Internal/resource/guest/sshkeys"
 	vmID "github.com/Telmate/terraform-provider-proxmox/v2/proxmox/Internal/resource/guest/vmid"
@@ -384,6 +385,7 @@ func resourceVmQemu() *schema.Resource {
 			pci.RootLegacyPCI: pci.SchemaLegacyPCI(),
 			pci.RootPCI:       pci.SchemaPCI(),
 			pci.RootPCIs:      pci.SchemaPCIs(),
+			tpm.Root:          tpm.Schema(),
 			"efidisk": {
 				Type:     schema.TypeList,
 				Optional: true,
@@ -709,6 +711,7 @@ func resourceVmQemuCreate(ctx context.Context, d *schema.ResourceData, meta inte
 		Serials:     serial.SDK(d),
 		Smbios1:     BuildSmbiosArgs(d.Get("smbios").([]interface{})),
 		CloudInit:   mapToSDK_CloudInit(d),
+		TPM:         tpm.SDK(d),
 	}
 
 	var diags, tmpDiags diag.Diagnostics
@@ -964,6 +967,7 @@ func resourceVmQemuUpdate(ctx context.Context, d *schema.ResourceData, meta inte
 		Serials:     serial.SDK(d),
 		Smbios1:     BuildSmbiosArgs(d.Get("smbios").([]interface{})),
 		CloudInit:   mapToSDK_CloudInit(d),
+		TPM:         tpm.SDK(d),
 	}
 	if len(qemuVgaList) > 0 {
 		config.QemuVga = qemuVgaList[0].(map[string]interface{})
@@ -1391,7 +1395,7 @@ func DropElementsFromMap(elements []string, mapList []map[string]interface{}) ([
 	return mapList, nil
 }
 
-// Consumes an API return (pxapi.QemuDevices) and "flattens" it into a []map[string]interface{} as
+// Consumes an API return (pveSDK.QemuDevices) and "flattens" it into a []map[string]interface{} as
 // expected by the terraform interface for TypeList
 func FlattenDevicesList(proxmoxDevices pveSDK.QemuDevices) ([]map[string]interface{}, error) {
 	flattenedDevices := make([]map[string]interface{}, 0, 1)
@@ -1489,7 +1493,7 @@ func ReadSmbiosArgs(smbios string) []interface{} {
 }
 
 // Consumes a terraform TypeList of a Qemu Device (network, hard drive, etc) and returns the "Expanded"
-// version of the equivalent configuration that the API understands (the struct pxapi.QemuDevices).
+// version of the equivalent configuration that the API understands (the struct pveSDK.QemuDevices).
 // NOTE this expects the provided deviceList to be []map[string]interface{}.
 func ExpandDevicesList(deviceList []interface{}) (pveSDK.QemuDevices, error) {
 	expandedDevices := make(pveSDK.QemuDevices)
@@ -1755,7 +1759,7 @@ func mapToTerraform_Description(description *string) string {
 }
 
 func mapToTerraform_Memory(config *pveSDK.QemuMemory, d *schema.ResourceData) {
-	// no nil check as pxapi.QemuMemory is always returned
+	// no nil check as pveSDK.QemuMemory is always returned
 	if config.CapacityMiB != nil {
 		d.Set("memory", int(*config.CapacityMiB))
 	}


### PR DESCRIPTION
This MR adds features in two commits.

1. pre_enrolled_keys to the efidisk stanza.  This gets translated to the pre-enrolled-keys flag to turn on secure boot.
2. Add tpmstate stanza to configure the tpm in the VM.  This takes a storage location and a version.

These were tested against v3.0.1-rc6.  The master tree has additional issues.

 The code difference between the two points on the tree is the pxapi rename to pveSDK.