### PR TITLE
fix: agent_timeout never set

### DIFF
--- a/docs/resources/vm_qemu.md
+++ b/docs/resources/vm_qemu.md
@@ -145,7 +145,7 @@ The following arguments are supported in the top level resource block.
 | `automatic_reboot`            | `bool`   | `true`               | Automatically reboot the VM when parameter changes require this. If disabled the provider will emit a warning when the VM needs to be rebooted. |
 | `skip_ipv4`                   | `bool`   | `false`              | Tells proxmox that acquiring an IPv4 address from the qemu guest agent isn't required, it will still return an ipv4 address if it could obtain one. Useful for reducing retries in environments without ipv4.|
 | `skip_ipv6`                   | `bool`   | `false`              | Tells proxmox that acquiring an IPv6 address from the qemu guest agent isn't required, it will still return an ipv6 address if it could obtain one. Useful for reducing retries in environments without ipv6.|
-| `agent_timeout`               | `int`    | `60`                 | Timeout in seconds to keep trying to obtain an IP address from the guest agent one we have a connection. |
+| `agent_timeout`               | `int`    | `90`                 | Timeout in seconds to keep trying to obtain an IP address from the guest agent one we have a connection. |
 | `current_node`                | `string` |                      | **Computed** The current node of the Qemu guest is on.|
 
 ### VGA Block

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/Telmate/terraform-provider-proxmox/v2
 go 1.21
 
 require (
-	github.com/Telmate/proxmox-api-go v0.0.0-20250312221820-b57bd2eabcaa
+	github.com/Telmate/proxmox-api-go v0.0.0-20250326210034-2dd4b9b7f48a
 	github.com/google/uuid v1.6.0
 	github.com/hashicorp/go-cty v1.4.1
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.34.0

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,8 @@ github.com/Microsoft/go-winio v0.6.1 h1:9/kr64B9VUZrLm5YYwbGtUJnMgqWVOdUAXu6Migc
 github.com/Microsoft/go-winio v0.6.1/go.mod h1:LRdKpFKfdobln8UmuiYcKPot9D2v6svN5+sAH+4kjUM=
 github.com/ProtonMail/go-crypto v1.1.0-alpha.2-proton h1:HKz85FwoXx86kVtTvFke7rgHvq/HoloSUvW5semjFWs=
 github.com/ProtonMail/go-crypto v1.1.0-alpha.2-proton/go.mod h1:rA3QumHc/FZ8pAHreoekgiAbzpNsfQAosU5td4SnOrE=
-github.com/Telmate/proxmox-api-go v0.0.0-20250312221820-b57bd2eabcaa h1:nfslT0Nwslc0JVcJ2MpwXgrtW5dmrhQo8E2/s6SzNXw=
-github.com/Telmate/proxmox-api-go v0.0.0-20250312221820-b57bd2eabcaa/go.mod h1:6qNnkqdMB+22ytC/5qGAIIqtdK9egN1b/Sqs9tB/i1Y=
+github.com/Telmate/proxmox-api-go v0.0.0-20250326210034-2dd4b9b7f48a h1:IydOkWK1H+Sjy5fx/kr94//wZw9+fDAK6+OhmA1QquY=
+github.com/Telmate/proxmox-api-go v0.0.0-20250326210034-2dd4b9b7f48a/go.mod h1:6qNnkqdMB+22ytC/5qGAIIqtdK9egN1b/Sqs9tB/i1Y=
 github.com/agext/levenshtein v1.2.3 h1:YB2fHEn0UJagG8T1rrWknE3ZQzWM06O8AMAatNn7lmo=
 github.com/agext/levenshtein v1.2.3/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
 github.com/apparentlymart/go-textseg/v12 v12.0.0/go.mod h1:S/4uRK2UtaQttw1GenVJEynmyUenKwP++x/+DdGV/Ec=

--- a/proxmox/resource_vm_qemu.go
+++ b/proxmox/resource_vm_qemu.go
@@ -99,7 +99,7 @@ func resourceVmQemu() *schema.Resource {
 			schemaAgentTimeout: { // suppressing the diff causes it to never be set
 				Type:        schema.TypeInt,
 				Optional:    true,
-				Default:     60,
+				Default:     90,
 				Description: "Timeout in seconds to keep trying to obtain an IP address from the guest agent one we have a connection.",
 				ValidateDiagFunc: func(i interface{}, k cty.Path) diag.Diagnostics {
 					v, ok := i.(int)

--- a/proxmox/resource_vm_qemu.go
+++ b/proxmox/resource_vm_qemu.go
@@ -1536,14 +1536,17 @@ func initConnInfo(ctx context.Context, d *schema.ResourceData, client *pveSDK.Cl
 	log.Print("[INFO][initConnInfo] trying to get vm ip address for provisioner")
 	logger.Info().Int(vmID.Root, int(vmr.VmId())).Msgf("trying to get vm ip address for provisioner")
 
-	// wait until the os has started the guest agent
-	guestAgentTimeout := d.Timeout(schema.TimeoutCreate)
-	guestAgentWaitEnd := time.Now().Add(time.Duration(guestAgentTimeout))
-	log.Printf("[DEBUG][initConnInfo] retrying for at most  %v minutes before giving up", guestAgentTimeout)
-	log.Printf("[DEBUG][initConnInfo] retries will end at %s", guestAgentWaitEnd)
-	logger.Debug().Int(vmID.Root, int(vmr.VmId())).Msgf("retrying for at most  %v minutes before giving up", guestAgentTimeout)
-	logger.Debug().Int(vmID.Root, int(vmr.VmId())).Msgf("retries will end at %s", guestAgentWaitEnd)
-	IPs, agentDiags := getPrimaryIP(ctx, config.CloudInit, config.Networks, vmr, client, guestAgentWaitEnd, d.Get(schemaAdditionalWait).(int), d.Get(schemaAgentTimeout).(int), ciAgentEnabled, d.Get(schemaSkipIPv4).(bool), d.Get(schemaSkipIPv6).(bool), hasCiDisk)
+	IPs, agentDiags := getPrimaryIP(
+		ctx, client,
+		config.CloudInit,
+		config.Networks,
+		vmr,
+		time.Duration(d.Get(schemaAgentTimeout).(int))*time.Second,
+		time.Duration(d.Get(schemaAdditionalWait).(int))*time.Second,
+		ciAgentEnabled,
+		d.Get(schemaSkipIPv4).(bool),
+		d.Get(schemaSkipIPv6).(bool),
+		hasCiDisk)
 	if len(agentDiags) > 0 {
 		diags = append(diags, agentDiags...)
 	}
@@ -1574,7 +1577,14 @@ func initConnInfo(ctx context.Context, d *schema.ResourceData, client *pveSDK.Cl
 	return diags
 }
 
-func getPrimaryIP(ctx context.Context, cloudInit *pveSDK.CloudInit, networks pveSDK.QemuNetworkInterfaces, vmr *pveSDK.VmRef, client *pveSDK.Client, endTime time.Time, additionalWait, agentTimeout int, ciAgentEnabled, skipIPv4, skipIPv6, hasCiDisk bool) (primaryIPs, diag.Diagnostics) {
+func getPrimaryIP(
+	ctx context.Context,
+	client *pveSDK.Client,
+	cloudInit *pveSDK.CloudInit,
+	networks pveSDK.QemuNetworkInterfaces,
+	vmr *pveSDK.VmRef,
+	retryDuration, retryInterval time.Duration,
+	ciAgentEnabled, skipIPv4, skipIPv6, hasCiDisk bool) (primaryIPs, diag.Diagnostics) {
 	logger, _ := CreateSubLogger("getPrimaryIP")
 	// TODO allow the primary interface to be a different one than the first
 
@@ -1608,56 +1618,57 @@ func getPrimaryIP(ctx context.Context, cloudInit *pveSDK.CloudInit, networks pve
 		}
 	}
 
-	// get all information we can from qemu agent until the timer runs out
-	if ciAgentEnabled {
-		var (
-			waitedTime        int
-			primaryMacAddress net.HardwareAddr
-			err               error
-		)
-		for i := 0; i < network.AmountNetworkInterfaces; i++ {
-			if v, ok := networks[pveSDK.QemuNetworkInterfaceID(i)]; ok && v.MAC != nil {
-				primaryMacAddress = *v.MAC
-				break
-			}
-		}
-		for time.Now().Before(endTime) {
-			var interfaces []pveSDK.AgentNetworkInterface
-			interfaces, err = vmr.GetAgentInformation(ctx, client, false)
-			if err != nil {
-				if !strings.Contains(err.Error(), ErrorGuestAgentNotRunning) {
-					return primaryIPs{}, diag.FromErr(err)
-				}
-				log.Printf("[INFO][getPrimaryIP] check ip result error %s", err.Error())
-				logger.Debug().Int(vmID.Root, int(vmr.VmId())).Msgf("check ip result error %s", err.Error())
-			} else { // vm is running and reachable
-				if len(interfaces) > 0 { // agent returned some information
-					log.Printf("[INFO][getPrimaryIP] QEMU Agent interfaces found: %v", interfaces)
-					logger.Debug().Int(vmID.Root, int(vmr.VmId())).Msgf("QEMU Agent interfaces found: %v", interfaces)
-					conn = conn.parsePrimaryIPs(interfaces, primaryMacAddress)
-					if conn.hasRequiredIP() {
-						return conn.IPs, diag.Diagnostics{}
-					}
-				}
-				if waitedTime > agentTimeout {
-					break
-				}
-				waitedTime += additionalWait
-			}
-			time.Sleep(time.Duration(additionalWait) * time.Second)
-		}
-		if err != nil {
-			if strings.Contains(err.Error(), ErrorGuestAgentNotRunning) {
-				return primaryIPs{}, diag.Diagnostics{diag.Diagnostic{
-					Severity: diag.Warning,
-					Summary:  "Qemu Guest Agent is enabled but not working",
-					Detail:   fmt.Sprintf("error from PVE: \"%s\"\n, Qemu Guest Agent is enabled in you configuration but non installed/not working on your vm", err)}}
-			}
-			return primaryIPs{}, diag.FromErr(err)
-		}
-		return conn.IPs, conn.agentDiagnostics()
+	if !ciAgentEnabled {
+		return conn.IPs, diag.Diagnostics{}
 	}
-	return conn.IPs, diag.Diagnostics{}
+
+	// get all information we can from qemu agent until the timer runs out
+	var (
+		primaryMacAddress net.HardwareAddr
+		err               error
+	)
+	for i := 0; i < network.AmountNetworkInterfaces; i++ {
+		if v, ok := networks[pveSDK.QemuNetworkInterfaceID(i)]; ok && v.MAC != nil {
+			primaryMacAddress = *v.MAC
+			break
+		}
+	}
+	endTime := time.Now().Add(retryDuration)
+	log.Printf("[DEBUG][initConnInfo] retrying for at most  %v before giving up", retryDuration)
+	log.Printf("[DEBUG][initConnInfo] retries will end at %s", endTime)
+	logger.Debug().Int(vmID.Root, int(vmr.VmId())).Msgf("retrying for at most  %v before giving up", retryDuration)
+	logger.Debug().Int(vmID.Root, int(vmr.VmId())).Msgf("retries will end at %s", endTime)
+	for time.Now().Before(endTime) {
+		var interfaces []pveSDK.AgentNetworkInterface
+		interfaces, err = vmr.GetAgentInformation(ctx, client, false)
+		if err != nil {
+			if !strings.Contains(err.Error(), ErrorGuestAgentNotRunning) {
+				return primaryIPs{}, diag.FromErr(err)
+			}
+			log.Printf("[INFO][getPrimaryIP] check ip result error %s", err.Error())
+			logger.Debug().Int(vmID.Root, int(vmr.VmId())).Msgf("check ip result error %s", err.Error())
+		} else { // vm is running and reachable
+			if len(interfaces) > 0 { // agent returned some information
+				log.Printf("[INFO][getPrimaryIP] QEMU Agent interfaces found: %v", interfaces)
+				logger.Debug().Int(vmID.Root, int(vmr.VmId())).Msgf("QEMU Agent interfaces found: %v", interfaces)
+				conn = conn.parsePrimaryIPs(interfaces, primaryMacAddress)
+				if conn.hasRequiredIP() {
+					return conn.IPs, diag.Diagnostics{}
+				}
+			}
+		}
+		time.Sleep(retryInterval)
+	}
+	if err != nil {
+		if strings.Contains(err.Error(), ErrorGuestAgentNotRunning) {
+			return primaryIPs{}, diag.Diagnostics{diag.Diagnostic{
+				Severity: diag.Warning,
+				Summary:  "Qemu Guest Agent is enabled but not working",
+				Detail:   fmt.Sprintf("error from PVE: \"%s\"\n, Qemu Guest Agent is enabled in you configuration but non installed/not working on your vm", err)}}
+		}
+		return primaryIPs{}, diag.FromErr(err)
+	}
+	return conn.IPs, conn.agentDiagnostics()
 }
 
 // Map struct to the terraform schema

--- a/proxmox/resource_vm_qemu.go
+++ b/proxmox/resource_vm_qemu.go
@@ -96,13 +96,10 @@ func resourceVmQemu() *schema.Resource {
 				Optional: true,
 				Default:  0,
 			},
-			schemaAgentTimeout: {
-				Type:     schema.TypeInt,
-				Optional: true,
-				Default:  60,
-				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-					return true
-				},
+			schemaAgentTimeout: { // suppressing the diff causes it to never be set
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Default:     60,
 				Description: "Timeout in seconds to keep trying to obtain an IP address from the guest agent one we have a connection.",
 				ValidateDiagFunc: func(i interface{}, k cty.Path) diag.Diagnostics {
 					v, ok := i.(int)


### PR DESCRIPTION
Fixed and issue where `agent_timeout` would never be set.
Increased the default `agent_timeout` from 60 to 90 seconds.
Refactored the `getPrimaryIP()` func to reduce nesting and complexity.
Updated proxmox-api-go

Closes #1106