### PR TITLE
feat: add `ignore` option to `disk` & `disks`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/Telmate/terraform-provider-proxmox/v2
 go 1.21
 
 require (
-	github.com/Telmate/proxmox-api-go v0.0.0-20250503175408-7fbd372efd64
+	github.com/Telmate/proxmox-api-go v0.0.0-20250510212736-893482bceff7
 	github.com/google/uuid v1.6.0
 	github.com/hashicorp/go-cty v1.5.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.34.0

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,8 @@ github.com/Microsoft/go-winio v0.6.1 h1:9/kr64B9VUZrLm5YYwbGtUJnMgqWVOdUAXu6Migc
 github.com/Microsoft/go-winio v0.6.1/go.mod h1:LRdKpFKfdobln8UmuiYcKPot9D2v6svN5+sAH+4kjUM=
 github.com/ProtonMail/go-crypto v1.1.0-alpha.2-proton h1:HKz85FwoXx86kVtTvFke7rgHvq/HoloSUvW5semjFWs=
 github.com/ProtonMail/go-crypto v1.1.0-alpha.2-proton/go.mod h1:rA3QumHc/FZ8pAHreoekgiAbzpNsfQAosU5td4SnOrE=
-github.com/Telmate/proxmox-api-go v0.0.0-20250503175408-7fbd372efd64 h1:z/fY7p/uepmdCqC2v601n307ma424Or3eJfr85wmzSw=
-github.com/Telmate/proxmox-api-go v0.0.0-20250503175408-7fbd372efd64/go.mod h1:6qNnkqdMB+22ytC/5qGAIIqtdK9egN1b/Sqs9tB/i1Y=
+github.com/Telmate/proxmox-api-go v0.0.0-20250510212736-893482bceff7 h1:L1Rz3NUFvTbAn84mcWRfGWDDQP/w7uA3CB2k1J76m2k=
+github.com/Telmate/proxmox-api-go v0.0.0-20250510212736-893482bceff7/go.mod h1:6qNnkqdMB+22ytC/5qGAIIqtdK9egN1b/Sqs9tB/i1Y=
 github.com/agext/levenshtein v1.2.3 h1:YB2fHEn0UJagG8T1rrWknE3ZQzWM06O8AMAatNn7lmo=
 github.com/agext/levenshtein v1.2.3/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
 github.com/apparentlymart/go-textseg/v12 v12.0.0/go.mod h1:S/4uRK2UtaQttw1GenVJEynmyUenKwP++x/+DdGV/Ec=

--- a/proxmox/Internal/resource/guest/qemu/disk/schema.go
+++ b/proxmox/Internal/resource/guest/qemu/disk/schema.go
@@ -65,6 +65,7 @@ const (
 	enumCdRom     = "cdrom"
 	enumCloudInit = "cloudinit"
 	enumDisk      = "disk"
+	enumIgnore    = "ignore"
 
 	slotIDE    string = schemaIDE
 	slotSata   string = schemaSata
@@ -138,10 +139,10 @@ func SchemaDisk() *schema.Schema {
 							return diag.Errorf(errorMSG.String, k)
 						}
 						switch v {
-						case enumDisk, enumCdRom, enumCloudInit:
+						case enumDisk, enumCdRom, enumCloudInit, enumIgnore:
 							return nil
 						}
-						return diag.Errorf(schemaType + " must be one of '" + enumDisk + "', '" + enumCdRom + "', '" + enumCloudInit + "'")
+						return diag.Errorf(schemaType + " must be one of '" + enumDisk + "', '" + enumCdRom + "', '" + enumCloudInit + "', '" + enumIgnore + "'")
 					}},
 				schemaWorldWideName: subSchemaDiskWWN(),
 			}}}

--- a/proxmox/Internal/resource/guest/qemu/disk/schema.go
+++ b/proxmox/Internal/resource/guest/qemu/disk/schema.go
@@ -62,9 +62,9 @@ const (
 	pathScsi   string = RootDisks + ".0." + schemaScsi + ".0."
 	pathVirtIO string = RootDisks + ".0." + schemaVirtIO + ".0."
 
-	enumCdRom     string = "cdrom"
-	enumCloudInit string = "cloudinit"
-	enumDisk      string = "disk"
+	enumCdRom     = "cdrom"
+	enumCloudInit = "cloudinit"
+	enumDisk      = "disk"
 
 	slotIDE    string = schemaIDE
 	slotSata   string = schemaSata
@@ -131,14 +131,14 @@ func SchemaDisk() *schema.Schema {
 				schemaType: {
 					Type:     schema.TypeString,
 					Optional: true,
-					Default:  schemaDisk,
+					Default:  enumDisk,
 					ValidateDiagFunc: func(i interface{}, k cty.Path) diag.Diagnostics {
 						v, ok := i.(string)
 						if !ok {
 							return diag.Errorf(errorMSG.String, k)
 						}
 						switch v {
-						case schemaDisk, schemaCdRom, schemaCloudInit:
+						case enumDisk, enumCdRom, enumCloudInit:
 							return nil
 						}
 						return diag.Errorf(schemaType + " must be one of '" + enumDisk + "', '" + enumCdRom + "', '" + enumCloudInit + "'")

--- a/proxmox/Internal/resource/guest/qemu/disk/sdk.go
+++ b/proxmox/Internal/resource/guest/qemu/disk/sdk.go
@@ -10,8 +10,8 @@ import (
 )
 
 func SDK(d *schema.ResourceData) (*pveAPI.QemuStorages, diag.Diagnostics) {
-	diags := make(diag.Diagnostics, 0)
 	if v, ok := d.GetOk(RootDisk); ok {
+		diags := make(diag.Diagnostics, 0)
 		storages := &pveAPI.QemuStorages{
 			Ide:    sdk_Disks_QemuIdeDisksDefault(),
 			Sata:   sdk_Disks_QemuSataDisksDefault(),
@@ -45,14 +45,14 @@ func SDK(d *schema.ResourceData) (*pveAPI.QemuStorages, diag.Diagnostics) {
 				Ide:    sdk_Disks_QemuIdeDisks(schemaStorages),
 				Sata:   sdk_Disks_QemuSataDisks(schemaStorages),
 				Scsi:   sdk_Disks_QemuScsiDisks(schemaStorages),
-				VirtIO: sdk_Disks_QemuVirtIODisks(schemaStorages)}, diags
+				VirtIO: sdk_Disks_QemuVirtIODisks(schemaStorages)}, nil
 		}
 	}
 	return &pveAPI.QemuStorages{
 		Ide:    sdk_Disks_QemuIdeDisksDefault(),
 		Sata:   sdk_Disks_QemuSataDisksDefault(),
 		Scsi:   sdk_Disks_QemuScsiDisksDefault(),
-		VirtIO: sdk_Disks_QemuVirtIODisksDefault()}, diags
+		VirtIO: sdk_Disks_QemuVirtIODisksDefault()}, nil
 }
 
 func sdkIsoFile(iso string) *pveAPI.IsoFile {

--- a/proxmox/Internal/resource/guest/qemu/disk/sdk.go
+++ b/proxmox/Internal/resource/guest/qemu/disk/sdk.go
@@ -10,71 +10,13 @@ import (
 )
 
 func SDK(d *schema.ResourceData) (*pveAPI.QemuStorages, diag.Diagnostics) {
-	storages := pveAPI.QemuStorages{
-		Ide: &pveAPI.QemuIdeDisks{
-			Disk_0: &pveAPI.QemuIdeStorage{},
-			Disk_1: &pveAPI.QemuIdeStorage{},
-			Disk_2: &pveAPI.QemuIdeStorage{},
-			Disk_3: &pveAPI.QemuIdeStorage{}},
-		Sata: &pveAPI.QemuSataDisks{
-			Disk_0: &pveAPI.QemuSataStorage{},
-			Disk_1: &pveAPI.QemuSataStorage{},
-			Disk_2: &pveAPI.QemuSataStorage{},
-			Disk_3: &pveAPI.QemuSataStorage{},
-			Disk_4: &pveAPI.QemuSataStorage{},
-			Disk_5: &pveAPI.QemuSataStorage{}},
-		Scsi: &pveAPI.QemuScsiDisks{
-			Disk_0:  &pveAPI.QemuScsiStorage{},
-			Disk_1:  &pveAPI.QemuScsiStorage{},
-			Disk_2:  &pveAPI.QemuScsiStorage{},
-			Disk_3:  &pveAPI.QemuScsiStorage{},
-			Disk_4:  &pveAPI.QemuScsiStorage{},
-			Disk_5:  &pveAPI.QemuScsiStorage{},
-			Disk_6:  &pveAPI.QemuScsiStorage{},
-			Disk_7:  &pveAPI.QemuScsiStorage{},
-			Disk_8:  &pveAPI.QemuScsiStorage{},
-			Disk_9:  &pveAPI.QemuScsiStorage{},
-			Disk_10: &pveAPI.QemuScsiStorage{},
-			Disk_11: &pveAPI.QemuScsiStorage{},
-			Disk_12: &pveAPI.QemuScsiStorage{},
-			Disk_13: &pveAPI.QemuScsiStorage{},
-			Disk_14: &pveAPI.QemuScsiStorage{},
-			Disk_15: &pveAPI.QemuScsiStorage{},
-			Disk_16: &pveAPI.QemuScsiStorage{},
-			Disk_17: &pveAPI.QemuScsiStorage{},
-			Disk_18: &pveAPI.QemuScsiStorage{},
-			Disk_19: &pveAPI.QemuScsiStorage{},
-			Disk_20: &pveAPI.QemuScsiStorage{},
-			Disk_21: &pveAPI.QemuScsiStorage{},
-			Disk_22: &pveAPI.QemuScsiStorage{},
-			Disk_23: &pveAPI.QemuScsiStorage{},
-			Disk_24: &pveAPI.QemuScsiStorage{},
-			Disk_25: &pveAPI.QemuScsiStorage{},
-			Disk_26: &pveAPI.QemuScsiStorage{},
-			Disk_27: &pveAPI.QemuScsiStorage{},
-			Disk_28: &pveAPI.QemuScsiStorage{},
-			Disk_29: &pveAPI.QemuScsiStorage{},
-			Disk_30: &pveAPI.QemuScsiStorage{}},
-		VirtIO: &pveAPI.QemuVirtIODisks{
-			Disk_0:  &pveAPI.QemuVirtIOStorage{},
-			Disk_1:  &pveAPI.QemuVirtIOStorage{},
-			Disk_2:  &pveAPI.QemuVirtIOStorage{},
-			Disk_3:  &pveAPI.QemuVirtIOStorage{},
-			Disk_4:  &pveAPI.QemuVirtIOStorage{},
-			Disk_5:  &pveAPI.QemuVirtIOStorage{},
-			Disk_6:  &pveAPI.QemuVirtIOStorage{},
-			Disk_7:  &pveAPI.QemuVirtIOStorage{},
-			Disk_8:  &pveAPI.QemuVirtIOStorage{},
-			Disk_9:  &pveAPI.QemuVirtIOStorage{},
-			Disk_10: &pveAPI.QemuVirtIOStorage{},
-			Disk_11: &pveAPI.QemuVirtIOStorage{},
-			Disk_12: &pveAPI.QemuVirtIOStorage{},
-			Disk_13: &pveAPI.QemuVirtIOStorage{},
-			Disk_14: &pveAPI.QemuVirtIOStorage{},
-			Disk_15: &pveAPI.QemuVirtIOStorage{}},
-	}
 	diags := make(diag.Diagnostics, 0)
 	if v, ok := d.GetOk(RootDisk); ok {
+		storages := &pveAPI.QemuStorages{
+			Ide:    sdk_Disks_QemuIdeDisksDefault(),
+			Sata:   sdk_Disks_QemuSataDisksDefault(),
+			Scsi:   sdk_Disks_QemuScsiDisksDefault(),
+			VirtIO: sdk_Disks_QemuVirtIODisksDefault()}
 		for _, disk := range v.([]interface{}) {
 			tmpDisk := disk.(map[string]interface{})
 			slot := tmpDisk[schemaSlot].(string)
@@ -95,19 +37,22 @@ func SDK(d *schema.ResourceData) (*pveAPI.QemuStorages, diag.Diagnostics) {
 				diags = append(diags, sdk_Disk_QemuIdeDisks(storages.Ide, slot[3:], tmpDisk)...)
 			}
 		}
-	} else {
-		schemaItem := d.Get(RootDisks).([]interface{})
-		if len(schemaItem) == 1 {
-			schemaStorages, ok := schemaItem[0].(map[string]interface{})
-			if ok {
-				sdk_Disks_QemuIdeDisks(storages.Ide, schemaStorages)
-				sdk_Disks_QemuSataDisks(storages.Sata, schemaStorages)
-				sdk_Disks_QemuScsiDisks(storages.Scsi, schemaStorages)
-				sdk_Disks_QemuVirtIODisks(storages.VirtIO, schemaStorages)
-			}
+		return storages, diags
+	} else if v, ok := d.GetOk(RootDisks); ok {
+		if vv, ok := v.([]any); ok && len(vv) == 1 && vv[0] != nil {
+			schemaStorages := vv[0].(map[string]any)
+			return &pveAPI.QemuStorages{
+				Ide:    sdk_Disks_QemuIdeDisks(schemaStorages),
+				Sata:   sdk_Disks_QemuSataDisks(schemaStorages),
+				Scsi:   sdk_Disks_QemuScsiDisks(schemaStorages),
+				VirtIO: sdk_Disks_QemuVirtIODisks(schemaStorages)}, diags
 		}
 	}
-	return &storages, diags
+	return &pveAPI.QemuStorages{
+		Ide:    sdk_Disks_QemuIdeDisksDefault(),
+		Sata:   sdk_Disks_QemuSataDisksDefault(),
+		Scsi:   sdk_Disks_QemuScsiDisksDefault(),
+		VirtIO: sdk_Disks_QemuVirtIODisksDefault()}, diags
 }
 
 func sdkIsoFile(iso string) *pveAPI.IsoFile {

--- a/proxmox/Internal/resource/guest/qemu/disk/sdk_disk.go
+++ b/proxmox/Internal/resource/guest/qemu/disk/sdk_disk.go
@@ -73,7 +73,7 @@ func sdk_Disk_QemuIdeStorage(ide *pveAPI.QemuIdeStorage, schema map[string]inter
 	switch schema[schemaType].(string) {
 	case enumDisk:
 		if schema[schemaIOthread].(bool) {
-			diags = append(diags, warningDisk(slot, schemaIOthread, schemaSlot, slot, ""))
+			diags = diag.Diagnostics{warningDisk(slot, schemaIOthread, schemaSlot, slot, "")}
 		}
 		if schema[schemaISO].(string) != "" {
 			diags = append(diags, warningDisk(slot, schemaISO, schemaSlot, slot, ""))
@@ -149,7 +149,7 @@ func sdk_Disk_QemuSataStorage(sata *pveAPI.QemuSataStorage, schema map[string]in
 	switch schema[schemaType].(string) {
 	case enumDisk:
 		if schema[schemaIOthread].(bool) {
-			diags = append(diags, warningDisk(slot, schemaIOthread, schemaSlot, slot, ""))
+			diags = diag.Diagnostics{warningDisk(slot, schemaIOthread, schemaSlot, slot, "")}
 		}
 		if schema[schemaISO].(string) != "" {
 			diags = append(diags, warningDisk(slot, schemaISO, schemaSlot, slot, ""))
@@ -275,7 +275,7 @@ func sdk_Disk_QemuScsiStorage(scsi *pveAPI.QemuScsiStorage, schema map[string]in
 	switch schema[schemaType].(string) {
 	case enumDisk:
 		if schema[schemaISO].(string) != "" {
-			diags = append(diags, warningDisk(slot, schemaISO, schemaSlot, slot, ""))
+			diags = diag.Diagnostics{warningDisk(slot, schemaISO, schemaSlot, slot, "")}
 		}
 		if schema[schemaPassthrough].(bool) { // passthrough disk
 			scsi.Passthrough = &pveAPI.QemuScsiPassthrough{
@@ -331,7 +331,7 @@ func sdk_Disk_QemuVirtIOStorage(virtio *pveAPI.QemuVirtIOStorage, schema map[str
 	switch schema[schemaType].(string) {
 	case enumDisk:
 		if schema[schemaEmulateSSD].(bool) {
-			diags = append(diags, warningDisk(slot, schemaEmulateSSD, schemaSlot, slot, ""))
+			diags = diag.Diagnostics{warningDisk(slot, schemaEmulateSSD, schemaSlot, slot, "")}
 		}
 		if schema[schemaISO].(string) != "" {
 			diags = append(diags, warningDisk(slot, schemaISO, schemaSlot, slot, ""))

--- a/proxmox/Internal/resource/guest/qemu/disk/sdk_disk.go
+++ b/proxmox/Internal/resource/guest/qemu/disk/sdk_disk.go
@@ -8,7 +8,7 @@ import (
 func sdk_Disk_QemuCdRom(slot string, schema map[string]interface{}) (*pveAPI.QemuCdRom, diag.Diagnostics) {
 	diags := warningsCdromAndCloudinit(slot, schemaCdRom, schema)
 	if schema[schemaStorage].(string) != "" {
-		diags = append(diags, warningDisk(slot, schemaStorage, schemaType, schemaCdRom, ""))
+		diags = append(diags, warningDisk(slot, schemaStorage, schemaType, enumCdRom, ""))
 	}
 	if schema[schemaPassthrough].(bool) {
 		return &pveAPI.QemuCdRom{Passthrough: true}, diags
@@ -19,10 +19,10 @@ func sdk_Disk_QemuCdRom(slot string, schema map[string]interface{}) (*pveAPI.Qem
 func sdk_Disk_QemuCloudInit(slot string, schema map[string]interface{}) (*pveAPI.QemuCloudInitDisk, diag.Diagnostics) {
 	diags := warningsCdromAndCloudinit(slot, schemaCloudInit, schema)
 	if schema[schemaISO].(string) != "" {
-		diags = append(diags, warningDisk(slot, schemaISO, schemaType, schemaCloudInit, ""))
+		diags = append(diags, warningDisk(slot, schemaISO, schemaType, enumCloudInit, ""))
 	}
 	if schema[schemaPassthrough].(bool) {
-		diags = append(diags, warningDisk(slot, schemaPassthrough, schemaType, schemaCloudInit, ""))
+		diags = append(diags, warningDisk(slot, schemaPassthrough, schemaType, enumCloudInit, ""))
 	}
 	return &pveAPI.QemuCloudInitDisk{
 		Format:  pveAPI.QemuDiskFormat_Raw,
@@ -71,7 +71,7 @@ func sdk_Disk_QemuIdeStorage(ide *pveAPI.QemuIdeStorage, schema map[string]inter
 		return errorDiskSlotDuplicate(slot)
 	}
 	switch schema[schemaType].(string) {
-	case schemaDisk:
+	case enumDisk:
 		if schema[schemaIOthread].(bool) {
 			diags = append(diags, warningDisk(slot, schemaIOthread, schemaSlot, slot, ""))
 		}
@@ -112,12 +112,12 @@ func sdk_Disk_QemuIdeStorage(ide *pveAPI.QemuIdeStorage, schema map[string]inter
 			ide.Disk.Storage, tmpDiags = sdk_Disk_Storage(slot, schema)
 			diags = append(diags, tmpDiags...)
 			if schema[schemaDiskFile].(string) != "" {
-				diags = append(diags, warningDisk(slot, schemaDiskFile, schemaType, schemaDisk, ""))
+				diags = append(diags, warningDisk(slot, schemaDiskFile, schemaType, enumDisk, ""))
 			}
 		}
-	case schemaCdRom:
+	case enumCdRom:
 		ide.CdRom, diags = sdk_Disk_QemuCdRom(slot, schema)
-	case schemaCloudInit:
+	case enumCloudInit:
 		ide.CloudInit, diags = sdk_Disk_QemuCloudInit(slot, schema)
 	}
 	return
@@ -147,7 +147,7 @@ func sdk_Disk_QemuSataStorage(sata *pveAPI.QemuSataStorage, schema map[string]in
 		return errorDiskSlotDuplicate(slot)
 	}
 	switch schema[schemaType].(string) {
-	case schemaDisk:
+	case enumDisk:
 		if schema[schemaIOthread].(bool) {
 			diags = append(diags, warningDisk(slot, schemaIOthread, schemaSlot, slot, ""))
 		}
@@ -188,12 +188,12 @@ func sdk_Disk_QemuSataStorage(sata *pveAPI.QemuSataStorage, schema map[string]in
 			sata.Disk.Storage, tmpDiags = sdk_Disk_Storage(slot, schema)
 			diags = append(diags, tmpDiags...)
 			if schema[schemaDiskFile].(string) != "" {
-				diags = append(diags, warningDisk(slot, schemaDiskFile, schemaType, schemaDisk, ""))
+				diags = append(diags, warningDisk(slot, schemaDiskFile, schemaType, enumDisk, ""))
 			}
 		}
-	case schemaCdRom:
+	case enumCdRom:
 		sata.CdRom, diags = sdk_Disk_QemuCdRom(slot, schema)
-	case schemaCloudInit:
+	case enumCloudInit:
 		sata.CloudInit, diags = sdk_Disk_QemuCloudInit(slot, schema)
 	}
 	return
@@ -273,7 +273,7 @@ func sdk_Disk_QemuScsiStorage(scsi *pveAPI.QemuScsiStorage, schema map[string]in
 		return errorDiskSlotDuplicate(slot)
 	}
 	switch schema[schemaType].(string) {
-	case schemaDisk:
+	case enumDisk:
 		if schema[schemaISO].(string) != "" {
 			diags = append(diags, warningDisk(slot, schemaISO, schemaSlot, slot, ""))
 		}
@@ -312,12 +312,12 @@ func sdk_Disk_QemuScsiStorage(scsi *pveAPI.QemuScsiStorage, schema map[string]in
 			scsi.Disk.Storage, tmpDiags = sdk_Disk_Storage(slot, schema)
 			diags = append(diags, tmpDiags...)
 			if schema[schemaDiskFile].(string) != "" {
-				diags = append(diags, warningDisk(slot, schemaDiskFile, schemaType, schemaDisk, ""))
+				diags = append(diags, warningDisk(slot, schemaDiskFile, schemaType, enumDisk, ""))
 			}
 		}
-	case schemaCdRom:
+	case enumCdRom:
 		scsi.CdRom, diags = sdk_Disk_QemuCdRom(slot, schema)
-	case schemaCloudInit:
+	case enumCloudInit:
 		scsi.CloudInit, diags = sdk_Disk_QemuCloudInit(slot, schema)
 	}
 	return
@@ -329,7 +329,7 @@ func sdk_Disk_QemuVirtIOStorage(virtio *pveAPI.QemuVirtIOStorage, schema map[str
 		return errorDiskSlotDuplicate(slot)
 	}
 	switch schema[schemaType].(string) {
-	case schemaDisk:
+	case enumDisk:
 		if schema[schemaEmulateSSD].(bool) {
 			diags = append(diags, warningDisk(slot, schemaEmulateSSD, schemaSlot, slot, ""))
 		}
@@ -369,12 +369,12 @@ func sdk_Disk_QemuVirtIOStorage(virtio *pveAPI.QemuVirtIOStorage, schema map[str
 			virtio.Disk.Storage, tmpDiags = sdk_Disk_Storage(slot, schema)
 			diags = append(diags, tmpDiags...)
 			if schema[schemaDiskFile].(string) != "" {
-				diags = append(diags, warningDisk(slot, schemaDiskFile, schemaType, schemaDisk, ""))
+				diags = append(diags, warningDisk(slot, schemaDiskFile, schemaType, enumDisk, ""))
 			}
 		}
-	case schemaCdRom:
+	case enumCdRom:
 		virtio.CdRom, diags = sdk_Disk_QemuCdRom(slot, schema)
-	case schemaCloudInit:
+	case enumCloudInit:
 		return diag.Diagnostics{{
 			Severity: diag.Error,
 			Summary:  schemaVirtIO + " can't have " + schemaCloudInit + " disk"}}

--- a/proxmox/Internal/resource/guest/qemu/disk/sdk_disk.go
+++ b/proxmox/Internal/resource/guest/qemu/disk/sdk_disk.go
@@ -67,9 +67,10 @@ func sdk_Disk_QemuIdeDisks(ide *pveAPI.QemuIdeDisks, id string, schema map[strin
 
 func sdk_Disk_QemuIdeStorage(ide *pveAPI.QemuIdeStorage, schema map[string]interface{}, id string) (diags diag.Diagnostics) {
 	slot := schemaIDE + id
-	if ide.CdRom != nil || ide.Disk != nil || ide.Passthrough != nil || ide.CloudInit != nil {
+	if !ide.Delete {
 		return errorDiskSlotDuplicate(slot)
 	}
+	ide.Delete = false
 	switch schema[schemaType].(string) {
 	case enumDisk:
 		if schema[schemaIOthread].(bool) {
@@ -119,6 +120,8 @@ func sdk_Disk_QemuIdeStorage(ide *pveAPI.QemuIdeStorage, schema map[string]inter
 		ide.CdRom, diags = sdk_Disk_QemuCdRom(slot, schema)
 	case enumCloudInit:
 		ide.CloudInit, diags = sdk_Disk_QemuCloudInit(slot, schema)
+	case enumIgnore:
+		return WarningIgnore(slot, schema)
 	}
 	return
 }
@@ -143,9 +146,10 @@ func sdk_Disk_QemuSataDisks(sata *pveAPI.QemuSataDisks, id string, schema map[st
 
 func sdk_Disk_QemuSataStorage(sata *pveAPI.QemuSataStorage, schema map[string]interface{}, id string) (diags diag.Diagnostics) {
 	slot := schemaSata + id
-	if sata.CdRom != nil || sata.Disk != nil || sata.Passthrough != nil || sata.CloudInit != nil {
+	if !sata.Delete {
 		return errorDiskSlotDuplicate(slot)
 	}
+	sata.Delete = false
 	switch schema[schemaType].(string) {
 	case enumDisk:
 		if schema[schemaIOthread].(bool) {
@@ -195,6 +199,8 @@ func sdk_Disk_QemuSataStorage(sata *pveAPI.QemuSataStorage, schema map[string]in
 		sata.CdRom, diags = sdk_Disk_QemuCdRom(slot, schema)
 	case enumCloudInit:
 		sata.CloudInit, diags = sdk_Disk_QemuCloudInit(slot, schema)
+	case enumIgnore:
+		return WarningIgnore(slot, schema)
 	}
 	return
 }
@@ -269,9 +275,10 @@ func sdk_Disk_QemuScsiDisks(scsi *pveAPI.QemuScsiDisks, id string, schema map[st
 
 func sdk_Disk_QemuScsiStorage(scsi *pveAPI.QemuScsiStorage, schema map[string]interface{}, id string) (diags diag.Diagnostics) {
 	slot := schemaScsi + id
-	if scsi.CdRom != nil || scsi.Disk != nil || scsi.Passthrough != nil || scsi.CloudInit != nil {
+	if !scsi.Delete {
 		return errorDiskSlotDuplicate(slot)
 	}
+	scsi.Delete = false
 	switch schema[schemaType].(string) {
 	case enumDisk:
 		if schema[schemaISO].(string) != "" {
@@ -319,15 +326,18 @@ func sdk_Disk_QemuScsiStorage(scsi *pveAPI.QemuScsiStorage, schema map[string]in
 		scsi.CdRom, diags = sdk_Disk_QemuCdRom(slot, schema)
 	case enumCloudInit:
 		scsi.CloudInit, diags = sdk_Disk_QemuCloudInit(slot, schema)
+	case enumIgnore:
+		return WarningIgnore(slot, schema)
 	}
 	return
 }
 
 func sdk_Disk_QemuVirtIOStorage(virtio *pveAPI.QemuVirtIOStorage, schema map[string]interface{}, id string) (diags diag.Diagnostics) {
 	slot := schemaVirtIO + id
-	if virtio.CdRom != nil || virtio.Disk != nil || virtio.Passthrough != nil || virtio.CloudInit != nil {
+	if !virtio.Delete {
 		return errorDiskSlotDuplicate(slot)
 	}
+	virtio.Delete = false
 	switch schema[schemaType].(string) {
 	case enumDisk:
 		if schema[schemaEmulateSSD].(bool) {
@@ -378,6 +388,8 @@ func sdk_Disk_QemuVirtIOStorage(virtio *pveAPI.QemuVirtIOStorage, schema map[str
 		return diag.Diagnostics{{
 			Severity: diag.Error,
 			Summary:  schemaVirtIO + " can't have " + schemaCloudInit + " disk"}}
+	case enumIgnore:
+		return WarningIgnore(slot, schema)
 	}
 	return
 }

--- a/proxmox/Internal/resource/guest/qemu/disk/terraform.go
+++ b/proxmox/Internal/resource/guest/qemu/disk/terraform.go
@@ -7,8 +7,8 @@ import (
 
 // Requires the caller to check for nil
 func Terraform_Unsafe(d *schema.ResourceData, config *pveAPI.QemuStorages, ciDisk *bool) {
-	if _, ok := d.GetOk(RootDisk); ok {
-		d.Set(RootDisk, terraform_Disk_QemuDisks(*config, ciDisk))
+	if v, ok := d.GetOk(RootDisk); ok {
+		d.Set(RootDisk, terraform_Disk_QemuDisks(*config, ciDisk, createDiskMap(v.([]any))))
 	} else {
 		d.Set(RootDisks, terraform_Disks_QemuDisks(*config, ciDisk, d))
 	}

--- a/proxmox/Internal/resource/guest/qemu/disk/terraform.go
+++ b/proxmox/Internal/resource/guest/qemu/disk/terraform.go
@@ -10,7 +10,7 @@ func Terraform_Unsafe(d *schema.ResourceData, config *pveAPI.QemuStorages, ciDis
 	if _, ok := d.GetOk(RootDisk); ok {
 		d.Set(RootDisk, terraform_Disk_QemuDisks(*config, ciDisk))
 	} else {
-		d.Set(RootDisks, terraform_Disks_QemuDisks(*config, ciDisk))
+		d.Set(RootDisks, terraform_Disks_QemuDisks(*config, ciDisk, d))
 	}
 }
 

--- a/proxmox/Internal/resource/guest/qemu/disk/terraform_disk.go
+++ b/proxmox/Internal/resource/guest/qemu/disk/terraform_disk.go
@@ -3,34 +3,33 @@ package disk
 import pveAPI "github.com/Telmate/proxmox-api-go/proxmox"
 
 // nil check is done by the caller
-func terraform_Disk_QemuCdRom_unsafe(config *pveAPI.QemuCdRom) map[string]interface{} {
-	return map[string]interface{}{
-		schemaBackup:      true, // always true to avoid diff
-		schemaISO:         terraformIsoFile(config.Iso),
-		schemaPassthrough: config.Passthrough,
-		schemaType:        schemaCdRom}
+func terraform_Disk_QemuCdRom_unsafe(config *pveAPI.QemuCdRom, schema map[string]any) {
+	schema[schemaBackup] = true // always true to avoid diff
+	schema[schemaISO] = terraformIsoFile(config.Iso)
+	schema[schemaCdRom] = true
+	schema[schemaPassthrough] = config.Passthrough
+	schema[schemaType] = enumCdRom
 }
 
 // nil check is done by the caller
-func terraform_Disk_QemuCloudInit_unsafe(config *pveAPI.QemuCloudInitDisk) map[string]interface{} {
-	return map[string]interface{}{
-		schemaBackup:  true, // always true to avoid diff
-		schemaStorage: config.Storage,
-		schemaType:    schemaCloudInit}
+func terraform_Disk_QemuCloudInit_unsafe(config *pveAPI.QemuCloudInitDisk, schema map[string]any) {
+	schema[schemaBackup] = true // always true to avoid diff
+	schema[schemaStorage] = config.Storage
+	schema[schemaType] = enumCloudInit
 }
 
-func terraform_Disk_QemuDisks(config pveAPI.QemuStorages, ciDisk *bool) []map[string]interface{} {
+func terraform_Disk_QemuDisks(config pveAPI.QemuStorages, ciDisk *bool, schema map[string]map[string]any) []map[string]any {
 	disks := make([]map[string]interface{}, 0, 56) // max is sum of underlying arrays
-	if ideDisks := terraform_Disk_QemuIdeDisks(config.Ide, ciDisk); ideDisks != nil {
+	if ideDisks := terraform_Disk_QemuIdeDisks(config.Ide, ciDisk, schema); ideDisks != nil {
 		disks = append(disks, ideDisks...)
 	}
-	if sataDisks := terraform_Disk_QemuSataDisks(config.Sata, ciDisk); sataDisks != nil {
+	if sataDisks := terraform_Disk_QemuSataDisks(config.Sata, ciDisk, schema); sataDisks != nil {
 		disks = append(disks, sataDisks...)
 	}
-	if scsiDisks := terraform_Disk_QemuScsiDisks(config.Scsi, ciDisk); scsiDisks != nil {
+	if scsiDisks := terraform_Disk_QemuScsiDisks(config.Scsi, ciDisk, schema); scsiDisks != nil {
 		disks = append(disks, scsiDisks...)
 	}
-	if virtioDisks := terraform_Disk_QemuVirtIODisks(config.VirtIO); virtioDisks != nil {
+	if virtioDisks := terraform_Disk_QemuVirtIODisks(config.VirtIO, schema); virtioDisks != nil {
 		disks = append(disks, virtioDisks...)
 	}
 	if len(disks) == 0 {
@@ -39,18 +38,18 @@ func terraform_Disk_QemuDisks(config pveAPI.QemuStorages, ciDisk *bool) []map[st
 	return disks
 }
 
-func terraform_Disk_QemuIdeDisks(config *pveAPI.QemuIdeDisks, ciDisk *bool) []map[string]interface{} {
+func terraform_Disk_QemuIdeDisks(config *pveAPI.QemuIdeDisks, ciDisk *bool, schema map[string]map[string]any) []map[string]any {
 	if config == nil {
-		return nil
+		config = &pveAPI.QemuIdeDisks{}
 	}
 	disks := make([]map[string]interface{}, 0, 3)
-	if disk := terraform_Disk_QemuIdeStorage(config.Disk_0, schemaIDE+"0", ciDisk); disk != nil {
+	if disk := terraform_Disk_QemuIdeStorage(config.Disk_0, ciDisk, schema[schemaIDE+"0"]); disk != nil {
 		disks = append(disks, disk)
 	}
-	if disk := terraform_Disk_QemuIdeStorage(config.Disk_1, schemaIDE+"1", ciDisk); disk != nil {
+	if disk := terraform_Disk_QemuIdeStorage(config.Disk_1, ciDisk, schema[schemaIDE+"1"]); disk != nil {
 		disks = append(disks, disk)
 	}
-	if disk := terraform_Disk_QemuIdeStorage(config.Disk_2, schemaIDE+"2", ciDisk); disk != nil {
+	if disk := terraform_Disk_QemuIdeStorage(config.Disk_2, ciDisk, schema[schemaIDE+"2"]); disk != nil {
 		disks = append(disks, disk)
 	}
 	if len(disks) == 0 {
@@ -59,76 +58,76 @@ func terraform_Disk_QemuIdeDisks(config *pveAPI.QemuIdeDisks, ciDisk *bool) []ma
 	return disks
 }
 
-func terraform_Disk_QemuIdeStorage(config *pveAPI.QemuIdeStorage, slot string, ciDisk *bool) (settings map[string]interface{}) {
+func terraform_Disk_QemuIdeStorage(config *pveAPI.QemuIdeStorage, ciDisk *bool, schema map[string]any) map[string]any {
+	if schema != nil && schema[schemaType] == enumIgnore {
+		return schema
+	}
 	if config == nil {
 		return nil
 	}
 	if config.Disk != nil {
-		settings = map[string]interface{}{
-			schemaAsyncIO:       string(config.Disk.AsyncIO),
-			schemaBackup:        config.Disk.Backup,
-			schemaCache:         string(config.Disk.Cache),
-			schemaDiscard:       config.Disk.Discard,
-			schemaEmulateSSD:    config.Disk.EmulateSSD,
-			schemaFormat:        string(config.Disk.Format),
-			schemaID:            int(config.Disk.Id),
-			schemaLinkedDiskId:  terraformLinkedCloneId(config.Disk.LinkedDiskId),
-			schemaReplicate:     config.Disk.Replicate,
-			schemaSerial:        string(config.Disk.Serial),
-			schemaSize:          convert_KibibytesToString(int64(config.Disk.SizeInKibibytes)),
-			schemaStorage:       string(config.Disk.Storage),
-			schemaType:          schemaDisk,
-			schemaWorldWideName: string(config.Disk.WorldWideName)}
-		terraformQemuDiskBandwidth(settings, config.Disk.Bandwidth)
+		schema[schemaAsyncIO] = string(config.Disk.AsyncIO)
+		schema[schemaBackup] = config.Disk.Backup
+		schema[schemaCache] = string(config.Disk.Cache)
+		schema[schemaDiscard] = config.Disk.Discard
+		schema[schemaEmulateSSD] = config.Disk.EmulateSSD
+		schema[schemaFormat] = string(config.Disk.Format)
+		schema[schemaID] = int(config.Disk.Id)
+		schema[schemaLinkedDiskId] = terraformLinkedCloneId(config.Disk.LinkedDiskId)
+		schema[schemaReplicate] = config.Disk.Replicate
+		schema[schemaSerial] = string(config.Disk.Serial)
+		schema[schemaSize] = convert_KibibytesToString(int64(config.Disk.SizeInKibibytes))
+		schema[schemaStorage] = string(config.Disk.Storage)
+		schema[schemaType] = schemaDisk
+		schema[schemaWorldWideName] = string(config.Disk.WorldWideName)
+		terraformQemuDiskBandwidth(schema, config.Disk.Bandwidth)
 	}
 	if config.Passthrough != nil {
-		settings = map[string]interface{}{
-			schemaAsyncIO:       string(config.Disk.AsyncIO),
-			schemaBackup:        config.Disk.Backup,
-			schemaCache:         string(config.Disk.Cache),
-			schemaDiscard:       config.Disk.Discard,
-			schemaEmulateSSD:    config.Disk.EmulateSSD,
-			schemaFile:          config.Passthrough.File,
-			schemaPassthrough:   true,
-			schemaReplicate:     config.Disk.Replicate,
-			schemaSerial:        string(config.Disk.Serial),
-			schemaSize:          convert_KibibytesToString(int64(config.Disk.SizeInKibibytes)),
-			schemaType:          schemaDisk,
-			schemaWorldWideName: string(config.Disk.WorldWideName)}
-		terraformQemuDiskBandwidth(settings, config.Passthrough.Bandwidth)
+		schema[schemaAsyncIO] = string(config.Disk.AsyncIO)
+		schema[schemaBackup] = config.Disk.Backup
+		schema[schemaCache] = string(config.Disk.Cache)
+		schema[schemaDiscard] = config.Disk.Discard
+		schema[schemaEmulateSSD] = config.Disk.EmulateSSD
+		schema[schemaFile] = config.Passthrough.File
+		schema[schemaPassthrough] = true
+		schema[schemaReplicate] = config.Disk.Replicate
+		schema[schemaSerial] = string(config.Disk.Serial)
+		schema[schemaSize] = convert_KibibytesToString(int64(config.Disk.SizeInKibibytes))
+		schema[schemaType] = schemaDisk
+		schema[schemaWorldWideName] = string(config.Disk.WorldWideName)
+		terraformQemuDiskBandwidth(schema, config.Passthrough.Bandwidth)
 	}
 	if config.CdRom != nil {
-		settings = terraform_Disk_QemuCdRom_unsafe(config.CdRom)
+		terraform_Disk_QemuCdRom_unsafe(config.CdRom, schema)
 	}
 	if config.CloudInit != nil {
 		*ciDisk = true
-		settings = terraform_Disk_QemuCloudInit_unsafe(config.CloudInit)
+		terraform_Disk_QemuCloudInit_unsafe(config.CloudInit, schema)
 	}
-	settings[schemaSlot] = slot
-	return settings
+	return schema
 }
 
-func terraform_Disk_QemuSataDisks(config *pveAPI.QemuSataDisks, ciDisk *bool) []map[string]interface{} {
+func terraform_Disk_QemuSataDisks(config *pveAPI.QemuSataDisks, ciDisk *bool, schema map[string]map[string]any) []map[string]any {
 	if config == nil {
-		return nil
+		config = &pveAPI.QemuSataDisks{}
 	}
 	disks := make([]map[string]interface{}, 0, 6)
-	if disk := terraform_Disk_QemuSataStorage(config.Disk_0, schemaSata+"0", ciDisk); disk != nil {
+	if disk := terraform_Disk_QemuSataStorage(config.Disk_0, ciDisk, schema[schemaSata+"0"]); disk != nil {
 		disks = append(disks, disk)
 	}
-	if disk := terraform_Disk_QemuSataStorage(config.Disk_1, schemaSata+"1", ciDisk); disk != nil {
+	if disk := terraform_Disk_QemuSataStorage(config.Disk_1, ciDisk, schema[schemaSata+"1"]); disk != nil {
 		disks = append(disks, disk)
 	}
-	if disk := terraform_Disk_QemuSataStorage(config.Disk_2, schemaSata+"2", ciDisk); disk != nil {
+	if disk := terraform_Disk_QemuSataStorage(config.Disk_2, ciDisk, schema[schemaSata+"2"]); disk != nil {
 		disks = append(disks, disk)
 	}
-	if disk := terraform_Disk_QemuSataStorage(config.Disk_2, schemaSata+"3", ciDisk); disk != nil {
+	if disk := terraform_Disk_QemuSataStorage(config.Disk_2, ciDisk, schema[schemaSata+"3"]); disk != nil {
 		disks = append(disks, disk)
 	}
-	if disk := terraform_Disk_QemuSataStorage(config.Disk_2, schemaSata+"4", ciDisk); disk != nil {
+	if disk := terraform_Disk_QemuSataStorage(config.Disk_2, ciDisk, schema[schemaSata+"4"]); disk != nil {
 		disks = append(disks, disk)
 	}
-	if disk := terraform_Disk_QemuSataStorage(config.Disk_2, schemaSata+"5", ciDisk); disk != nil {
+	if disk := terraform_Disk_QemuSataStorage(config.Disk_2, ciDisk, schema[schemaSata+"5"]); disk != nil {
 		disks = append(disks, disk)
 	}
 	if len(disks) == 0 {
@@ -137,151 +136,151 @@ func terraform_Disk_QemuSataDisks(config *pveAPI.QemuSataDisks, ciDisk *bool) []
 	return disks
 }
 
-func terraform_Disk_QemuSataStorage(config *pveAPI.QemuSataStorage, slot string, ciDisk *bool) (settings map[string]interface{}) {
+func terraform_Disk_QemuSataStorage(config *pveAPI.QemuSataStorage, ciDisk *bool, schema map[string]any) map[string]any {
+	if schema != nil && schema[schemaType] == enumIgnore {
+		return schema
+	}
 	if config == nil {
 		return nil
 	}
 	if config.Disk != nil {
-		settings = map[string]interface{}{
-			schemaAsyncIO:       string(config.Disk.AsyncIO),
-			schemaBackup:        config.Disk.Backup,
-			schemaCache:         string(config.Disk.Cache),
-			schemaDiscard:       config.Disk.Discard,
-			schemaEmulateSSD:    config.Disk.EmulateSSD,
-			schemaFormat:        string(config.Disk.Format),
-			schemaID:            int(config.Disk.Id),
-			schemaLinkedDiskId:  terraformLinkedCloneId(config.Disk.LinkedDiskId),
-			schemaReplicate:     config.Disk.Replicate,
-			schemaSerial:        string(config.Disk.Serial),
-			schemaSize:          convert_KibibytesToString(int64(config.Disk.SizeInKibibytes)),
-			schemaStorage:       string(config.Disk.Storage),
-			schemaType:          schemaDisk,
-			schemaWorldWideName: string(config.Disk.WorldWideName)}
-		terraformQemuDiskBandwidth(settings, config.Disk.Bandwidth)
+		schema[schemaAsyncIO] = string(config.Disk.AsyncIO)
+		schema[schemaBackup] = config.Disk.Backup
+		schema[schemaCache] = string(config.Disk.Cache)
+		schema[schemaDiscard] = config.Disk.Discard
+		schema[schemaEmulateSSD] = config.Disk.EmulateSSD
+		schema[schemaFormat] = string(config.Disk.Format)
+		schema[schemaID] = int(config.Disk.Id)
+		schema[schemaLinkedDiskId] = terraformLinkedCloneId(config.Disk.LinkedDiskId)
+		schema[schemaReplicate] = config.Disk.Replicate
+		schema[schemaSerial] = string(config.Disk.Serial)
+		schema[schemaSize] = convert_KibibytesToString(int64(config.Disk.SizeInKibibytes))
+		schema[schemaStorage] = string(config.Disk.Storage)
+		schema[schemaType] = schemaDisk
+		schema[schemaWorldWideName] = string(config.Disk.WorldWideName)
+		terraformQemuDiskBandwidth(schema, config.Disk.Bandwidth)
 	}
 	if config.Passthrough != nil {
-		settings = map[string]interface{}{
-			schemaAsyncIO:       string(config.Disk.AsyncIO),
-			schemaBackup:        config.Disk.Backup,
-			schemaCache:         string(config.Disk.Cache),
-			schemaDiscard:       config.Disk.Discard,
-			schemaEmulateSSD:    config.Disk.EmulateSSD,
-			schemaFile:          config.Passthrough.File,
-			schemaPassthrough:   true,
-			schemaReplicate:     config.Disk.Replicate,
-			schemaSerial:        string(config.Disk.Serial),
-			schemaSize:          convert_KibibytesToString(int64(config.Disk.SizeInKibibytes)),
-			schemaType:          schemaDisk,
-			schemaWorldWideName: string(config.Disk.WorldWideName)}
-		terraformQemuDiskBandwidth(settings, config.Passthrough.Bandwidth)
+		schema[schemaAsyncIO] = string(config.Disk.AsyncIO)
+		schema[schemaBackup] = config.Disk.Backup
+		schema[schemaCache] = string(config.Disk.Cache)
+		schema[schemaDiscard] = config.Disk.Discard
+		schema[schemaEmulateSSD] = config.Disk.EmulateSSD
+		schema[schemaFile] = config.Passthrough.File
+		schema[schemaPassthrough] = true
+		schema[schemaReplicate] = config.Disk.Replicate
+		schema[schemaSerial] = string(config.Disk.Serial)
+		schema[schemaSize] = convert_KibibytesToString(int64(config.Disk.SizeInKibibytes))
+		schema[schemaType] = schemaDisk
+		schema[schemaWorldWideName] = string(config.Disk.WorldWideName)
+		terraformQemuDiskBandwidth(schema, config.Passthrough.Bandwidth)
 	}
 	if config.CdRom != nil {
-		settings = terraform_Disk_QemuCdRom_unsafe(config.CdRom)
+		terraform_Disk_QemuCdRom_unsafe(config.CdRom, schema)
 	}
 	if config.CloudInit != nil {
 		*ciDisk = true
-		settings = terraform_Disk_QemuCloudInit_unsafe(config.CloudInit)
+		terraform_Disk_QemuCloudInit_unsafe(config.CloudInit, schema)
 	}
-	settings[schemaSlot] = slot
-	return settings
+	return schema
 }
 
-func terraform_Disk_QemuScsiDisks(config *pveAPI.QemuScsiDisks, ciDisk *bool) []map[string]interface{} {
+func terraform_Disk_QemuScsiDisks(config *pveAPI.QemuScsiDisks, ciDisk *bool, schema map[string]map[string]any) []map[string]any {
 	if config == nil {
-		return nil
+		config = &pveAPI.QemuScsiDisks{}
 	}
 	disks := make([]map[string]interface{}, 0, 31)
-	if disk := terraform_Disk_QemuScsiStorage(config.Disk_0, schemaScsi+"0", ciDisk); disk != nil {
+	if disk := terraform_Disk_QemuScsiStorage(config.Disk_0, ciDisk, schema[schemaScsi+"0"]); disk != nil {
 		disks = append(disks, disk)
 	}
-	if disk := terraform_Disk_QemuScsiStorage(config.Disk_1, schemaScsi+"1", ciDisk); disk != nil {
+	if disk := terraform_Disk_QemuScsiStorage(config.Disk_1, ciDisk, schema[schemaScsi+"1"]); disk != nil {
 		disks = append(disks, disk)
 	}
-	if disk := terraform_Disk_QemuScsiStorage(config.Disk_2, schemaScsi+"2", ciDisk); disk != nil {
+	if disk := terraform_Disk_QemuScsiStorage(config.Disk_2, ciDisk, schema[schemaScsi+"2"]); disk != nil {
 		disks = append(disks, disk)
 	}
-	if disk := terraform_Disk_QemuScsiStorage(config.Disk_3, schemaScsi+"3", ciDisk); disk != nil {
+	if disk := terraform_Disk_QemuScsiStorage(config.Disk_3, ciDisk, schema[schemaScsi+"3"]); disk != nil {
 		disks = append(disks, disk)
 	}
-	if disk := terraform_Disk_QemuScsiStorage(config.Disk_4, schemaScsi+"4", ciDisk); disk != nil {
+	if disk := terraform_Disk_QemuScsiStorage(config.Disk_4, ciDisk, schema[schemaScsi+"4"]); disk != nil {
 		disks = append(disks, disk)
 	}
-	if disk := terraform_Disk_QemuScsiStorage(config.Disk_5, schemaScsi+"5", ciDisk); disk != nil {
+	if disk := terraform_Disk_QemuScsiStorage(config.Disk_5, ciDisk, schema[schemaScsi+"5"]); disk != nil {
 		disks = append(disks, disk)
 	}
-	if disk := terraform_Disk_QemuScsiStorage(config.Disk_6, schemaScsi+"6", ciDisk); disk != nil {
+	if disk := terraform_Disk_QemuScsiStorage(config.Disk_6, ciDisk, schema[schemaScsi+"6"]); disk != nil {
 		disks = append(disks, disk)
 	}
-	if disk := terraform_Disk_QemuScsiStorage(config.Disk_7, schemaScsi+"7", ciDisk); disk != nil {
+	if disk := terraform_Disk_QemuScsiStorage(config.Disk_7, ciDisk, schema[schemaScsi+"7"]); disk != nil {
 		disks = append(disks, disk)
 	}
-	if disk := terraform_Disk_QemuScsiStorage(config.Disk_8, schemaScsi+"8", ciDisk); disk != nil {
+	if disk := terraform_Disk_QemuScsiStorage(config.Disk_8, ciDisk, schema[schemaScsi+"8"]); disk != nil {
 		disks = append(disks, disk)
 	}
-	if disk := terraform_Disk_QemuScsiStorage(config.Disk_9, schemaScsi+"9", ciDisk); disk != nil {
+	if disk := terraform_Disk_QemuScsiStorage(config.Disk_9, ciDisk, schema[schemaScsi+"9"]); disk != nil {
 		disks = append(disks, disk)
 	}
-	if disk := terraform_Disk_QemuScsiStorage(config.Disk_10, schemaScsi+"10", ciDisk); disk != nil {
+	if disk := terraform_Disk_QemuScsiStorage(config.Disk_10, ciDisk, schema[schemaScsi+"10"]); disk != nil {
 		disks = append(disks, disk)
 	}
-	if disk := terraform_Disk_QemuScsiStorage(config.Disk_11, schemaScsi+"11", ciDisk); disk != nil {
+	if disk := terraform_Disk_QemuScsiStorage(config.Disk_11, ciDisk, schema[schemaScsi+"11"]); disk != nil {
 		disks = append(disks, disk)
 	}
-	if disk := terraform_Disk_QemuScsiStorage(config.Disk_12, schemaScsi+"12", ciDisk); disk != nil {
+	if disk := terraform_Disk_QemuScsiStorage(config.Disk_12, ciDisk, schema[schemaScsi+"12"]); disk != nil {
 		disks = append(disks, disk)
 	}
-	if disk := terraform_Disk_QemuScsiStorage(config.Disk_13, schemaScsi+"13", ciDisk); disk != nil {
+	if disk := terraform_Disk_QemuScsiStorage(config.Disk_13, ciDisk, schema[schemaScsi+"13"]); disk != nil {
 		disks = append(disks, disk)
 	}
-	if disk := terraform_Disk_QemuScsiStorage(config.Disk_14, schemaScsi+"14", ciDisk); disk != nil {
+	if disk := terraform_Disk_QemuScsiStorage(config.Disk_14, ciDisk, schema[schemaScsi+"14"]); disk != nil {
 		disks = append(disks, disk)
 	}
-	if disk := terraform_Disk_QemuScsiStorage(config.Disk_15, schemaScsi+"15", ciDisk); disk != nil {
+	if disk := terraform_Disk_QemuScsiStorage(config.Disk_15, ciDisk, schema[schemaScsi+"15"]); disk != nil {
 		disks = append(disks, disk)
 	}
-	if disk := terraform_Disk_QemuScsiStorage(config.Disk_16, schemaScsi+"16", ciDisk); disk != nil {
+	if disk := terraform_Disk_QemuScsiStorage(config.Disk_16, ciDisk, schema[schemaScsi+"16"]); disk != nil {
 		disks = append(disks, disk)
 	}
-	if disk := terraform_Disk_QemuScsiStorage(config.Disk_17, schemaScsi+"17", ciDisk); disk != nil {
+	if disk := terraform_Disk_QemuScsiStorage(config.Disk_17, ciDisk, schema[schemaScsi+"17"]); disk != nil {
 		disks = append(disks, disk)
 	}
-	if disk := terraform_Disk_QemuScsiStorage(config.Disk_18, schemaScsi+"18", ciDisk); disk != nil {
+	if disk := terraform_Disk_QemuScsiStorage(config.Disk_18, ciDisk, schema[schemaScsi+"18"]); disk != nil {
 		disks = append(disks, disk)
 	}
-	if disk := terraform_Disk_QemuScsiStorage(config.Disk_19, schemaScsi+"19", ciDisk); disk != nil {
+	if disk := terraform_Disk_QemuScsiStorage(config.Disk_19, ciDisk, schema[schemaScsi+"19"]); disk != nil {
 		disks = append(disks, disk)
 	}
-	if disk := terraform_Disk_QemuScsiStorage(config.Disk_20, schemaScsi+"20", ciDisk); disk != nil {
+	if disk := terraform_Disk_QemuScsiStorage(config.Disk_20, ciDisk, schema[schemaScsi+"20"]); disk != nil {
 		disks = append(disks, disk)
 	}
-	if disk := terraform_Disk_QemuScsiStorage(config.Disk_21, schemaScsi+"21", ciDisk); disk != nil {
+	if disk := terraform_Disk_QemuScsiStorage(config.Disk_21, ciDisk, schema[schemaScsi+"21"]); disk != nil {
 		disks = append(disks, disk)
 	}
-	if disk := terraform_Disk_QemuScsiStorage(config.Disk_22, schemaScsi+"22", ciDisk); disk != nil {
+	if disk := terraform_Disk_QemuScsiStorage(config.Disk_22, ciDisk, schema[schemaScsi+"22"]); disk != nil {
 		disks = append(disks, disk)
 	}
-	if disk := terraform_Disk_QemuScsiStorage(config.Disk_23, schemaScsi+"23", ciDisk); disk != nil {
+	if disk := terraform_Disk_QemuScsiStorage(config.Disk_23, ciDisk, schema[schemaScsi+"23"]); disk != nil {
 		disks = append(disks, disk)
 	}
-	if disk := terraform_Disk_QemuScsiStorage(config.Disk_24, schemaScsi+"24", ciDisk); disk != nil {
+	if disk := terraform_Disk_QemuScsiStorage(config.Disk_24, ciDisk, schema[schemaScsi+"24"]); disk != nil {
 		disks = append(disks, disk)
 	}
-	if disk := terraform_Disk_QemuScsiStorage(config.Disk_25, schemaScsi+"25", ciDisk); disk != nil {
+	if disk := terraform_Disk_QemuScsiStorage(config.Disk_25, ciDisk, schema[schemaScsi+"25"]); disk != nil {
 		disks = append(disks, disk)
 	}
-	if disk := terraform_Disk_QemuScsiStorage(config.Disk_26, schemaScsi+"26", ciDisk); disk != nil {
+	if disk := terraform_Disk_QemuScsiStorage(config.Disk_26, ciDisk, schema[schemaScsi+"26"]); disk != nil {
 		disks = append(disks, disk)
 	}
-	if disk := terraform_Disk_QemuScsiStorage(config.Disk_27, schemaScsi+"27", ciDisk); disk != nil {
+	if disk := terraform_Disk_QemuScsiStorage(config.Disk_27, ciDisk, schema[schemaScsi+"27"]); disk != nil {
 		disks = append(disks, disk)
 	}
-	if disk := terraform_Disk_QemuScsiStorage(config.Disk_28, schemaScsi+"28", ciDisk); disk != nil {
+	if disk := terraform_Disk_QemuScsiStorage(config.Disk_28, ciDisk, schema[schemaScsi+"28"]); disk != nil {
 		disks = append(disks, disk)
 	}
-	if disk := terraform_Disk_QemuScsiStorage(config.Disk_29, schemaScsi+"29", ciDisk); disk != nil {
+	if disk := terraform_Disk_QemuScsiStorage(config.Disk_29, ciDisk, schema[schemaScsi+"29"]); disk != nil {
 		disks = append(disks, disk)
 	}
-	if disk := terraform_Disk_QemuScsiStorage(config.Disk_30, schemaScsi+"30", ciDisk); disk != nil {
+	if disk := terraform_Disk_QemuScsiStorage(config.Disk_30, ciDisk, schema[schemaScsi+"30"]); disk != nil {
 		disks = append(disks, disk)
 	}
 	if len(disks) == 0 {
@@ -290,110 +289,110 @@ func terraform_Disk_QemuScsiDisks(config *pveAPI.QemuScsiDisks, ciDisk *bool) []
 	return disks
 }
 
-func terraform_Disk_QemuScsiStorage(config *pveAPI.QemuScsiStorage, slot string, ciDisk *bool) (settings map[string]interface{}) {
+func terraform_Disk_QemuScsiStorage(config *pveAPI.QemuScsiStorage, ciDisk *bool, schema map[string]any) map[string]any {
+	if schema != nil && schema[schemaType] == enumIgnore {
+		return schema
+	}
 	if config == nil {
 		return nil
 	}
 	if config.Disk != nil {
-		settings = map[string]interface{}{
-			schemaAsyncIO:       string(config.Disk.AsyncIO),
-			schemaBackup:        config.Disk.Backup,
-			schemaCache:         string(config.Disk.Cache),
-			schemaDiscard:       config.Disk.Discard,
-			schemaEmulateSSD:    config.Disk.EmulateSSD,
-			schemaFormat:        string(config.Disk.Format),
-			schemaID:            int(config.Disk.Id),
-			schemaIOthread:      config.Disk.IOThread,
-			schemaLinkedDiskId:  terraformLinkedCloneId(config.Disk.LinkedDiskId),
-			schemaReadOnly:      config.Disk.ReadOnly,
-			schemaReplicate:     config.Disk.Replicate,
-			schemaSerial:        string(config.Disk.Serial),
-			schemaSize:          convert_KibibytesToString(int64(config.Disk.SizeInKibibytes)),
-			schemaStorage:       string(config.Disk.Storage),
-			schemaType:          schemaDisk,
-			schemaWorldWideName: string(config.Disk.WorldWideName)}
-		terraformQemuDiskBandwidth(settings, config.Disk.Bandwidth)
+		schema[schemaAsyncIO] = string(config.Disk.AsyncIO)
+		schema[schemaBackup] = config.Disk.Backup
+		schema[schemaCache] = string(config.Disk.Cache)
+		schema[schemaDiscard] = config.Disk.Discard
+		schema[schemaEmulateSSD] = config.Disk.EmulateSSD
+		schema[schemaFormat] = string(config.Disk.Format)
+		schema[schemaID] = int(config.Disk.Id)
+		schema[schemaIOthread] = config.Disk.IOThread
+		schema[schemaLinkedDiskId] = terraformLinkedCloneId(config.Disk.LinkedDiskId)
+		schema[schemaReadOnly] = config.Disk.ReadOnly
+		schema[schemaReplicate] = config.Disk.Replicate
+		schema[schemaSerial] = string(config.Disk.Serial)
+		schema[schemaSize] = convert_KibibytesToString(int64(config.Disk.SizeInKibibytes))
+		schema[schemaStorage] = string(config.Disk.Storage)
+		schema[schemaType] = schemaDisk
+		schema[schemaWorldWideName] = string(config.Disk.WorldWideName)
+		terraformQemuDiskBandwidth(schema, config.Disk.Bandwidth)
 	}
 	if config.Passthrough != nil {
-		settings = map[string]interface{}{
-			schemaAsyncIO:       string(config.Disk.AsyncIO),
-			schemaBackup:        config.Disk.Backup,
-			schemaCache:         string(config.Disk.Cache),
-			schemaDiscard:       config.Disk.Discard,
-			schemaEmulateSSD:    config.Disk.EmulateSSD,
-			schemaFile:          config.Passthrough.File,
-			schemaIOthread:      config.Disk.IOThread,
-			schemaPassthrough:   true,
-			schemaReadOnly:      config.Disk.ReadOnly,
-			schemaReplicate:     config.Disk.Replicate,
-			schemaSerial:        string(config.Disk.Serial),
-			schemaSize:          convert_KibibytesToString(int64(config.Disk.SizeInKibibytes)),
-			schemaType:          schemaDisk,
-			schemaWorldWideName: string(config.Disk.WorldWideName)}
-		terraformQemuDiskBandwidth(settings, config.Passthrough.Bandwidth)
+		schema[schemaAsyncIO] = string(config.Disk.AsyncIO)
+		schema[schemaBackup] = config.Disk.Backup
+		schema[schemaCache] = string(config.Disk.Cache)
+		schema[schemaDiscard] = config.Disk.Discard
+		schema[schemaEmulateSSD] = config.Disk.EmulateSSD
+		schema[schemaFile] = config.Passthrough.File
+		schema[schemaIOthread] = config.Disk.IOThread
+		schema[schemaPassthrough] = true
+		schema[schemaReadOnly] = config.Disk.ReadOnly
+		schema[schemaReplicate] = config.Disk.Replicate
+		schema[schemaSerial] = string(config.Disk.Serial)
+		schema[schemaSize] = convert_KibibytesToString(int64(config.Disk.SizeInKibibytes))
+		schema[schemaType] = schemaDisk
+		schema[schemaWorldWideName] = string(config.Disk.WorldWideName)
+		terraformQemuDiskBandwidth(schema, config.Passthrough.Bandwidth)
 	}
 	if config.CdRom != nil {
-		settings = terraform_Disk_QemuCdRom_unsafe(config.CdRom)
+		terraform_Disk_QemuCdRom_unsafe(config.CdRom, schema)
 	}
 	if config.CloudInit != nil {
 		*ciDisk = true
-		settings = terraform_Disk_QemuCloudInit_unsafe(config.CloudInit)
+		terraform_Disk_QemuCloudInit_unsafe(config.CloudInit, schema)
 	}
-	settings[schemaSlot] = slot
-	return settings
+	return schema
 }
 
-func terraform_Disk_QemuVirtIODisks(config *pveAPI.QemuVirtIODisks) []map[string]interface{} {
+func terraform_Disk_QemuVirtIODisks(config *pveAPI.QemuVirtIODisks, schema map[string]map[string]any) []map[string]any {
 	if config == nil {
-		return nil
+		config = &pveAPI.QemuVirtIODisks{}
 	}
 	disks := make([]map[string]interface{}, 0, 16)
-	if disk := terraform_Disk_QemuVirtIOStorage(config.Disk_0, schemaVirtIO+"0"); disk != nil {
+	if disk := terraform_Disk_QemuVirtIOStorage(config.Disk_0, schema[schemaVirtIO+"0"]); disk != nil {
 		disks = append(disks, disk)
 	}
-	if disk := terraform_Disk_QemuVirtIOStorage(config.Disk_1, schemaVirtIO+"1"); disk != nil {
+	if disk := terraform_Disk_QemuVirtIOStorage(config.Disk_1, schema[schemaVirtIO+"1"]); disk != nil {
 		disks = append(disks, disk)
 	}
-	if disk := terraform_Disk_QemuVirtIOStorage(config.Disk_2, schemaVirtIO+"2"); disk != nil {
+	if disk := terraform_Disk_QemuVirtIOStorage(config.Disk_2, schema[schemaVirtIO+"2"]); disk != nil {
 		disks = append(disks, disk)
 	}
-	if disk := terraform_Disk_QemuVirtIOStorage(config.Disk_3, schemaVirtIO+"3"); disk != nil {
+	if disk := terraform_Disk_QemuVirtIOStorage(config.Disk_3, schema[schemaVirtIO+"3"]); disk != nil {
 		disks = append(disks, disk)
 	}
-	if disk := terraform_Disk_QemuVirtIOStorage(config.Disk_4, schemaVirtIO+"4"); disk != nil {
+	if disk := terraform_Disk_QemuVirtIOStorage(config.Disk_4, schema[schemaVirtIO+"4"]); disk != nil {
 		disks = append(disks, disk)
 	}
-	if disk := terraform_Disk_QemuVirtIOStorage(config.Disk_5, schemaVirtIO+"5"); disk != nil {
+	if disk := terraform_Disk_QemuVirtIOStorage(config.Disk_5, schema[schemaVirtIO+"5"]); disk != nil {
 		disks = append(disks, disk)
 	}
-	if disk := terraform_Disk_QemuVirtIOStorage(config.Disk_6, schemaVirtIO+"6"); disk != nil {
+	if disk := terraform_Disk_QemuVirtIOStorage(config.Disk_6, schema[schemaVirtIO+"6"]); disk != nil {
 		disks = append(disks, disk)
 	}
-	if disk := terraform_Disk_QemuVirtIOStorage(config.Disk_7, schemaVirtIO+"7"); disk != nil {
+	if disk := terraform_Disk_QemuVirtIOStorage(config.Disk_7, schema[schemaVirtIO+"7"]); disk != nil {
 		disks = append(disks, disk)
 	}
-	if disk := terraform_Disk_QemuVirtIOStorage(config.Disk_8, schemaVirtIO+"8"); disk != nil {
+	if disk := terraform_Disk_QemuVirtIOStorage(config.Disk_8, schema[schemaVirtIO+"8"]); disk != nil {
 		disks = append(disks, disk)
 	}
-	if disk := terraform_Disk_QemuVirtIOStorage(config.Disk_9, schemaVirtIO+"9"); disk != nil {
+	if disk := terraform_Disk_QemuVirtIOStorage(config.Disk_9, schema[schemaVirtIO+"9"]); disk != nil {
 		disks = append(disks, disk)
 	}
-	if disk := terraform_Disk_QemuVirtIOStorage(config.Disk_10, schemaVirtIO+"10"); disk != nil {
+	if disk := terraform_Disk_QemuVirtIOStorage(config.Disk_10, schema[schemaVirtIO+"10"]); disk != nil {
 		disks = append(disks, disk)
 	}
-	if disk := terraform_Disk_QemuVirtIOStorage(config.Disk_11, schemaVirtIO+"11"); disk != nil {
+	if disk := terraform_Disk_QemuVirtIOStorage(config.Disk_11, schema[schemaVirtIO+"11"]); disk != nil {
 		disks = append(disks, disk)
 	}
-	if disk := terraform_Disk_QemuVirtIOStorage(config.Disk_12, schemaVirtIO+"12"); disk != nil {
+	if disk := terraform_Disk_QemuVirtIOStorage(config.Disk_12, schema[schemaVirtIO+"12"]); disk != nil {
 		disks = append(disks, disk)
 	}
-	if disk := terraform_Disk_QemuVirtIOStorage(config.Disk_13, schemaVirtIO+"13"); disk != nil {
+	if disk := terraform_Disk_QemuVirtIOStorage(config.Disk_13, schema[schemaVirtIO+"13"]); disk != nil {
 		disks = append(disks, disk)
 	}
-	if disk := terraform_Disk_QemuVirtIOStorage(config.Disk_14, schemaVirtIO+"14"); disk != nil {
+	if disk := terraform_Disk_QemuVirtIOStorage(config.Disk_14, schema[schemaVirtIO+"14"]); disk != nil {
 		disks = append(disks, disk)
 	}
-	if disk := terraform_Disk_QemuVirtIOStorage(config.Disk_15, schemaVirtIO+"15"); disk != nil {
+	if disk := terraform_Disk_QemuVirtIOStorage(config.Disk_15, schema[schemaVirtIO+"15"]); disk != nil {
 		disks = append(disks, disk)
 	}
 	if len(disks) == 0 {
@@ -402,49 +401,58 @@ func terraform_Disk_QemuVirtIODisks(config *pveAPI.QemuVirtIODisks) []map[string
 	return disks
 }
 
-func terraform_Disk_QemuVirtIOStorage(config *pveAPI.QemuVirtIOStorage, slot string) (settings map[string]interface{}) {
+func terraform_Disk_QemuVirtIOStorage(config *pveAPI.QemuVirtIOStorage, schema map[string]any) map[string]any {
+	if schema != nil && schema[schemaType] == enumIgnore {
+		return schema
+	}
 	if config == nil {
 		return nil
 	}
 	if config.Disk != nil {
-		settings = map[string]interface{}{
-			schemaAsyncIO:       string(config.Disk.AsyncIO),
-			schemaBackup:        config.Disk.Backup,
-			schemaCache:         string(config.Disk.Cache),
-			schemaDiscard:       config.Disk.Discard,
-			schemaFormat:        string(config.Disk.Format),
-			schemaID:            int(config.Disk.Id),
-			schemaIOthread:      config.Disk.IOThread,
-			schemaLinkedDiskId:  terraformLinkedCloneId(config.Disk.LinkedDiskId),
-			schemaReadOnly:      config.Disk.ReadOnly,
-			schemaReplicate:     config.Disk.Replicate,
-			schemaSerial:        string(config.Disk.Serial),
-			schemaSize:          convert_KibibytesToString(int64(config.Disk.SizeInKibibytes)),
-			schemaStorage:       string(config.Disk.Storage),
-			schemaType:          schemaDisk,
-			schemaWorldWideName: string(config.Disk.WorldWideName)}
-		terraformQemuDiskBandwidth(settings, config.Disk.Bandwidth)
+		schema[schemaAsyncIO] = string(config.Disk.AsyncIO)
+		schema[schemaBackup] = config.Disk.Backup
+		schema[schemaCache] = string(config.Disk.Cache)
+		schema[schemaDiscard] = config.Disk.Discard
+		schema[schemaFormat] = string(config.Disk.Format)
+		schema[schemaID] = int(config.Disk.Id)
+		schema[schemaIOthread] = config.Disk.IOThread
+		schema[schemaLinkedDiskId] = terraformLinkedCloneId(config.Disk.LinkedDiskId)
+		schema[schemaReadOnly] = config.Disk.ReadOnly
+		schema[schemaReplicate] = config.Disk.Replicate
+		schema[schemaSerial] = string(config.Disk.Serial)
+		schema[schemaSize] = convert_KibibytesToString(int64(config.Disk.SizeInKibibytes))
+		schema[schemaStorage] = string(config.Disk.Storage)
+		schema[schemaType] = schemaDisk
+		schema[schemaWorldWideName] = string(config.Disk.WorldWideName)
+		terraformQemuDiskBandwidth(schema, config.Disk.Bandwidth)
 	}
 	if config.Passthrough != nil {
-		settings = map[string]interface{}{
-			schemaAsyncIO:       string(config.Passthrough.AsyncIO),
-			schemaBackup:        config.Passthrough.Backup,
-			schemaCache:         string(config.Passthrough.Cache),
-			schemaDiscard:       config.Passthrough.Discard,
-			schemaFile:          config.Passthrough.File,
-			schemaIOthread:      config.Passthrough.IOThread,
-			schemaPassthrough:   true,
-			schemaReadOnly:      config.Passthrough.ReadOnly,
-			schemaReplicate:     config.Passthrough.Replicate,
-			schemaSerial:        string(config.Passthrough.Serial),
-			schemaSize:          convert_KibibytesToString(int64(config.Passthrough.SizeInKibibytes)),
-			schemaType:          schemaDisk,
-			schemaWorldWideName: string(config.Passthrough.WorldWideName)}
-		terraformQemuDiskBandwidth(settings, config.Passthrough.Bandwidth)
+		schema[schemaAsyncIO] = string(config.Passthrough.AsyncIO)
+		schema[schemaBackup] = config.Passthrough.Backup
+		schema[schemaCache] = string(config.Passthrough.Cache)
+		schema[schemaDiscard] = config.Passthrough.Discard
+		schema[schemaFile] = config.Passthrough.File
+		schema[schemaIOthread] = config.Passthrough.IOThread
+		schema[schemaPassthrough] = true
+		schema[schemaReadOnly] = config.Passthrough.ReadOnly
+		schema[schemaReplicate] = config.Passthrough.Replicate
+		schema[schemaSerial] = string(config.Passthrough.Serial)
+		schema[schemaSize] = convert_KibibytesToString(int64(config.Passthrough.SizeInKibibytes))
+		schema[schemaType] = schemaDisk
+		schema[schemaWorldWideName] = string(config.Passthrough.WorldWideName)
+		terraformQemuDiskBandwidth(schema, config.Passthrough.Bandwidth)
 	}
 	if config.CdRom != nil {
-		settings = terraform_Disk_QemuCdRom_unsafe(config.CdRom)
+		terraform_Disk_QemuCdRom_unsafe(config.CdRom, schema)
 	}
-	settings[schemaSlot] = slot
-	return settings
+	return schema
+}
+
+func createDiskMap(schema []any) map[string]map[string]any {
+	newMap := map[string]map[string]any{}
+	for i := range schema {
+		subSchema := schema[i].(map[string]any)
+		newMap[subSchema[schemaSlot].(string)] = subSchema
+	}
+	return newMap
 }

--- a/proxmox/Internal/resource/guest/qemu/disk/terraform_disk.go
+++ b/proxmox/Internal/resource/guest/qemu/disk/terraform_disk.go
@@ -6,7 +6,6 @@ import pveAPI "github.com/Telmate/proxmox-api-go/proxmox"
 func terraform_Disk_QemuCdRom_unsafe(config *pveAPI.QemuCdRom, schema map[string]any) {
 	schema[schemaBackup] = true // always true to avoid diff
 	schema[schemaISO] = terraformIsoFile(config.Iso)
-	schema[schemaCdRom] = true
 	schema[schemaPassthrough] = config.Passthrough
 	schema[schemaType] = enumCdRom
 }

--- a/proxmox/Internal/resource/guest/qemu/disk/warning.go
+++ b/proxmox/Internal/resource/guest/qemu/disk/warning.go
@@ -10,7 +10,7 @@ func warningDisk(slot, setting, property, value, extra string) diag.Diagnostic {
 
 func warningsCdromAndCloudinit(slot, kind string, schema map[string]interface{}) (diags diag.Diagnostics) {
 	if schema[schemaAsyncIO].(string) != "" {
-		diags = append(diags, warningDisk(slot, schemaAsyncIO, schemaType, kind, ""))
+		diags = diag.Diagnostics{warningDisk(slot, schemaAsyncIO, schemaType, kind, "")}
 	}
 	if schema[schemaCache].(string) != "" {
 		diags = append(diags, warningDisk(slot, schemaCache, schemaType, kind, ""))

--- a/proxmox/Internal/resource/guest/qemu/disk/warning.go
+++ b/proxmox/Internal/resource/guest/qemu/disk/warning.go
@@ -87,3 +87,85 @@ func warningsDiskPassthrough(slot string, schema map[string]interface{}) diag.Di
 	}
 	return diag.Diagnostics{}
 }
+
+func WarningIgnore(slot string, schema map[string]any) (diags diag.Diagnostics) {
+	if schema[schemaAsyncIO].(string) != "" {
+		diags = diag.Diagnostics{warningDisk(slot, schemaAsyncIO, schemaType, enumIgnore, "")}
+	}
+	if !schema[schemaBackup].(bool) {
+		diags = append(diags, warningDisk(slot, schemaBackup, schemaType, enumIgnore, ""))
+	}
+	if schema[schemaCache].(string) != "" {
+		diags = append(diags, warningDisk(slot, schemaCache, schemaType, enumIgnore, ""))
+	}
+	if schema[schemaDiscard].(bool) {
+		diags = append(diags, warningDisk(slot, schemaDiscard, schemaType, enumIgnore, ""))
+	}
+	if schema[schemaDiskFile].(string) != "" {
+		diags = append(diags, warningDisk(slot, schemaDiskFile, schemaType, enumIgnore, ""))
+	}
+	if schema[schemaEmulateSSD].(bool) {
+		diags = append(diags, warningDisk(slot, schemaEmulateSSD, schemaType, enumIgnore, ""))
+	}
+	if schema[schemaFormat].(string) != "" {
+		diags = append(diags, warningDisk(slot, schemaFormat, schemaType, enumIgnore, ""))
+	}
+	if schema[schemaIOPSrBurst].(int) != 0 {
+		diags = append(diags, warningDisk(slot, schemaIOPSrBurst, schemaType, enumIgnore, ""))
+	}
+	if schema[schemaIOPSrBurstLength].(int) != 0 {
+		diags = append(diags, warningDisk(slot, schemaIOPSrBurstLength, schemaType, enumIgnore, ""))
+	}
+	if schema[schemaIOPSrConcurrent].(int) != 0 {
+		diags = append(diags, warningDisk(slot, schemaIOPSrConcurrent, schemaType, enumIgnore, ""))
+	}
+	if schema[schemaIOPSwrBurst].(int) != 0 {
+		diags = append(diags, warningDisk(slot, schemaIOPSwrBurst, schemaType, enumIgnore, ""))
+	}
+	if schema[schemaIOPSwrBurstLength].(int) != 0 {
+		diags = append(diags, warningDisk(slot, schemaIOPSwrBurstLength, schemaType, enumIgnore, ""))
+	}
+	if schema[schemaIOPSwrConcurrent].(int) != 0 {
+		diags = append(diags, warningDisk(slot, schemaIOPSwrConcurrent, schemaType, enumIgnore, ""))
+	}
+	if schema[schemaIOthread].(bool) {
+		diags = append(diags, warningDisk(slot, schemaIOthread, schemaType, enumIgnore, ""))
+	}
+	if schema[schemaISO].(string) != "" {
+		diags = append(diags, warningDisk(slot, schemaISO, schemaType, enumIgnore, ""))
+	}
+	if schema[schemaMBPSrBurst].(float64) != 0.0 {
+		diags = append(diags, warningDisk(slot, schemaMBPSrBurst, schemaType, enumIgnore, ""))
+	}
+	if schema[schemaMBPSrConcurrent].(float64) != 0.0 {
+		diags = append(diags, warningDisk(slot, schemaMBPSrConcurrent, schemaType, enumIgnore, ""))
+	}
+	if schema[schemaMBPSwrBurst].(float64) != 0.0 {
+		diags = append(diags, warningDisk(slot, schemaMBPSwrBurst, schemaType, enumIgnore, ""))
+	}
+	if schema[schemaMBPSwrConcurrent].(float64) != 0.0 {
+		diags = append(diags, warningDisk(slot, schemaMBPSwrConcurrent, schemaType, enumIgnore, ""))
+	}
+	if schema[schemaPassthrough].(bool) {
+		diags = append(diags, warningDisk(slot, schemaPassthrough, schemaType, enumIgnore, ""))
+	}
+	if schema[schemaReadOnly].(bool) {
+		diags = append(diags, warningDisk(slot, schemaReadOnly, schemaType, enumIgnore, ""))
+	}
+	if schema[schemaReplicate].(bool) {
+		diags = append(diags, warningDisk(slot, schemaReplicate, schemaType, enumIgnore, ""))
+	}
+	if schema[schemaSerial].(string) != "" {
+		diags = append(diags, warningDisk(slot, schemaSerial, schemaType, enumIgnore, ""))
+	}
+	if schema[schemaSize].(string) != "" {
+		diags = append(diags, warningDisk(slot, schemaSize, schemaType, enumIgnore, ""))
+	}
+	if schema[schemaStorage].(string) != "" {
+		diags = append(diags, warningDisk(slot, schemaStorage, schemaType, enumIgnore, ""))
+	}
+	if schema[schemaWorldWideName].(string) != "" {
+		diags = append(diags, warningDisk(slot, schemaWorldWideName, schemaType, enumIgnore, ""))
+	}
+	return
+}


### PR DESCRIPTION
Adds the `ignore` option to `disk` and `disks`.
With this setting Terraform will ignore the state of the disk, and **NOT** modify or remove it.

Closes #1206 