### PR TITLE
Update Proxmox 9 privileges in documentation

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -21,6 +21,8 @@ pveum user add terraform-prov@pve --password <password>
 pveum aclmod / -user terraform-prov@pve -role TerraformProv
 ```
 
+Promox 9 : Remove `VM.Monitor` from the "privs" line.
+
 After the role is in use, if there is a need to modify the privileges, simply issue the command showed, adding or
 removing privileges as needed.
 


### PR DESCRIPTION
Hi, 

Privilege `VM.Monitor` has been drop in proxmox 9. According to https://github.com/Telmate/terraform-provider-proxmox/pull/1382 here is just a fix for Documentation. 

see https://pve.proxmox.com/wiki/Roadmap#:~:text=Drop%20the-,VM.Monitor,-privilege%20and%20instead%20require%20the