### PR TITLE
fix: 3.0.1-rc7 unable to set sshkeys with EOF

### DIFF
--- a/proxmox/Internal/resource/guest/sshkeys/schema.go
+++ b/proxmox/Internal/resource/guest/sshkeys/schema.go
@@ -33,6 +33,9 @@ func Schema() *schema.Schema {
 			for i := range rawKeys {
 				err := (&pveAPI.AuthorizedKey{}).Parse([]byte(rawKeys[i]))
 				if err != nil {
+					if strings.ReplaceAll(strings.ReplaceAll(rawKeys[i], "\t", ""), " ", "") == "" { // skip empty lines
+						continue
+					}
 					return diag.Diagnostics{{
 						Severity: diag.Error,
 						Summary:  err.Error()}}


### PR DESCRIPTION
The `EOF` syntax adds extra `\n` characters which will result in empty items or items with whitespace, which would be detected as invalid ssh-keys.

Resolves #1280 