### PR TITLE
Fix missing `IDE` slot

### DIFF
--- a/proxmox/Internal/resource/guest/qemu/disk/schema.go
+++ b/proxmox/Internal/resource/guest/qemu/disk/schema.go
@@ -78,6 +78,8 @@ const (
 	amountVirtIOSlots = 16
 
 	totalSlots = amountIdeSlots + amountSataSlots + amountScsiSlots + amountVirtIOSlots
+
+	defaultSize = ""
 )
 
 func SchemaDisk() *schema.Schema {

--- a/proxmox/Internal/resource/guest/qemu/disk/schema.go
+++ b/proxmox/Internal/resource/guest/qemu/disk/schema.go
@@ -76,6 +76,8 @@ const (
 	amountSataSlots   = 6
 	amountScsiSlots   = 31
 	amountVirtIOSlots = 16
+
+	totalSlots = amountIdeSlots + amountSataSlots + amountScsiSlots + amountVirtIOSlots
 )
 
 func SchemaDisk() *schema.Schema {

--- a/proxmox/Internal/resource/guest/qemu/disk/terraform_disk.go
+++ b/proxmox/Internal/resource/guest/qemu/disk/terraform_disk.go
@@ -123,13 +123,13 @@ func terraform_Disk_QemuSataDisks(config *pveAPI.QemuSataDisks, ciDisk *bool, sc
 	if disk := terraform_Disk_QemuSataStorage(config.Disk_2, ciDisk, schema[schemaSata+"2"]); disk != nil {
 		disks = append(disks, disk)
 	}
-	if disk := terraform_Disk_QemuSataStorage(config.Disk_2, ciDisk, schema[schemaSata+"3"]); disk != nil {
+	if disk := terraform_Disk_QemuSataStorage(config.Disk_3, ciDisk, schema[schemaSata+"3"]); disk != nil {
 		disks = append(disks, disk)
 	}
-	if disk := terraform_Disk_QemuSataStorage(config.Disk_2, ciDisk, schema[schemaSata+"4"]); disk != nil {
+	if disk := terraform_Disk_QemuSataStorage(config.Disk_4, ciDisk, schema[schemaSata+"4"]); disk != nil {
 		disks = append(disks, disk)
 	}
-	if disk := terraform_Disk_QemuSataStorage(config.Disk_2, ciDisk, schema[schemaSata+"5"]); disk != nil {
+	if disk := terraform_Disk_QemuSataStorage(config.Disk_5, ciDisk, schema[schemaSata+"5"]); disk != nil {
 		disks = append(disks, disk)
 	}
 	if len(disks) == 0 {

--- a/proxmox/Internal/resource/guest/qemu/disk/terraform_disk.go
+++ b/proxmox/Internal/resource/guest/qemu/disk/terraform_disk.go
@@ -18,7 +18,7 @@ func terraform_Disk_QemuCloudInit_unsafe(config *pveAPI.QemuCloudInitDisk, schem
 }
 
 func terraform_Disk_QemuDisks(config pveAPI.QemuStorages, ciDisk *bool, schema map[string]map[string]any) []map[string]any {
-	disks := make([]map[string]interface{}, 0, 56) // max is sum of underlying arrays
+	disks := make([]map[string]any, 0, totalSlots)
 	if ideDisks := terraform_Disk_QemuIdeDisks(config.Ide, ciDisk, schema); ideDisks != nil {
 		disks = append(disks, ideDisks...)
 	}
@@ -41,7 +41,7 @@ func terraform_Disk_QemuIdeDisks(config *pveAPI.QemuIdeDisks, ciDisk *bool, sche
 	if config == nil {
 		config = &pveAPI.QemuIdeDisks{}
 	}
-	disks := make([]map[string]interface{}, 0, 3)
+	disks := make([]map[string]any, 0, amountIdeSlots)
 	if disk := terraform_Disk_QemuIdeStorage(config.Disk_0, ciDisk, schema[schemaIDE+"0"]); disk != nil {
 		disks = append(disks, disk)
 	}
@@ -49,6 +49,9 @@ func terraform_Disk_QemuIdeDisks(config *pveAPI.QemuIdeDisks, ciDisk *bool, sche
 		disks = append(disks, disk)
 	}
 	if disk := terraform_Disk_QemuIdeStorage(config.Disk_2, ciDisk, schema[schemaIDE+"2"]); disk != nil {
+		disks = append(disks, disk)
+	}
+	if disk := terraform_Disk_QemuIdeStorage(config.Disk_3, ciDisk, schema[schemaIDE+"3"]); disk != nil {
 		disks = append(disks, disk)
 	}
 	if len(disks) == 0 {
@@ -110,7 +113,7 @@ func terraform_Disk_QemuSataDisks(config *pveAPI.QemuSataDisks, ciDisk *bool, sc
 	if config == nil {
 		config = &pveAPI.QemuSataDisks{}
 	}
-	disks := make([]map[string]interface{}, 0, 6)
+	disks := make([]map[string]any, 0, amountSataSlots)
 	if disk := terraform_Disk_QemuSataStorage(config.Disk_0, ciDisk, schema[schemaSata+"0"]); disk != nil {
 		disks = append(disks, disk)
 	}
@@ -188,7 +191,7 @@ func terraform_Disk_QemuScsiDisks(config *pveAPI.QemuScsiDisks, ciDisk *bool, sc
 	if config == nil {
 		config = &pveAPI.QemuScsiDisks{}
 	}
-	disks := make([]map[string]interface{}, 0, 31)
+	disks := make([]map[string]any, 0, amountScsiSlots)
 	if disk := terraform_Disk_QemuScsiStorage(config.Disk_0, ciDisk, schema[schemaScsi+"0"]); disk != nil {
 		disks = append(disks, disk)
 	}
@@ -345,7 +348,7 @@ func terraform_Disk_QemuVirtIODisks(config *pveAPI.QemuVirtIODisks, schema map[s
 	if config == nil {
 		config = &pveAPI.QemuVirtIODisks{}
 	}
-	disks := make([]map[string]interface{}, 0, 16)
+	disks := make([]map[string]any, 0, amountVirtIOSlots)
 	if disk := terraform_Disk_QemuVirtIOStorage(config.Disk_0, schema[schemaVirtIO+"0"]); disk != nil {
 		disks = append(disks, disk)
 	}

--- a/proxmox/Internal/resource/guest/qemu/disk/terraform_disk.go
+++ b/proxmox/Internal/resource/guest/qemu/disk/terraform_disk.go
@@ -4,7 +4,7 @@ import pveAPI "github.com/Telmate/proxmox-api-go/proxmox"
 
 // nil check is done by the caller
 func terraform_Disk_QemuCdRom_unsafe(config *pveAPI.QemuCdRom, schema map[string]any) {
-	schema[schemaBackup] = true // always true to avoid diff
+	schema[schemaSize] = defaultSize // set avoid diff
 	schema[schemaISO] = terraformIsoFile(config.Iso)
 	schema[schemaPassthrough] = config.Passthrough
 	schema[schemaType] = enumCdRom
@@ -12,7 +12,7 @@ func terraform_Disk_QemuCdRom_unsafe(config *pveAPI.QemuCdRom, schema map[string
 
 // nil check is done by the caller
 func terraform_Disk_QemuCloudInit_unsafe(config *pveAPI.QemuCloudInitDisk, schema map[string]any) {
-	schema[schemaBackup] = true // always true to avoid diff
+	schema[schemaSize] = defaultSize // set to avoid diff
 	schema[schemaStorage] = config.Storage
 	schema[schemaType] = enumCloudInit
 }

--- a/proxmox/Internal/resource/guest/qemu/disk/terraform_disks.go
+++ b/proxmox/Internal/resource/guest/qemu/disk/terraform_disks.go
@@ -323,7 +323,6 @@ func terraform_Disks_QemuVirtIOStorage(config *pveAPI.QemuVirtIOStorage, schema 
 	if config == nil {
 		return nil
 	}
-	terraform_Disks_QemuCdRom(config.CdRom)
 	if config.Disk != nil {
 		mapParams := map[string]interface{}{
 			schemaAsyncIO:      string(config.Disk.AsyncIO),


### PR DESCRIPTION
Slot 4 is missing from `disk`
Removed a redundant call to parse the `cdrom`.

Closes #1124
Except for the disk size, #1124 this has been resolved by #1306 