### PR TITLE
Fix: multiple target nodes

### DIFF
--- a/docs/resources/lxc.md
+++ b/docs/resources/lxc.md
@@ -267,6 +267,7 @@ The following arguments may be optionally defined when using this resource:
 * `unique` - A boolean that determines if a unique random ethernet address is assigned to the container.
 * `unprivileged` - A boolean that makes the container run as an unprivileged user. Default is `false`.
 * `vmid` - A number that sets the VMID of the container. If set to `0`, the next available VMID is used. Default is `0`.
+* `current_node` __(computed)__ - A string that shows on which node the LXC guest exists.|
 
 ## Attribute Reference
 

--- a/docs/resources/vm_qemu.md
+++ b/docs/resources/vm_qemu.md
@@ -92,7 +92,8 @@ The following arguments are supported in the top level resource block.
 | Argument                      | Type     | Default Value        | Description |
 | ----------------------------- | -------- | -------------------- | ----------- |
 | `name`                        | `str`    |                      | **Required** The name of the VM within Proxmox. |
-| `target_node`                 | `str`    |                      | **Required** The name of the Proxmox Node on which to place the VM. |
+| `target_node`                 | `str`    |                      | The name of the PVE Node on which to place the VM.|
+| `target_nodes`                | `str`    |                      | A list of PVE node names on which to place the VM.|
 | `vmid`                        | `int`    | `0`                  | The ID of the VM in Proxmox. The default value of `0` indicates it should use the next available ID in the sequence. |
 | `desc`                        | `str`    |                      | The description of the VM. Shows as the 'Notes' field in the Proxmox GUI. |
 | `define_connection_info`      | `bool`   | `true`               | Whether to let terraform define the (SSH) connection parameters for preprovisioners, see config block below. |
@@ -145,6 +146,7 @@ The following arguments are supported in the top level resource block.
 | `skip_ipv4`                   | `bool`   | `false`              | Tells proxmox that acquiring an IPv4 address from the qemu guest agent isn't required, it will still return an ipv4 address if it could obtain one. Useful for reducing retries in environments without ipv4.|
 | `skip_ipv6`                   | `bool`   | `false`              | Tells proxmox that acquiring an IPv6 address from the qemu guest agent isn't required, it will still return an ipv6 address if it could obtain one. Useful for reducing retries in environments without ipv6.|
 | `agent_timeout`               | `int`    | `60`                 | Timeout in seconds to keep trying to obtain an IP address from the guest agent one we have a connection. |
+| `current_node`                | `string` |                      | **Computed** The current node of the Qemu guest is on.|
 
 ### VGA Block
 

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.21
 toolchain go1.21.0
 
 require (
-	github.com/Telmate/proxmox-api-go v0.0.0-20250301154022-c19968ff06eb
+	github.com/Telmate/proxmox-api-go v0.0.0-20250312221820-b57bd2eabcaa
 	github.com/google/uuid v1.6.0
 	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.34.0

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,8 @@ github.com/Microsoft/go-winio v0.6.1 h1:9/kr64B9VUZrLm5YYwbGtUJnMgqWVOdUAXu6Migc
 github.com/Microsoft/go-winio v0.6.1/go.mod h1:LRdKpFKfdobln8UmuiYcKPot9D2v6svN5+sAH+4kjUM=
 github.com/ProtonMail/go-crypto v1.1.0-alpha.2-proton h1:HKz85FwoXx86kVtTvFke7rgHvq/HoloSUvW5semjFWs=
 github.com/ProtonMail/go-crypto v1.1.0-alpha.2-proton/go.mod h1:rA3QumHc/FZ8pAHreoekgiAbzpNsfQAosU5td4SnOrE=
-github.com/Telmate/proxmox-api-go v0.0.0-20250301154022-c19968ff06eb h1:TOvQgWR9N6PORA1jcaPLJsemiZarHVbONrSNnkwhi4Q=
-github.com/Telmate/proxmox-api-go v0.0.0-20250301154022-c19968ff06eb/go.mod h1:6qNnkqdMB+22ytC/5qGAIIqtdK9egN1b/Sqs9tB/i1Y=
+github.com/Telmate/proxmox-api-go v0.0.0-20250312221820-b57bd2eabcaa h1:nfslT0Nwslc0JVcJ2MpwXgrtW5dmrhQo8E2/s6SzNXw=
+github.com/Telmate/proxmox-api-go v0.0.0-20250312221820-b57bd2eabcaa/go.mod h1:6qNnkqdMB+22ytC/5qGAIIqtdK9egN1b/Sqs9tB/i1Y=
 github.com/agext/levenshtein v1.2.3 h1:YB2fHEn0UJagG8T1rrWknE3ZQzWM06O8AMAatNn7lmo=
 github.com/agext/levenshtein v1.2.3/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
 github.com/apparentlymart/go-textseg/v12 v12.0.0/go.mod h1:S/4uRK2UtaQttw1GenVJEynmyUenKwP++x/+DdGV/Ec=

--- a/proxmox/Internal/resource/guest/node/schema.go
+++ b/proxmox/Internal/resource/guest/node/schema.go
@@ -11,10 +11,12 @@ import (
 const (
 	RootNode  string = "target_node"
 	RootNodes string = "target_nodes"
+	Computed  string = "current_node"
 )
 
 func SchemaNode(s schema.Schema, guestType string) *schema.Schema {
 	s.Type = schema.TypeString
+	s.Optional = true
 	s.Description = "The node the " + guestType + " guest goes to."
 	s.ValidateDiagFunc = func(i interface{}, path cty.Path) diag.Diagnostics {
 		v, ok := i.(string)
@@ -36,11 +38,12 @@ func SchemaNode(s schema.Schema, guestType string) *schema.Schema {
 	return &s
 }
 
-func SchemaNodes() *schema.Schema {
+func SchemaNodes(guestType string) *schema.Schema {
 	return &schema.Schema{
-		Type:        schema.TypeList, // TODO should be `schema.TypeSet`
-		Optional:    true,
-		Description: "A list of nodes the qemu guest goes to.",
+		Type:          schema.TypeSet,
+		Optional:      true,
+		Description:   "A list of nodes the " + guestType + " guest may be placed on.",
+		ConflictsWith: []string{RootNode},
 		Elem: &schema.Schema{
 			Type: schema.TypeString,
 			ValidateDiagFunc: func(i interface{}, path cty.Path) diag.Diagnostics {
@@ -60,4 +63,11 @@ func SchemaNodes() *schema.Schema {
 				}
 				return nil
 			}}}
+}
+
+func SchemaComputed(guestType string) *schema.Schema {
+	return &schema.Schema{
+		Type:        schema.TypeString,
+		Computed:    true,
+		Description: "The node the " + guestType + " guest is currently on."}
 }

--- a/proxmox/Internal/resource/guest/node/sdk.go
+++ b/proxmox/Internal/resource/guest/node/sdk.go
@@ -1,0 +1,49 @@
+package node
+
+import (
+	"math/rand"
+	"time"
+
+	pveAPI "github.com/Telmate/proxmox-api-go/proxmox"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func SdkUpdate(d *schema.ResourceData, current pveAPI.NodeName) pveAPI.NodeName {
+	if node, ok := d.GetOk(RootNode); ok {
+		return pveAPI.NodeName(node.(string))
+	}
+	nodes := d.Get(RootNodes).(*schema.Set).List()
+	currentNode := string(current)
+	if len(nodes) == 1 {
+		if currentNode != nodes[0].(string) {
+			return pveAPI.NodeName(nodes[0].(string))
+		}
+		return current
+	}
+	if inArray(nodes, currentNode) {
+		return current
+	}
+	randomIndex := rand.New(rand.NewSource(time.Now().UnixNano())).Intn(len(nodes))
+	return pveAPI.NodeName(nodes[randomIndex].(string))
+}
+
+func SdkCreate(d *schema.ResourceData) pveAPI.NodeName {
+	if node, ok := d.GetOk(RootNode); ok {
+		return pveAPI.NodeName(node.(string))
+	}
+	nodes := d.Get(RootNodes).(*schema.Set).List()
+	if len(nodes) == 1 {
+		return pveAPI.NodeName(nodes[0].(string))
+	}
+	randomIndex := rand.New(rand.NewSource(time.Now().UnixNano())).Intn(len(nodes))
+	return pveAPI.NodeName(nodes[randomIndex].(string))
+}
+
+func inArray(nodes []interface{}, current string) bool {
+	for i := range nodes {
+		if current == nodes[i].(string) {
+			return true
+		}
+	}
+	return false
+}

--- a/proxmox/Internal/resource/guest/node/terraform.go
+++ b/proxmox/Internal/resource/guest/node/terraform.go
@@ -1,0 +1,21 @@
+package node
+
+import (
+	pveAPI "github.com/Telmate/proxmox-api-go/proxmox"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func Terraform(d *schema.ResourceData, currentNode pveAPI.NodeName) {
+	current := string(currentNode)
+	d.Set(Computed, current)
+	if _, ok := d.GetOk(RootNode); ok {
+		d.Set(RootNode, current)
+		return
+	}
+	nodes := d.Get(RootNodes).(*schema.Set).List()
+	if inArray(nodes, current) {
+		d.Set(RootNodes, nodes)
+		return
+	}
+	d.Set(RootNodes, []interface{}{current})
+}

--- a/proxmox/util.go
+++ b/proxmox/util.go
@@ -357,12 +357,14 @@ func resourceDataToFlatValues(d *schema.ResourceData, resource *schema.Resource)
 		case schema.TypeFloat:
 			flatValues[key] = d.Get(key).(float64)
 		case schema.TypeSet:
-			values, _ := schemaSetToFlatValues(d.Get(key).(*schema.Set), value.Elem.(*schema.Resource))
-			flatValues[key] = values
+			if _, ok := value.Elem.(*schema.Schema); ok {
+				flatValues[key] = value.Elem.(*schema.Schema)
+			} else {
+				values, _ := schemaSetToFlatValues(d.Get(key).(*schema.Set), value.Elem.(*schema.Resource))
+				flatValues[key] = values
+			}
 		case schema.TypeList:
-			_, ok := value.Elem.(*schema.Schema)
-
-			if ok {
+			if _, ok := value.Elem.(*schema.Schema); ok {
 				flatValues[key] = value.Elem.(*schema.Schema)
 			} else {
 				values, _ := schemaListToFlatValues(d.Get(key).([]interface{}), value.Elem.(*schema.Resource))


### PR DESCRIPTION
When using `target_nodes` the guest will be move to one of the guests at random, and it will stay there until the node is not in the list specified by `target_nodes`.

Adds `current_node` which will display the name of the node the guest is currently on.

`target_node` and `target_nodes` have been made mutually exclusive.

Solves the issues of the following tickets.
closes #1031
closes #1081

Solved due to dependency version update. 
closes #1259

