### PR TITLE
Update cloud-init getting started docs

### DIFF
--- a/docs/guides/cloud-init getting started.md
+++ b/docs/guides/cloud-init getting started.md
@@ -125,7 +125,7 @@ terraform {
   required_providers {
     proxmox = {
       source = "Telmate/proxmox"
-      version = ">=3.0.1rc4"
+      version = "3.0.1rc4"
     }
   }
 }


### PR DESCRIPTION
This change fixes a bug in the Terraform code snippet. Terraform follows semver rules and its version constraints only allows pre-release versions with `=` operator.

ref: https://developer.hashicorp.com/terraform/language/expressions/version-constraints#specify-a-pre-release-version