### PR TITLE
Feat: error when `automatic_reboot` = false

### DIFF
--- a/proxmox/Internal/resource/guest/reboot/diag.go
+++ b/proxmox/Internal/resource/guest/reboot/diag.go
@@ -1,0 +1,18 @@
+package reboot
+
+import "github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+
+func ErrorLxc() diag.Diagnostic {
+	return errorMSG("LXC")
+}
+
+func ErrorQemu() diag.Diagnostic {
+	return errorMSG("QEMU")
+}
+
+func errorMSG(guest string) diag.Diagnostic {
+	return diag.Diagnostic{
+		Summary:  "the " + guest + " guest needs to be rebooted and `" + Root + " = false`.",
+		Detail:   "the " + guest + " guest needs to be rebooted for the changes to take effect. Set `" + Root + " = true` to allow the provider to reboot the guest.",
+		Severity: diag.Error}
+}

--- a/proxmox/Internal/resource/guest/reboot/schema.go
+++ b/proxmox/Internal/resource/guest/reboot/schema.go
@@ -1,0 +1,17 @@
+package reboot
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+const (
+	Root = "automatic_reboot"
+)
+
+func Schema() *schema.Schema {
+	return &schema.Schema{
+		Type:        schema.TypeBool,
+		Description: "Automatically reboot the guest system if any of the modified parameters requires a reboot to take effect.",
+		Optional:    true,
+		Default:     true}
+}

--- a/proxmox/Internal/resource/guest/reboot/sdk.go
+++ b/proxmox/Internal/resource/guest/reboot/sdk.go
@@ -1,0 +1,9 @@
+package reboot
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func SDK(d *schema.ResourceData) bool {
+	return d.Get(Root).(bool)
+}


### PR DESCRIPTION
Change the behavior of `automatic_reboot` to give an error instead of a warning when we can't reboot, as the task we asked of Terraform could not be completed.

Removes the hard-coded reboot triggers in favor of letting the SDK handle it. For cloud-init setting we will trigger a reboot manually.

Closes #1393