### PR TITLE
fix(doc): use single quotes for PM_API_TOKEN_ID env var

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -69,7 +69,8 @@ provider "proxmox" {
 ## Creating the connection via username and API token
 
 ```bash
-export PM_API_TOKEN_ID="terraform-prov@pve!mytoken"
+# use single quotes for the API token ID because of the exclamation mark
+export PM_API_TOKEN_ID='terraform-prov@pve!mytoken'
 export PM_API_TOKEN_SECRET="afcd8f45-acc1-4d0f-bb12-a70b0777ec11"
 ```
 


### PR DESCRIPTION
Ran into some problems with the docs because of the exclamation mark in bash. 

Works for me when using single quotes. So I thought I'll send a quick patch.