### PR TITLE
Fix: Remove VM.Monitor from required permissions for Proxmox 9 compatibility

### DIFF
--- a/proxmox/provider.go
+++ b/proxmox/provider.go
@@ -254,7 +254,6 @@ func providerConfigure(d *schema.ResourceData) (any, error) {
 		"VM.Config.Network",
 		"VM.Config.Options",
 		"VM.Migrate",
-		"VM.Monitor",
 		"VM.PowerMgmt",
 	}
 	if v, ok := d.GetOk(schemaMinimumPermissionList); ok {


### PR DESCRIPTION
## Problem

The `VM.Monitor` permission is causing authentication failures with Proxmox VE 9.x, as users may not have it granted by default. This prevents the Terraform provider from working with standard user permissions.

---

## Solution

Remove `VM.Monitor` from the minimum required permission list in `proxmox/provider.go`, as it is not essential for basic VM operations like:

* VM creation
* Configuration changes
* Power management
* Network/disk management

This aligns with Proxmox VE 9.x changes, where `VM.Monitor` was replaced with `Sys.Audit` for KVM monitor access (https://pve.proxmox.com/wiki/Roadmap at `Drop the VM.Monitor privilege and instead require the Sys.Audit privilege for basic access to the KVM monitor.
`).

---

## Testing

* ✅ Tested with Proxmox VE 9.x
* ✅ VM creation and configuration work correctly without `VM.Monitor`
* ✅ All existing functionality preserved
* ✅ Terraform plan/apply operations succeed

---

## Changes

* Removed `"VM.Monitor"` from the `minimumPermissionList` array
* Ensures compatibility with more restrictive permission setups in Proxmox 9.x

This update maintains backward compatibility while aligning with the new permission model in Proxmox VE 9.x.