### PR TITLE
Feat: New CPU schema

### DIFF
--- a/docs/resources/vm_qemu.md
+++ b/docs/resources/vm_qemu.md
@@ -116,11 +116,6 @@ The following arguments are supported in the top level resource block.
 | `qemu_os`                     | `str`    | `"l26"`              | The type of OS in the guest. Set properly to allow Proxmox to enable optimizations for the appropriate guest OS. It takes the value from the source template and ignore any changes to resource configuration parameter. |
 | `memory`                      | `int`    | `512`                | The amount of memory to allocate to the VM in Megabytes. |
 | `balloon`                     | `int`    | `0`                  | The minimum amount of memory to allocate to the VM in Megabytes, when Automatic Memory Allocation is desired. Proxmox will enable a balloon device on the guest to manage dynamic allocation. See the [docs about memory](https://pve.proxmox.com/pve-docs/chapter-qm.html#qm_memory) for more info. |
-| `sockets`                     | `int`    | `1`                  | The number of CPU sockets to allocate to the VM. |
-| `cores`                       | `int`    | `1`                  | The number of CPU cores per CPU socket to allocate to the VM. |
-| `vcpus`                       | `int`    | `0`                  | The number of vCPUs plugged into the VM when it starts. If `0`, this is set automatically by Proxmox to `sockets * cores`. |
-| `cpu_type`                    | `str`    | `"host"`             | The type of CPU to emulate in the Guest. See the [docs about CPU Types](https://pve.proxmox.com/pve-docs/chapter-qm.html#qm_cpu) for more info. |
-| `numa`                        | `bool`   | `false`              | Whether to enable [Non-Uniform Memory Access](https://pve.proxmox.com/pve-docs/chapter-qm.html#qm_cpu) in the guest. |
 | `hotplug`                     | `str`    | `"network,disk,usb"` | Comma delimited list of hotplug features to enable. Options: `network`, `disk`, `cpu`, `memory`, `usb`. Set to `0` to disable hotplug. |
 | `scsihw`                      | `str`    | `"lsi"`              | The SCSI controller to emulate. Options: `lsi`, `lsi53c810`, `megasas`, `pvscsi`, `virtio-scsi-pci`, `virtio-scsi-single`. |
 | `pool`                        | `str`    |                      | The resource pool to which the VM will be added. |
@@ -147,6 +142,42 @@ The following arguments are supported in the top level resource block.
 | `skip_ipv6`                   | `bool`   | `false`              | Tells proxmox that acquiring an IPv6 address from the qemu guest agent isn't required, it will still return an ipv6 address if it could obtain one. Useful for reducing retries in environments without ipv6.|
 | `agent_timeout`               | `int`    | `90`                 | Timeout in seconds to keep trying to obtain an IP address from the guest agent one we have a connection. |
 | `current_node`                | `string` |                      | **Computed** The current node of the Qemu guest is on.|
+
+### CPU Block
+
+The `cpu` block is used to configure the CPU settings. It may be specified once.
+See the [docs about CPU](https://pve.proxmox.com/pve-docs/chapter-qm.html#qm_cpu) for more details.
+
+| Argument  | Type  | Default Value | Description |
+| --------- | ----- | ------------- |:----------- |
+| `affinity`| `str` | `""`          | The CPU affinity for the Qemu guest. This is a comma separated list of values and ranges which define to which CPU cores the Qemu guest is bound. Example: `1,3-5`.|
+| `cores`   | `int` | `1`           | The number of CPU cores to allocate to the Qemu guest.|
+| `limit`   | `int` | `0`           | The CPU limit for the Qemu guest. `0` means unlimited.|
+| `numa`    | `bool`| `false`       | Whether to enable [Non-Uniform Memory Access](https://pve.proxmox.com/pve-docs/chapter-qm.html#qm_cpu) in the Qemu guest.|
+| `sockets` | `int` | `1`           | The number of CPU sockets to allocate to the Qemu guest.|
+| `type`    | `str` | `"host"`      | The CPU type to emulate. See the [docs about CPU Types](https://pve.proxmox.com/pve-docs/chapter-qm.html#_cpu_type) for more info.|
+| `units`   | `int` | `0`        | The CPU units for the Qemu guest. This is a relative value which defines the CPU weight of the Qemu guest. The default value of `0` indicates the PVE default is used.|
+| `vcores`  | `int` | `0`        | The number of virtual cores exposed to the Qemu guest. If `0`, this is set automatically by Proxmox to `sockets * cores`.|
+| `flags`   | `list`|         | The CPU flags to enable for the Qemu guest. |
+
+#### CPU Flags Block
+
+The CPU flags to enable for the Qemu guest. A flag can be set with `on` ot `off`, when a flag isn't specified, it will be set to the default value in PVE and will be inherited from the `cpu.type`.
+
+| Argument     | Type | Description |
+| ------------ | ---- | ----------- |
+| `md_clear`   | `str`| Required to let the guest OS know if MDS is mitigated correctly.|
+| `pcid`       | `str`| Meltdown fix cost reduction on Westmere, Sandy-, and IvyBridge Intel CPUs.|
+| `spec_ctrl`  | `str`| Allows improved Spectre mitigation with Intel CPUs.|
+| `ssbd`       | `str`| Protection for "Speculative Store Bypass" for Intel models.|
+| `ibpb`       | `str`| Allows improved Spectre mitigation with AMD CPUs.|
+| `virt_ssbd`  | `str`| Basis for "Speculative Store Bypass" protection for AMD models.|
+| `amd_ssbd`   | `str`| Improves Spectre mitigation performance with AMD CPUs, best used with "virt-ssbd".|
+| `amd_no_ssb` | `str`| Notifies guest OS that host is not vulnerable for Spectre on AMD CPUs.|
+| `pbpe1gb`    | `str`| Allow guest OS to use 1GB size pages, if host HW supports it.|
+| `hv_tlbflush`| `str`| Improve performance in overcommitted Windows guests. May lead to guest bluescreens on old CPUs.|
+| `hv_evmcs`   | `str`| Improve performance for nested virtualization. Only supported on Intel CPUs.|
+| `aes`        | `str`| Activate AES instruction set for HW acceleration.|
 
 ### VGA Block
 

--- a/examples/cloudinit_example.tf
+++ b/examples/cloudinit_example.tf
@@ -24,10 +24,12 @@ resource "proxmox_vm_qemu" "cloudinit-test" {
     agent = 1
 
     os_type = "cloud-init"
-    cores = 2
-    sockets = 1
-    vcpus = 0
-    cpu_type = "host"
+    
+    cpu {
+        cores = 2
+        sockets = 1
+        type = "host"
+    }
     memory = 2048
     scsihw = "lsi"
 

--- a/examples/pxe_example.tf
+++ b/examples/pxe_example.tf
@@ -31,24 +31,25 @@ resource "proxmox_vm_qemu" "pxe-example" {
 # Optinally, setting a disk first means that PXE will be used first boot
 # and future boots will run off the disk
     boot                      = "order=scsi0;net0"
-    cores                     = 2
-    cpu_type                  = "host"
     define_connection_info    = true
     force_create              = false
     hotplug                   = "network,disk,usb"
     kvm                       = true
     memory                    = 2048
-    numa                      = false
     onboot                    = false
     vm_state                  = "running"
     os_type                   = "Linux 5.x - 2.6 Kernel"
     qemu_os                   = "l26"
     scsihw                    = "virtio-scsi-pci"
-    sockets                   = 1
     protection                = false
     tablet                    = true
     target_node               = "test"
-    vcpus                     = 0
+
+    cpu {
+        cores    = 2
+        sockets  = 1
+        type     = "host"
+    }
 
     disks {
         scsi {

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/Telmate/terraform-provider-proxmox/v2
 go 1.21
 
 require (
-	github.com/Telmate/proxmox-api-go v0.0.0-20250326210034-2dd4b9b7f48a
+	github.com/Telmate/proxmox-api-go v0.0.0-20250503175408-7fbd372efd64
 	github.com/google/uuid v1.6.0
 	github.com/hashicorp/go-cty v1.5.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.34.0

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,8 @@ github.com/Microsoft/go-winio v0.6.1 h1:9/kr64B9VUZrLm5YYwbGtUJnMgqWVOdUAXu6Migc
 github.com/Microsoft/go-winio v0.6.1/go.mod h1:LRdKpFKfdobln8UmuiYcKPot9D2v6svN5+sAH+4kjUM=
 github.com/ProtonMail/go-crypto v1.1.0-alpha.2-proton h1:HKz85FwoXx86kVtTvFke7rgHvq/HoloSUvW5semjFWs=
 github.com/ProtonMail/go-crypto v1.1.0-alpha.2-proton/go.mod h1:rA3QumHc/FZ8pAHreoekgiAbzpNsfQAosU5td4SnOrE=
-github.com/Telmate/proxmox-api-go v0.0.0-20250326210034-2dd4b9b7f48a h1:IydOkWK1H+Sjy5fx/kr94//wZw9+fDAK6+OhmA1QquY=
-github.com/Telmate/proxmox-api-go v0.0.0-20250326210034-2dd4b9b7f48a/go.mod h1:6qNnkqdMB+22ytC/5qGAIIqtdK9egN1b/Sqs9tB/i1Y=
+github.com/Telmate/proxmox-api-go v0.0.0-20250503175408-7fbd372efd64 h1:z/fY7p/uepmdCqC2v601n307ma424Or3eJfr85wmzSw=
+github.com/Telmate/proxmox-api-go v0.0.0-20250503175408-7fbd372efd64/go.mod h1:6qNnkqdMB+22ytC/5qGAIIqtdK9egN1b/Sqs9tB/i1Y=
 github.com/agext/levenshtein v1.2.3 h1:YB2fHEn0UJagG8T1rrWknE3ZQzWM06O8AMAatNn7lmo=
 github.com/agext/levenshtein v1.2.3/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
 github.com/apparentlymart/go-textseg/v12 v12.0.0/go.mod h1:S/4uRK2UtaQttw1GenVJEynmyUenKwP++x/+DdGV/Ec=

--- a/proxmox/Internal/resource/guest/qemu/cpu/schema.go
+++ b/proxmox/Internal/resource/guest/qemu/cpu/schema.go
@@ -1,82 +1,256 @@
 package cpu
 
 import (
-	pveAPI "github.com/Telmate/proxmox-api-go/proxmox"
+	pveSDK "github.com/Telmate/proxmox-api-go/proxmox"
 	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 const (
-	Root             string = "cpu"
-	RootCores        string = "cores"
-	RootCpuType      string = "cpu_type"
-	RootNuma         string = "numa"
-	RootSockets      string = "sockets"
-	RootVirtualCores string = "vcpus"
+	Root = "cpu"
+
+	schemaAffinity     = "affinity"
+	schemaCores        = "cores"
+	schemaLimit        = "limit"
+	schemaNuma         = "numa"
+	schemaSockets      = "sockets"
+	schemaType         = "type"
+	schemaUnits        = "units"
+	schemaVirtualCores = "vcores"
+
+	schemaFlags = "flags"
+
+	schemaFlagAes        = "aes"
+	schemaFlagAmdNoSsb   = "amd_no_ssb"
+	schemaFlagAmdSsbd    = "amd_ssbd"
+	schemaFlagHvEvmcs    = "hv_evmcs"
+	schemaFlagHvTlbflush = "hv_tlbflush"
+	schemaFlagIbpb       = "ibpb"
+	schemaFlagMdClear    = "md_clear"
+	schemaFlagPbpe1gb    = "pbpe1gb"
+	schemaFlagPcidev     = "pcid"
+	schemaFlagSpecCtrl   = "spec_ctrl"
+	schemaFlagSsbd       = "ssbd"
+	schemaFlagVirtSsbd   = "virt_ssbd"
+
+	defaultAffinity     = ""
+	defaultCores        = 1
+	defaultLimit        = 0
+	defaultNuma         = false
+	defaultSockets      = 1
+	defaultType         = "host"
+	defaultUnits        = 0
+	defaultVirtualCores = 0
+
+	flagOn  = "on"
+	flagOff = "off"
 )
 
-func SchemaCores() *schema.Schema {
+func Schema() *schema.Schema {
 	return &schema.Schema{
-		Type:     schema.TypeInt,
+		Type:     schema.TypeList,
 		Optional: true,
-		Default:  1,
-		ValidateDiagFunc: func(i interface{}, p cty.Path) diag.Diagnostics {
-			v, ok := i.(int)
+		MaxItems: 1,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				schemaAffinity:     subSchemaAffinity(),
+				schemaCores:        subSchemaCores(schemaCores, schema.Schema{Default: defaultCores}),
+				schemaFlags:        subSchemaFlags(),
+				schemaLimit:        subSchemaLimit(),
+				schemaNuma:         subSchemaNuma(schema.Schema{Default: defaultNuma}),
+				schemaSockets:      subSchemaSockets(schemaSockets, schema.Schema{Default: defaultSockets}),
+				schemaType:         subSchemaType(schema.Schema{Default: defaultType}),
+				schemaUnits:        subSchemaUnits(),
+				schemaVirtualCores: subSchemaVirtualCores(schemaVirtualCores, schema.Schema{Default: defaultVirtualCores})}}}
+}
+
+func subSchemaAffinity() *schema.Schema {
+	return &schema.Schema{
+		Type:        schema.TypeString,
+		Optional:    true,
+		Description: "CPU affinity",
+		Default:     defaultAffinity,
+		DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+			oldAffinity, _ := sdkAffinity(old)
+			newAffinity, _ := sdkAffinity(new)
+			if len(*oldAffinity) == 0 && len(*newAffinity) == 0 {
+				return terraformAffinity(*oldAffinity) == terraformAffinity(*newAffinity)
+			}
+			return false
+		},
+		ValidateDiagFunc: func(i any, p cty.Path) diag.Diagnostics {
+			v, ok := i.(string)
 			if !ok {
-				return diag.Errorf(RootCores + " must be an integer")
+				return diag.Errorf(schemaAffinity + " must be a string")
 			}
-			if v < 1 {
-				return diag.Errorf(RootCores + " must be greater than 0")
+			if v == "" {
+				return nil
 			}
-			return diag.FromErr(pveAPI.QemuCpuCores(v).Validate())
-		}}
-}
-
-func SchemaType(s schema.Schema) *schema.Schema {
-	s.Type = schema.TypeString
-	s.Optional = true
-	return &s
-}
-
-func SchemaNuma() *schema.Schema {
-	return &schema.Schema{
-		Type:     schema.TypeBool,
-		Optional: true,
-	}
-}
-
-func SchemaSockets() *schema.Schema {
-	return &schema.Schema{
-		Type:     schema.TypeInt,
-		Optional: true,
-		Default:  1,
-		ValidateDiagFunc: func(i interface{}, p cty.Path) diag.Diagnostics {
-			v, ok := i.(int)
-			if !ok {
-				return diag.Errorf(RootSockets + " must be an integer")
-			}
-			if v < 1 {
-				return diag.Errorf(RootSockets + " must be greater than 0")
-			}
-			return diag.FromErr(pveAPI.QemuCpuSockets(v).Validate())
-		}}
-}
-
-func SchemaVirtualCores() *schema.Schema {
-	return &schema.Schema{
-		Type:     schema.TypeInt,
-		Optional: true,
-		Default:  0,
-		ValidateDiagFunc: func(i interface{}, p cty.Path) diag.Diagnostics {
-			v, ok := i.(int)
-			if !ok {
-				return diag.Errorf(RootVirtualCores + " must be an integer")
-			}
-			if v < 0 {
-				return diag.Errorf(RootVirtualCores + " must be greater than or equal to 0")
+			if _, err := sdkAffinity(v); err != nil {
+				return diag.FromErr(err)
 			}
 			return nil
 		},
 	}
+}
+
+func subSchemaCores(key string, s schema.Schema) *schema.Schema {
+	s.Type = schema.TypeInt
+	s.Optional = true
+	s.Description = "Number of CPU cores"
+	s.ValidateDiagFunc = func(i any, p cty.Path) diag.Diagnostics {
+		v, ok := i.(int)
+		if !ok {
+			return diag.Errorf(key + " must be an integer")
+		}
+		if v < 1 {
+			return diag.Errorf(key + " must be greater than 0")
+		}
+		return diag.FromErr(pveSDK.QemuCpuCores(v).Validate())
+	}
+	return &s
+}
+
+func subSchemaFlag(key string) *schema.Schema {
+	return &schema.Schema{
+		Type:        schema.TypeString,
+		Optional:    true,
+		Description: "CPU flag " + key,
+		ValidateDiagFunc: func(i any, p cty.Path) diag.Diagnostics {
+			v, ok := i.(string)
+			if !ok {
+				return diag.Errorf(schemaFlags + " must be a string")
+			}
+			if v == "" {
+				return diag.Errorf(schemaFlags + " must not be empty")
+			}
+			switch v {
+			case flagOn, flagOff:
+				return nil
+			default:
+				return diag.Errorf(schemaFlags + " must be one of " + flagOn + " or " + flagOff)
+			}
+		}}
+}
+
+func subSchemaFlags() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeList,
+		Optional: true,
+		MaxItems: 1,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				schemaFlagAes:        subSchemaFlag(schemaFlagAes),
+				schemaFlagAmdNoSsb:   subSchemaFlag(schemaFlagAmdNoSsb),
+				schemaFlagAmdSsbd:    subSchemaFlag(schemaFlagAmdSsbd),
+				schemaFlagHvEvmcs:    subSchemaFlag(schemaFlagHvEvmcs),
+				schemaFlagHvTlbflush: subSchemaFlag(schemaFlagHvTlbflush),
+				schemaFlagIbpb:       subSchemaFlag(schemaFlagIbpb),
+				schemaFlagMdClear:    subSchemaFlag(schemaFlagMdClear),
+				schemaFlagPbpe1gb:    subSchemaFlag(schemaFlagPbpe1gb),
+				schemaFlagPcidev:     subSchemaFlag(schemaFlagPcidev),
+				schemaFlagSpecCtrl:   subSchemaFlag(schemaFlagSpecCtrl),
+				schemaFlagSsbd:       subSchemaFlag(schemaFlagSsbd),
+				schemaFlagVirtSsbd:   subSchemaFlag(schemaFlagVirtSsbd)}}}
+}
+
+func subSchemaLimit() *schema.Schema {
+	return &schema.Schema{
+		Type:        schema.TypeInt,
+		Optional:    true,
+		Description: "CPU limit",
+		Default:     defaultLimit,
+		ValidateDiagFunc: func(i any, p cty.Path) diag.Diagnostics {
+			v, ok := i.(int)
+			if !ok {
+				return diag.Errorf(schemaLimit + " must be an integer")
+			}
+			if v < 0 {
+				return diag.Errorf(schemaLimit + " must be greater than or equal to 0")
+			}
+			if err := pveSDK.CpuLimit(v).Validate(); err != nil {
+				return diag.FromErr(err)
+			}
+			return nil
+		}}
+}
+
+func subSchemaNuma(s schema.Schema) *schema.Schema {
+	s.Type = schema.TypeBool
+	s.Optional = true
+	s.Description = "Enable NUMA"
+	return &s
+}
+
+func subSchemaSockets(key string, s schema.Schema) *schema.Schema {
+	s.Type = schema.TypeInt
+	s.Optional = true
+	s.Description = "Number of CPU sockets"
+	s.ValidateDiagFunc = func(i any, p cty.Path) diag.Diagnostics {
+		v, ok := i.(int)
+		if !ok {
+			return diag.Errorf(key + " must be an integer")
+		}
+		if v < 1 {
+			return diag.Errorf(key + " must be greater than 0")
+		}
+		return diag.FromErr(pveSDK.QemuCpuSockets(v).Validate())
+	}
+	return &s
+}
+
+func subSchemaType(s schema.Schema) *schema.Schema {
+	s.Type = schema.TypeString
+	s.Optional = true
+	s.Description = "CPU type"
+	s.ValidateDiagFunc = func(i any, p cty.Path) diag.Diagnostics {
+		v, ok := i.(string)
+		if !ok {
+			return diag.Errorf(RootLegacyCpuType + " must be a string")
+		}
+		if v == "" {
+			return diag.Errorf(RootLegacyCpuType + " must not be empty")
+		}
+		if err := pveSDK.CpuType(v).Validate(pveSDK.Version{Major: 255}); err != nil {
+			return diag.FromErr(err)
+		}
+		return nil
+	}
+	return &s
+}
+
+func subSchemaUnits() *schema.Schema {
+	return &schema.Schema{
+		Type:        schema.TypeInt,
+		Optional:    true,
+		Description: "CPU units",
+		Default:     defaultUnits,
+		ValidateDiagFunc: func(i any, p cty.Path) diag.Diagnostics {
+			v, ok := i.(int)
+			if !ok {
+				return diag.Errorf(schemaUnits + " must be an integer")
+			}
+			if err := pveSDK.CpuUnits(v).Validate(); err != nil {
+				return diag.FromErr(err)
+			}
+			return nil
+		}}
+}
+
+func subSchemaVirtualCores(key string, s schema.Schema) *schema.Schema {
+	s.Type = schema.TypeInt
+	s.Optional = true
+	s.Description = "Number of virtual cores"
+	s.ValidateDiagFunc = func(i any, p cty.Path) diag.Diagnostics {
+		v, ok := i.(int)
+		if !ok {
+			return diag.Errorf(key + " must be an integer")
+		}
+		if v < 0 {
+			return diag.Errorf(key + " must be greater than or equal to 0")
+		}
+		return nil
+	}
+	return &s
 }

--- a/proxmox/Internal/resource/guest/qemu/cpu/schema_legacy.go
+++ b/proxmox/Internal/resource/guest/qemu/cpu/schema_legacy.go
@@ -1,0 +1,59 @@
+package cpu
+
+import (
+	"strconv"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+const (
+	RootLegacyCores        = "cores"
+	RootLegacyCpuType      = "cpu_type"
+	RootLegacyNuma         = "numa"
+	RootLegacySockets      = "sockets"
+	RootLegacyVirtualCores = "vcpus"
+)
+
+func SchemaLegacyCores() *schema.Schema {
+	return subSchemaCores(RootLegacyCores, schema.Schema{
+		Deprecated:    "use " + Root + "." + RootLegacyCores + " instead",
+		ConflictsWith: []string{Root}})
+}
+
+func SchemaLegacyType() *schema.Schema {
+	return subSchemaType(schema.Schema{
+		Deprecated:    "use " + Root + "." + RootLegacyCpuType + " instead",
+		ConflictsWith: []string{Root},
+		DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+			newNew := defaultType
+			if new != "" {
+				newNew = new
+			}
+			return old == newNew
+		}})
+}
+
+func SchemaLegacyNuma() *schema.Schema {
+	return subSchemaNuma(schema.Schema{
+		Deprecated:    "use " + Root + "." + RootLegacyNuma + " instead",
+		ConflictsWith: []string{Root}})
+}
+
+func SchemaLegacySockets() *schema.Schema {
+	return subSchemaSockets(RootLegacySockets, schema.Schema{
+		Deprecated:    "use " + Root + "." + RootLegacySockets + " instead",
+		ConflictsWith: []string{Root},
+		DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+			newNew := strconv.Itoa(defaultSockets)
+			if new != "0" {
+				newNew = new
+			}
+			return old == newNew
+		}})
+}
+
+func SchemaLegacyVirtualCores() *schema.Schema {
+	return subSchemaVirtualCores(RootLegacyVirtualCores, schema.Schema{
+		Deprecated:    "use " + Root + "." + RootLegacyVirtualCores + " instead",
+		ConflictsWith: []string{Root}})
+}

--- a/proxmox/Internal/resource/guest/qemu/cpu/sdk.go
+++ b/proxmox/Internal/resource/guest/qemu/cpu/sdk.go
@@ -1,23 +1,145 @@
 package cpu
 
 import (
-	pveAPI "github.com/Telmate/proxmox-api-go/proxmox"
+	"errors"
+	"strconv"
+	"strings"
+
+	pveSDK "github.com/Telmate/proxmox-api-go/proxmox"
 	"github.com/Telmate/terraform-provider-proxmox/v2/proxmox/Internal/util"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
-func SDK(d *schema.ResourceData) *pveAPI.QemuCPU {
-	var cpuType pveAPI.CpuType
-	if v, ok := d.GetOk(Root); ok {
-		cpuType = pveAPI.CpuType(v.(string))
-	} else {
-		v := d.Get(RootCpuType)
-		cpuType = pveAPI.CpuType(v.(string))
+const (
+	error_AffinityFormat = "invalid affinity format"
+)
+
+func SDK(d *schema.ResourceData) *pveSDK.QemuCPU {
+	v, ok := d.GetOk(Root)
+	if !ok { // defaults
+		if v := sdkLegacy(d); v != nil {
+			return v
+		}
+		return defaults()
 	}
-	return &pveAPI.QemuCPU{
-		Cores:        util.Pointer(pveAPI.QemuCpuCores(d.Get(RootCores).(int))),
-		Numa:         util.Pointer(d.Get(RootNuma).(bool)),
-		Sockets:      util.Pointer(pveAPI.QemuCpuSockets(d.Get(RootSockets).(int))),
-		Type:         util.Pointer(cpuType),
-		VirtualCores: util.Pointer(pveAPI.CpuVirtualCores(d.Get(RootVirtualCores).(int)))}
+	vv, ok := v.([]any)
+	if ok && len(vv) != 1 {
+		return nil
+	}
+	if settings, ok := vv[0].(map[string]any); ok {
+		affinity, _ := sdkAffinity(settings[schemaAffinity].(string))
+		return &pveSDK.QemuCPU{
+			Affinity:     affinity,
+			Cores:        util.Pointer(pveSDK.QemuCpuCores(settings[schemaCores].(int))),
+			Flags:        sdkFlags(settings),
+			Limit:        util.Pointer(pveSDK.CpuLimit(settings[schemaLimit].(int))),
+			Numa:         util.Pointer(settings[schemaNuma].(bool)),
+			Sockets:      util.Pointer(pveSDK.QemuCpuSockets(settings[schemaSockets].(int))),
+			Type:         util.Pointer(pveSDK.CpuType(settings[schemaType].(string))),
+			Units:        util.Pointer(pveSDK.CpuUnits(settings[schemaUnits].(int))),
+			VirtualCores: util.Pointer(pveSDK.CpuVirtualCores(settings[schemaVirtualCores].(int)))}
+	}
+	return defaults()
+}
+
+func sdkAffinity(rawAffinity string) (*[]uint, error) {
+	affinity := make([]uint, 0)
+	if rawAffinity == "" {
+		return &affinity, nil
+	}
+	affinityParts := strings.Split(rawAffinity, ",")
+	for i := range affinityParts {
+		if affinityParts[i] == "" {
+			continue
+		}
+		parts := strings.Split(affinityParts[i], "-")
+		switch len(parts) {
+		case 1:
+			i, err := strconv.Atoi(parts[0])
+			if err != nil {
+				return nil, errors.New(error_AffinityFormat)
+			}
+			affinity = append(affinity, uint(i))
+		case 2:
+			start, err := strconv.Atoi(parts[0])
+			if err != nil {
+				return nil, errors.New(error_AffinityFormat)
+			}
+			end, err := strconv.Atoi(parts[1])
+			if err != nil {
+				return nil, errors.New(error_AffinityFormat)
+			}
+			if start >= end {
+				return nil, errors.New(error_AffinityFormat)
+			}
+			tmpAffinities := make([]uint, end-start+1)
+			for i := start; i <= end; i++ {
+				tmpAffinities[i-start] = uint(i)
+			}
+			affinity = append(affinity, tmpAffinities...)
+		default:
+			return nil, errors.New(error_AffinityFormat)
+		}
+	}
+	return &affinity, nil
+}
+
+func sdkFlags(schema map[string]any) *pveSDK.CpuFlags {
+	v, ok := schema[schemaFlags].([]any)
+	if !ok || len(v) != 1 || v[0] == nil {
+		return defaultFlags()
+	}
+	schemaItems := v[0].(map[string]any)
+	return &pveSDK.CpuFlags{
+		AES:        sdkFlag(schemaItems[schemaFlagAes].(string)),
+		AmdNoSSB:   sdkFlag(schemaItems[schemaFlagAmdNoSsb].(string)),
+		AmdSSBD:    sdkFlag(schemaItems[schemaFlagAmdSsbd].(string)),
+		HvEvmcs:    sdkFlag(schemaItems[schemaFlagHvEvmcs].(string)),
+		HvTlbFlush: sdkFlag(schemaItems[schemaFlagHvTlbflush].(string)),
+		Ibpb:       sdkFlag(schemaItems[schemaFlagIbpb].(string)),
+		MdClear:    sdkFlag(schemaItems[schemaFlagMdClear].(string)),
+		PCID:       sdkFlag(schemaItems[schemaFlagPcidev].(string)),
+		Pdpe1GB:    sdkFlag(schemaItems[schemaFlagPbpe1gb].(string)),
+		SSBD:       sdkFlag(schemaItems[schemaFlagSsbd].(string)),
+		SpecCtrl:   sdkFlag(schemaItems[schemaFlagSpecCtrl].(string)),
+		VirtSSBD:   sdkFlag(schemaItems[schemaFlagVirtSsbd].(string))}
+}
+
+func sdkFlag(rawFlag string) *pveSDK.TriBool {
+	switch strings.ToLower(rawFlag) {
+	case flagOn:
+		return util.Pointer(pveSDK.TriBoolTrue)
+	case flagOff:
+		return util.Pointer(pveSDK.TriBoolFalse)
+	}
+	return util.Pointer(pveSDK.TriBoolNone)
+}
+
+func defaultFlags() *pveSDK.CpuFlags {
+	return &pveSDK.CpuFlags{
+		AES:        util.Pointer(pveSDK.TriBoolNone),
+		AmdNoSSB:   util.Pointer(pveSDK.TriBoolNone),
+		AmdSSBD:    util.Pointer(pveSDK.TriBoolNone),
+		HvEvmcs:    util.Pointer(pveSDK.TriBoolNone),
+		HvTlbFlush: util.Pointer(pveSDK.TriBoolNone),
+		Ibpb:       util.Pointer(pveSDK.TriBoolNone),
+		MdClear:    util.Pointer(pveSDK.TriBoolNone),
+		PCID:       util.Pointer(pveSDK.TriBoolNone),
+		Pdpe1GB:    util.Pointer(pveSDK.TriBoolNone),
+		SSBD:       util.Pointer(pveSDK.TriBoolNone),
+		SpecCtrl:   util.Pointer(pveSDK.TriBoolNone),
+		VirtSSBD:   util.Pointer(pveSDK.TriBoolNone)}
+}
+
+func defaults() *pveSDK.QemuCPU {
+	return &pveSDK.QemuCPU{
+		Affinity:     util.Pointer([]uint{}),
+		Cores:        util.Pointer(pveSDK.QemuCpuCores(defaultCores)),
+		Flags:        defaultFlags(),
+		Limit:        util.Pointer(pveSDK.CpuLimit(defaultLimit)),
+		Numa:         util.Pointer(defaultNuma),
+		Sockets:      util.Pointer(pveSDK.QemuCpuSockets(defaultSockets)),
+		Type:         util.Pointer(pveSDK.CpuType(defaultType)),
+		Units:        util.Pointer(pveSDK.CpuUnits(defaultUnits)),
+		VirtualCores: util.Pointer(pveSDK.CpuVirtualCores(defaultVirtualCores))}
 }

--- a/proxmox/Internal/resource/guest/qemu/cpu/sdk_legacy.go
+++ b/proxmox/Internal/resource/guest/qemu/cpu/sdk_legacy.go
@@ -1,0 +1,46 @@
+package cpu
+
+import (
+	pveSDk "github.com/Telmate/proxmox-api-go/proxmox"
+	"github.com/Telmate/terraform-provider-proxmox/v2/proxmox/Internal/util"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func sdkLegacy(d *schema.ResourceData) *pveSDk.QemuCPU {
+	var cpu pveSDk.QemuCPU
+	var isSet bool
+	if v, ok := d.GetOk(RootLegacyCores); ok {
+		cpu.Cores = util.Pointer(pveSDk.QemuCpuCores(v.(int)))
+		isSet = true
+	} else {
+		cpu.Cores = util.Pointer(pveSDk.QemuCpuCores(defaultCores))
+	}
+	if v, ok := d.GetOk(RootLegacySockets); ok {
+		cpu.Sockets = util.Pointer(pveSDk.QemuCpuSockets(v.(int)))
+		isSet = true
+	} else {
+		cpu.Sockets = util.Pointer(pveSDk.QemuCpuSockets(defaultSockets))
+	}
+	if v, ok := d.GetOk(RootLegacyNuma); ok {
+		cpu.Numa = util.Pointer(v.(bool))
+		isSet = true
+	} else {
+		cpu.Numa = util.Pointer(defaultNuma)
+	}
+	if v, ok := d.GetOk(RootLegacyCpuType); ok {
+		cpu.Type = util.Pointer(pveSDk.CpuType(v.(string)))
+		isSet = true
+	} else {
+		cpu.Type = util.Pointer(pveSDk.CpuType(defaultType))
+	}
+	if v, ok := d.GetOk(RootLegacyVirtualCores); ok {
+		cpu.VirtualCores = util.Pointer(pveSDk.CpuVirtualCores(v.(int)))
+		isSet = true
+	} else {
+		cpu.VirtualCores = util.Pointer(pveSDk.CpuVirtualCores(defaultVirtualCores))
+	}
+	if isSet {
+		return &cpu
+	}
+	return nil
+}

--- a/proxmox/Internal/resource/guest/qemu/cpu/terraform.go
+++ b/proxmox/Internal/resource/guest/qemu/cpu/terraform.go
@@ -1,28 +1,145 @@
 package cpu
 
 import (
-	pveAPI "github.com/Telmate/proxmox-api-go/proxmox"
+	"strconv"
+	"strings"
+
+	"slices"
+
+	pveSDK "github.com/Telmate/proxmox-api-go/proxmox"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
-func Terraform(config pveAPI.QemuCPU, d *schema.ResourceData) {
-	if config.Cores != nil {
-		d.Set(RootCores, int(*config.Cores))
-	}
-	if config.Numa != nil {
-		d.Set(RootNuma, *config.Numa)
-	}
-	if config.Sockets != nil {
-		d.Set(RootSockets, int(*config.Sockets))
-	}
-	if config.Type != nil {
-		if _, ok := d.GetOk(Root); ok {
-			d.Set(Root, string(*config.Type))
-		} else {
-			d.Set(RootCpuType, string(*config.Type))
+func Terraform(config pveSDK.QemuCPU, d *schema.ResourceData) {
+	if _, ok := d.GetOk(Root); !ok {
+		if hasLegacySettings := terraformLegacy(config, d); hasLegacySettings {
+			return
 		}
 	}
-	if config.VirtualCores != nil {
-		d.Set(RootVirtualCores, int(*config.VirtualCores))
+	cpu := map[string]any{}
+	if config.Affinity != nil {
+		cpu[schemaAffinity] = terraformAffinity(*config.Affinity)
+	} else {
+		cpu[schemaAffinity] = defaultAffinity
 	}
+	if config.Cores != nil {
+		cpu[schemaCores] = int(*config.Cores)
+	} else {
+		cpu[schemaCores] = defaultCores
+	}
+	if config.Flags != nil {
+		if flags := terraformFlags(*config.Flags); flags != nil {
+			cpu[schemaFlags] = flags
+		}
+	}
+	if config.Limit != nil {
+		cpu[schemaLimit] = int(*config.Limit)
+	} else {
+		cpu[schemaLimit] = defaultLimit
+	}
+	if config.Numa != nil {
+		cpu[schemaNuma] = *config.Numa
+	} else {
+		cpu[schemaNuma] = defaultNuma
+	}
+	if config.Sockets != nil {
+		cpu[schemaSockets] = int(*config.Sockets)
+	} else {
+		cpu[schemaSockets] = defaultSockets
+	}
+	if config.Type != nil {
+		cpu[schemaType] = string(*config.Type)
+	} else {
+		cpu[schemaType] = defaultType
+	}
+	if config.Units != nil {
+		cpu[schemaUnits] = int(*config.Units)
+	} else {
+		cpu[schemaUnits] = defaultUnits
+	}
+	if config.VirtualCores != nil {
+		cpu[schemaVirtualCores] = int(*config.VirtualCores)
+	} else {
+		cpu[schemaVirtualCores] = defaultVirtualCores
+	}
+	d.Set(Root, []any{cpu})
+	terraformLegacyClear(d)
+}
+
+func terraformAffinity(affinity []uint) string {
+	slices.Sort(affinity)
+	var builder strings.Builder
+	rangeStart, rangeEnd := affinity[0], affinity[0]
+	for i := 1; i < len(affinity); i++ {
+		if affinity[i] == affinity[i-1] {
+			continue
+		}
+		if affinity[i] == rangeEnd+1 {
+			// Continue the range
+			rangeEnd = affinity[i]
+		} else {
+			// Close the current range and start a new range
+			if rangeStart == rangeEnd {
+				builder.WriteString(strconv.Itoa(int(rangeStart)) + ",")
+			} else {
+				builder.WriteString(strconv.Itoa(int(rangeStart)) + "-" + strconv.Itoa(int(rangeEnd)) + ",")
+			}
+			rangeStart, rangeEnd = affinity[i], affinity[i]
+		}
+	}
+	// Append the last range
+	if rangeStart == rangeEnd {
+		builder.WriteString(strconv.Itoa(int(rangeStart)))
+	} else {
+		builder.WriteString(strconv.Itoa(int(rangeStart)) + "-" + strconv.Itoa(int(rangeEnd)))
+	}
+	return builder.String()
+}
+
+func terraformFlag(flag *pveSDK.TriBool) string {
+	if flag == nil {
+		return ""
+	}
+	switch *flag {
+	case pveSDK.TriBoolTrue:
+		return flagOn
+	case pveSDK.TriBoolFalse:
+		return flagOff
+	default:
+		return ""
+	}
+}
+
+func terraformFlags(flags pveSDK.CpuFlags) []map[string]any {
+	tmpFlags := [12]string{"", "", "", "", "", "", "", "", "", "", "", ""}
+	tmpFlags[0] = terraformFlag(flags.AES)
+	tmpFlags[1] = terraformFlag(flags.AmdNoSSB)
+	tmpFlags[2] = terraformFlag(flags.AmdSSBD)
+	tmpFlags[3] = terraformFlag(flags.HvEvmcs)
+	tmpFlags[4] = terraformFlag(flags.HvTlbFlush)
+	tmpFlags[5] = terraformFlag(flags.Ibpb)
+	tmpFlags[6] = terraformFlag(flags.MdClear)
+	tmpFlags[7] = terraformFlag(flags.PCID)
+	tmpFlags[8] = terraformFlag(flags.Pdpe1GB)
+	tmpFlags[9] = terraformFlag(flags.SSBD)
+	tmpFlags[10] = terraformFlag(flags.SpecCtrl)
+	tmpFlags[11] = terraformFlag(flags.VirtSSBD)
+	for i := range tmpFlags {
+		if tmpFlags[i] != "" {
+			return []map[string]any{{
+				schemaFlagAes:        tmpFlags[0],
+				schemaFlagAmdNoSsb:   tmpFlags[1],
+				schemaFlagAmdSsbd:    tmpFlags[2],
+				schemaFlagHvEvmcs:    tmpFlags[3],
+				schemaFlagHvTlbflush: tmpFlags[4],
+				schemaFlagIbpb:       tmpFlags[5],
+				schemaFlagMdClear:    tmpFlags[6],
+				schemaFlagPcidev:     tmpFlags[7],
+				schemaFlagPbpe1gb:    tmpFlags[8],
+				schemaFlagSsbd:       tmpFlags[9],
+				schemaFlagSpecCtrl:   tmpFlags[10],
+				schemaFlagVirtSsbd:   tmpFlags[11]}}
+		}
+	}
+	return nil
 }

--- a/proxmox/Internal/resource/guest/qemu/cpu/terraform_legacy.go
+++ b/proxmox/Internal/resource/guest/qemu/cpu/terraform_legacy.go
@@ -1,0 +1,52 @@
+package cpu
+
+import (
+	pveSDK "github.com/Telmate/proxmox-api-go/proxmox"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func terraformLegacy(config pveSDK.QemuCPU, d *schema.ResourceData) bool {
+	var legacy bool
+	if _, ok := d.GetOk(RootLegacyCores); ok {
+		legacy = true
+	}
+	if _, ok := d.GetOk(RootLegacyCpuType); ok {
+		legacy = true
+	}
+	if _, ok := d.GetOk(RootLegacyNuma); ok {
+		legacy = true
+	}
+	if _, ok := d.GetOk(RootLegacySockets); ok {
+		legacy = true
+	}
+	if _, ok := d.GetOk(RootLegacyVirtualCores); ok {
+		legacy = true
+	}
+	if !legacy {
+		return false
+	}
+	if config.Cores != nil {
+		d.Set(RootLegacyCores, int(*config.Cores))
+	}
+	if config.Numa != nil {
+		d.Set(RootLegacyNuma, *config.Numa)
+	}
+	if config.Sockets != nil {
+		d.Set(RootLegacySockets, int(*config.Sockets))
+	}
+	if config.Type != nil {
+		d.Set(RootLegacyCpuType, string(*config.Type))
+	}
+	if config.VirtualCores != nil {
+		d.Set(RootLegacyVirtualCores, int(*config.VirtualCores))
+	}
+	return true
+}
+
+func terraformLegacyClear(d *schema.ResourceData) {
+	d.Set(RootLegacyCores, nil)
+	d.Set(RootLegacyCpuType, nil)
+	d.Set(RootLegacyNuma, nil)
+	d.Set(RootLegacySockets, nil)
+	d.Set(RootLegacyVirtualCores, nil)
+}

--- a/proxmox/resource_vm_qemu.go
+++ b/proxmox/resource_vm_qemu.go
@@ -267,16 +267,12 @@ func resourceVmQemu() *schema.Resource {
 				Optional: true,
 				Default:  0,
 			},
-			cpu.Root: cpu.SchemaType(schema.Schema{
-				ConflictsWith: []string{cpu.RootCpuType},
-				Deprecated:    "use '" + cpu.RootCpuType + "' instead"}),
-			cpu.RootCores: cpu.SchemaCores(),
-			cpu.RootCpuType: cpu.SchemaType(schema.Schema{
-				ConflictsWith: []string{cpu.Root},
-				Default:       "host"}),
-			cpu.RootNuma:         cpu.SchemaNuma(),
-			cpu.RootSockets:      cpu.SchemaSockets(),
-			cpu.RootVirtualCores: cpu.SchemaVirtualCores(),
+			cpu.Root:                   cpu.Schema(),
+			cpu.RootLegacyCores:        cpu.SchemaLegacyCores(),
+			cpu.RootLegacyCpuType:      cpu.SchemaLegacyType(),
+			cpu.RootLegacyNuma:         cpu.SchemaLegacyNuma(),
+			cpu.RootLegacySockets:      cpu.SchemaLegacySockets(),
+			cpu.RootLegacyVirtualCores: cpu.SchemaLegacyVirtualCores(),
 			"kvm": {
 				Type:     schema.TypeBool,
 				Optional: true,


### PR DESCRIPTION
Resolves #1149

Implements the CPU schema as discussed in #1149.
The minor change is that the way to unset a CPU flag is done by removing it from the Teraform config, this is due to how it diffs.