### PR TITLE
fix: `nameserver` reports diff when delimiter changes

### DIFF
--- a/proxmox/Internal/resource/guest/qemu/cloudinit/helper.go
+++ b/proxmox/Internal/resource/guest/qemu/cloudinit/helper.go
@@ -1,0 +1,7 @@
+package cloudinit
+
+import "strings"
+
+func trimNameServers(nameServers string) string {
+	return strings.ReplaceAll(strings.ReplaceAll(nameServers, " ", ""), ",", "")
+}

--- a/proxmox/Internal/resource/guest/qemu/cloudinit/schema.go
+++ b/proxmox/Internal/resource/guest/qemu/cloudinit/schema.go
@@ -1,0 +1,18 @@
+package cloudinit
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+const (
+	RootNameServers = "nameserver"
+)
+
+func SchemaNameServers() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeString,
+		Optional: true,
+		DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+			return trimNameServers(old) == trimNameServers(new)
+		}}
+}


### PR DESCRIPTION
Resolves #1311

Moved part of the cloud-init code to a separate package as we don't make additions of this kind in [proxmox/resource_vm_qemu.go](https://github.com/Telmate/terraform-provider-proxmox/blob/master/proxmox/resource_vm_qemu.go) anymore.