### PR TITLE
fix: 3.0.1-rc7 doesnt create the vmid specified on tf

### DIFF
--- a/proxmox/resource_lxc.go
+++ b/proxmox/resource_lxc.go
@@ -600,8 +600,8 @@ func resourceLxcCreate(ctx context.Context, d *schema.ResourceData, meta interfa
 		}
 
 	} else { // Create
-		var nextID pveSDK.GuestID
-		if setGuestID != 0 {
+		nextID := pveSDK.GuestID(setGuestID)
+		if setGuestID == 0 {
 			if pconf.MaxParallel > 1 { // TODO actually fix the parallelism! workaround for #1136
 				diags = append(diags, diag.Diagnostic{
 					Summary:  "setting " + schemaPmParallel + " greater than 1 is currently not recommended when creating LXC containers with dynamic id allocation",


### PR DESCRIPTION
Logic for using a dynamic id was inverted.
When the id would be dynamic it would also have been `0`.

Resolves #1279
