### PR TITLE
Fix panic when no target nodes specified

### DIFF
--- a/proxmox/Internal/resource/guest/node/schema.go
+++ b/proxmox/Internal/resource/guest/node/schema.go
@@ -43,6 +43,7 @@ func SchemaNodes(guestType string) *schema.Schema {
 		Type:          schema.TypeSet,
 		Optional:      true,
 		Description:   "A list of nodes the " + guestType + " guest may be placed on.",
+		MinItems:      1,
 		ConflictsWith: []string{RootNode},
 		Elem: &schema.Schema{
 			Type: schema.TypeString,

--- a/proxmox/resource_lxc.go
+++ b/proxmox/resource_lxc.go
@@ -511,9 +511,11 @@ func resourceLxcCreate(ctx context.Context, d *schema.ResourceData, meta interfa
 
 	setGuestID := d.Get(vmID.Root).(int)
 
-	targetNode := node.SdkCreate(d)
+	targetNode, err := node.SdkCreate(d)
+	if err != nil {
+		return diag.FromErr(err)
+	}
 	var diags diag.Diagnostics
-	var err error
 	var vmr *pveSDK.VmRef
 	if d.Get("clone").(string) != "" { // Clone
 		var sourceVmr *pveSDK.VmRef


### PR DESCRIPTION
Sets a minimum of `1` node when `target_nodes` is specified.
Return en error when `target_node` and `target_nodes` aren't specified.

Resolves #1297