### PR TITLE
feature/import-disk: add import_from to disk options

### DIFF
--- a/proxmox/Internal/resource/guest/qemu/disk/schema.go
+++ b/proxmox/Internal/resource/guest/qemu/disk/schema.go
@@ -30,6 +30,7 @@ const (
 	schemaFormat            string = "format"
 	schemaID                string = "id"
 	schemaIDE               string = "ide"
+	schemaImportFrom        string = "import_from"
 	schemaIOPSrBurst        string = "iops_r_burst"
 	schemaIOPSrBurstLength  string = "iops_r_burst_length"
 	schemaIOPSrConcurrent   string = "iops_r_concurrent"
@@ -97,6 +98,7 @@ func SchemaDisk() *schema.Schema {
 				schemaEmulateSSD:        {Type: schema.TypeBool, Optional: true},
 				schemaFormat:            subSchemaDiskFormat(schema.Schema{}),
 				schemaID:                subSchemaDiskId(),
+				schemaImportFrom:        {Type: schema.TypeString, Optional: true},
 				schemaIOPSrBurst:        subSchemaDiskBandwidthIopsBurst(),
 				schemaIOPSrBurstLength:  subSchemaDiskBandwidthIopsBurstLength(),
 				schemaIOPSrConcurrent:   subSchemaDiskBandwidthIopsConcurrent(),
@@ -635,6 +637,7 @@ func subSchemaIde(slot string) *schema.Schema {
 							schemaLinkedDiskId:  subSchemaLinkedDiskId(),
 							schemaReplicate:     {Type: schema.TypeBool, Optional: true},
 							schemaSerial:        subSchemaDiskSerial(),
+							schemaImportFrom:    {Type: schema.TypeString, Optional: true},
 							schemaSize:          subSchemaDiskSize(schema.Schema{Required: true}),
 							schemaStorage:       subSchemaDiskStorage(schema.Schema{Required: true}),
 							schemaWorldWideName: subSchemaDiskWWN()})}},
@@ -718,6 +721,7 @@ func subSchemaSata(slot string) *schema.Schema {
 							schemaEmulateSSD:    {Type: schema.TypeBool, Optional: true},
 							schemaFormat:        subSchemaDiskFormat(schema.Schema{Default: "raw"}),
 							schemaID:            subSchemaDiskId(),
+							schemaImportFrom:    {Type: schema.TypeString, Optional: true},
 							schemaLinkedDiskId:  subSchemaLinkedDiskId(),
 							schemaReplicate:     {Type: schema.TypeBool, Optional: true},
 							schemaSerial:        subSchemaDiskSerial(),
@@ -768,6 +772,7 @@ func subSchemaScsi(slot string) *schema.Schema {
 							schemaEmulateSSD:    {Type: schema.TypeBool, Optional: true},
 							schemaFormat:        subSchemaDiskFormat(schema.Schema{Default: "raw"}),
 							schemaID:            subSchemaDiskId(),
+							schemaImportFrom:    {Type: schema.TypeString, Optional: true},
 							schemaIOthread:      {Type: schema.TypeBool, Optional: true},
 							schemaLinkedDiskId:  subSchemaLinkedDiskId(),
 							schemaReadOnly:      {Type: schema.TypeBool, Optional: true},
@@ -820,6 +825,7 @@ func subSchemaVirtio(setting string) *schema.Schema {
 							schemaDiscard:       {Type: schema.TypeBool, Optional: true},
 							schemaFormat:        subSchemaDiskFormat(schema.Schema{Default: "raw"}),
 							schemaID:            subSchemaDiskId(),
+							schemaImportFrom:    {Type: schema.TypeString, Optional: true},
 							schemaIOthread:      {Type: schema.TypeBool, Optional: true},
 							schemaLinkedDiskId:  subSchemaLinkedDiskId(),
 							schemaReadOnly:      {Type: schema.TypeBool, Optional: true},

--- a/proxmox/Internal/resource/guest/qemu/disk/sdk_disk.go
+++ b/proxmox/Internal/resource/guest/qemu/disk/sdk_disk.go
@@ -104,6 +104,7 @@ func sdk_Disk_QemuIdeStorage(ide *pveAPI.QemuIdeStorage, schema map[string]inter
 				Discard:       schema[schemaDiscard].(bool),
 				EmulateSSD:    schema[schemaEmulateSSD].(bool),
 				Format:        default_format(schema[schemaFormat].(string)),
+				ImportFrom:    schema[schemaImportFrom].(string),
 				Replicate:     schema[schemaReplicate].(bool),
 				Serial:        pveAPI.QemuDiskSerial(schema[schemaSerial].(string)),
 				WorldWideName: pveAPI.QemuWorldWideName(schema[schemaWorldWideName].(string))}
@@ -183,6 +184,7 @@ func sdk_Disk_QemuSataStorage(sata *pveAPI.QemuSataStorage, schema map[string]in
 				Discard:       schema[schemaDiscard].(bool),
 				EmulateSSD:    schema[schemaEmulateSSD].(bool),
 				Format:        default_format(schema[schemaFormat].(string)),
+				ImportFrom:    schema[schemaImportFrom].(string),
 				Replicate:     schema[schemaReplicate].(bool),
 				Serial:        pveAPI.QemuDiskSerial(schema[schemaSerial].(string)),
 				WorldWideName: pveAPI.QemuWorldWideName(schema[schemaWorldWideName].(string))}
@@ -309,6 +311,7 @@ func sdk_Disk_QemuScsiStorage(scsi *pveAPI.QemuScsiStorage, schema map[string]in
 				EmulateSSD:    schema[schemaEmulateSSD].(bool),
 				Format:        default_format(schema[schemaFormat].(string)),
 				IOThread:      schema[schemaIOthread].(bool),
+				ImportFrom:    schema[schemaImportFrom].(string),
 				ReadOnly:      schema[schemaReadOnly].(bool),
 				Replicate:     schema[schemaReplicate].(bool),
 				Serial:        pveAPI.QemuDiskSerial(schema[schemaSerial].(string)),
@@ -369,6 +372,7 @@ func sdk_Disk_QemuVirtIOStorage(virtio *pveAPI.QemuVirtIOStorage, schema map[str
 				Discard:       schema[schemaDiscard].(bool),
 				Format:        default_format(schema[schemaFormat].(string)),
 				IOThread:      schema[schemaIOthread].(bool),
+				ImportFrom:    schema[schemaImportFrom].(string),
 				ReadOnly:      schema[schemaReadOnly].(bool),
 				Replicate:     schema[schemaReplicate].(bool),
 				Serial:        pveAPI.QemuDiskSerial(schema[schemaSerial].(string)),

--- a/proxmox/Internal/resource/guest/qemu/disk/sdk_disks.go
+++ b/proxmox/Internal/resource/guest/qemu/disk/sdk_disks.go
@@ -82,6 +82,7 @@ func sdk_Disks_QemuIdeStorage(key string, schema map[string]any) *pveAPI.QemuIde
 			Discard:         diskMap[schemaDiscard].(bool),
 			EmulateSSD:      diskMap[schemaEmulateSSD].(bool),
 			Format:          pveAPI.QemuDiskFormat(diskMap[schemaFormat].(string)),
+			ImportFrom:      diskMap[schemaImportFrom].(string),
 			Replicate:       diskMap[schemaReplicate].(bool),
 			SizeInKibibytes: pveAPI.QemuDiskSize(convert_SizeStringToKibibytes_Unsafe(diskMap[schemaSize].(string))),
 			Storage:         diskMap[schemaStorage].(string)}
@@ -171,6 +172,7 @@ func sdk_Disks_QemuSataStorage(key string, schema map[string]any) *pveAPI.QemuSa
 			Discard:         diskMap[schemaDiscard].(bool),
 			EmulateSSD:      diskMap[schemaEmulateSSD].(bool),
 			Format:          pveAPI.QemuDiskFormat(diskMap[schemaFormat].(string)),
+			ImportFrom:      diskMap[schemaImportFrom].(string),
 			Replicate:       diskMap[schemaReplicate].(bool),
 			SizeInKibibytes: pveAPI.QemuDiskSize(convert_SizeStringToKibibytes_Unsafe(diskMap[schemaSize].(string))),
 			Storage:         diskMap[schemaStorage].(string)}
@@ -310,6 +312,7 @@ func sdk_Disks_QemuScsiStorage(key string, schema map[string]any) *pveAPI.QemuSc
 			Discard:         diskMap[schemaDiscard].(bool),
 			EmulateSSD:      diskMap[schemaEmulateSSD].(bool),
 			Format:          pveAPI.QemuDiskFormat(diskMap[schemaFormat].(string)),
+			ImportFrom:      diskMap[schemaImportFrom].(string),
 			IOThread:        diskMap[schemaIOthread].(bool),
 			ReadOnly:        diskMap[schemaReadOnly].(bool),
 			Replicate:       diskMap[schemaReplicate].(bool),
@@ -422,6 +425,7 @@ func sdk_Disks_QemuVirtIOStorage(key string, schema map[string]any) *pveAPI.Qemu
 			Bandwidth:       sdk_Disks_QemuDiskBandwidth(diskMap),
 			Discard:         diskMap[schemaDiscard].(bool),
 			Format:          pveAPI.QemuDiskFormat(diskMap[schemaFormat].(string)),
+			ImportFrom:      diskMap[schemaImportFrom].(string),
 			IOThread:        diskMap[schemaIOthread].(bool),
 			ReadOnly:        diskMap[schemaReadOnly].(bool),
 			Replicate:       diskMap[schemaReplicate].(bool),


### PR DESCRIPTION
This PR will resolve https://github.com/Telmate/terraform-provider-proxmox/issues/1236.

The option ìmport_from` was added in https://github.com/Telmate/terraform-provider-proxmox/pull/606 but never made the cut to the version `3.x.x` updates made to the provider. 

Simply adding the option to the SDK (which added that feature with https://github.com/Telmate/proxmox-api-go/pull/412) will create the disks.

However the size of the disk will not be changed, even if a different size than the imported disk is desired. 
A second `plan` will show that the sizes need to be changed (and `applied`) again.

There are still open points to be done here:
- [ ] ignore `import_from` for present disks, as proxmox doesn't save this option and won't return it either. It is only used for disk creation.
- [ ] let the TF provider resize the disk after creation so the state fits the planned resources.