### PR TITLE
Fix: Trying to create two VMs with identical names causes only one VM to be created, while tfstate thinks both exist

### DIFF
--- a/proxmox/Internal/resource/guest/vmid/get.go
+++ b/proxmox/Internal/resource/guest/vmid/get.go
@@ -1,0 +1,10 @@
+package vmid
+
+import (
+	pveSDK "github.com/Telmate/proxmox-api-go/proxmox"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func Get(d *schema.ResourceData) pveSDK.GuestID {
+	return pveSDK.GuestID(d.Get(Root).(int))
+}

--- a/proxmox/Internal/resource/id/guest.go
+++ b/proxmox/Internal/resource/id/guest.go
@@ -1,0 +1,46 @@
+package id
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+
+	pveSDK "github.com/Telmate/proxmox-api-go/proxmox"
+)
+
+const (
+	GuestLxc  = "lxc"
+	GuestQemu = "qemu"
+)
+
+type Guest struct {
+	ID   pveSDK.GuestID
+	Node pveSDK.NodeName
+	Type string
+}
+
+func (g *Guest) Parse(resourceID string) error {
+	idParts := strings.Split(resourceID, "/")
+	if len(idParts) != 3 {
+		return errors.New("failed to get resource format: '" + resourceID + "'. Must be <node>/<type>/<vmid>")
+	}
+	if idParts[0] == "" {
+		return errors.New("failed to get node name: '" + idParts[0] + "'")
+	}
+	g.Node = pveSDK.NodeName(idParts[0])
+	if idParts[1] != GuestLxc && idParts[1] != GuestQemu {
+		return errors.New("failed to get guest type: '" + idParts[1] + "'. Must be 'lxc' or 'qemu'")
+	}
+	g.Type = idParts[1]
+	tmpID, err := strconv.Atoi(idParts[2])
+	if err != nil {
+		return fmt.Errorf("failed to get vmid: '%s'. Must be an integer", idParts[2])
+	}
+	g.ID = pveSDK.GuestID(tmpID)
+	return nil
+}
+
+func (g Guest) String() string {
+	return g.Node.String() + "/" + g.Type + "/" + g.ID.String()
+}

--- a/proxmox/provider.go
+++ b/proxmox/provider.go
@@ -7,7 +7,6 @@ import (
 	"net/url"
 	"os"
 	"sort"
-	"strconv"
 	"strings"
 	"sync"
 
@@ -425,29 +424,6 @@ func pmParallelBegin(pconf *providerConfiguration) *pmApiLockHolder {
 	}
 	lock.lock()
 	return lock
-}
-
-func resourceId(targetNode pveSDK.NodeName, resType string, guestID pveSDK.GuestID) string {
-	return fmt.Sprintf("%s/%s/%d", targetNode.String(), resType, guestID)
-}
-
-func parseResourceId(resId string) (targetNode string, resType string, guestID pveSDK.GuestID, err error) {
-	// create a logger for this function
-	logger, _ := CreateSubLogger("parseResourceId")
-
-	if !rxRsId.MatchString(resId) {
-		return "", "", 0, fmt.Errorf("invalid resource format: %s. Must be <node>/<type>/<vmid>", resId)
-	}
-	idMatch := rxRsId.FindStringSubmatch(resId)
-	targetNode = idMatch[1]
-	resType = idMatch[2]
-	var tmpID int
-	tmpID, err = strconv.Atoi(idMatch[3])
-	if err != nil {
-		logger.Info().Str("error", err.Error()).Msgf("failed to get vmId")
-	}
-	guestID = pveSDK.GuestID(tmpID)
-	return
 }
 
 func clusterResourceId(resType string, resId string) string {

--- a/proxmox/resource_lxc_disk.go
+++ b/proxmox/resource_lxc_disk.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	pveSDK "github.com/Telmate/proxmox-api-go/proxmox"
+	"github.com/Telmate/terraform-provider-proxmox/v2/proxmox/Internal/resource/id"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -116,13 +117,14 @@ func resourceLxcDiskCreate(ctx context.Context, d *schema.ResourceData, meta int
 	lock := pmParallelBegin(pconf)
 	defer lock.unlock()
 
-	_, _, vmID, err := parseResourceId(d.Get("container").(string))
+	var resourceID id.Guest
+	err := resourceID.Parse(d.Get("container").(string))
 	if err != nil {
 		return diag.FromErr(err)
 	}
 
 	client := pconf.Client
-	vmr := pveSDK.NewVmRef(vmID)
+	vmr := pveSDK.NewVmRef(resourceID.ID)
 	vmr.SetVmType(pveSDK.GuestLxc)
 	_, err = client.GetVmInfo(ctx, vmr)
 	if err != nil {
@@ -161,12 +163,13 @@ func resourceLxcDiskUpdate(ctx context.Context, d *schema.ResourceData, meta int
 
 	client := pconf.Client
 
-	_, _, vmID, err := parseResourceId(d.Get("container").(string))
+	var resourceID id.Guest
+	err := resourceID.Parse(d.Get("container").(string))
 	if err != nil {
 		return diag.FromErr(err)
 	}
 
-	vmr := pveSDK.NewVmRef(vmID)
+	vmr := pveSDK.NewVmRef(resourceID.ID)
 	_, err = client.GetVmInfo(ctx, vmr)
 	if err != nil {
 		return diag.FromErr(err)
@@ -196,12 +199,13 @@ func _resourceLxcDiskRead(ctx context.Context, d *schema.ResourceData, meta inte
 	pconf := meta.(*providerConfiguration)
 	client := pconf.Client
 
-	_, _, vmID, err := parseResourceId(d.Get("container").(string))
+	var resourceID id.Guest
+	err := resourceID.Parse(d.Get("container").(string))
 	if err != nil {
 		return err
 	}
 
-	vmr := pveSDK.NewVmRef(vmID)
+	vmr := pveSDK.NewVmRef(resourceID.ID)
 	_, err = client.GetVmInfo(ctx, vmr)
 	if err != nil {
 		return err
@@ -238,13 +242,14 @@ func resourceLxcDiskDelete(ctx context.Context, d *schema.ResourceData, meta int
 	lock := pmParallelBegin(pconf)
 	defer lock.unlock()
 
-	_, _, vmID, err := parseResourceId(d.Get("container").(string))
+	var resourceID id.Guest
+	err := resourceID.Parse(d.Get("container").(string))
 	if err != nil {
 		return diag.FromErr(err)
 	}
 
 	client := pconf.Client
-	vmr := pveSDK.NewVmRef(vmID)
+	vmr := pveSDK.NewVmRef(resourceID.ID)
 	_, err = client.GetVmInfo(ctx, vmr)
 	if err != nil {
 		return diag.FromErr(err)

--- a/proxmox/resource_vm_qemu.go
+++ b/proxmox/resource_vm_qemu.go
@@ -634,7 +634,7 @@ func resourceVmQemuCreate(ctx context.Context, d *schema.ResourceData, meta inte
 		config.Node = &targetNode
 
 		var guestID *pveSDK.GuestID
-		if newID := pveSDK.GuestID(d.Get(vmID.Root).(int)); newID != 0 {
+		if newID := vmID.Get(d); newID != 0 {
 			guestID = &newID
 		}
 

--- a/proxmox/resource_vm_qemu.go
+++ b/proxmox/resource_vm_qemu.go
@@ -38,6 +38,7 @@ import (
 	"github.com/Telmate/terraform-provider-proxmox/v2/proxmox/Internal/resource/guest/sshkeys"
 	"github.com/Telmate/terraform-provider-proxmox/v2/proxmox/Internal/resource/guest/tags"
 	vmID "github.com/Telmate/terraform-provider-proxmox/v2/proxmox/Internal/resource/guest/vmid"
+	"github.com/Telmate/terraform-provider-proxmox/v2/proxmox/Internal/resource/id"
 	"github.com/Telmate/terraform-provider-proxmox/v2/proxmox/Internal/util"
 )
 
@@ -679,7 +680,10 @@ func resourceVmQemuCreate(ctx context.Context, d *schema.ResourceData, meta inte
 			rebootRequired, err = config.Update(ctx, false, vmr, client)
 			if err != nil {
 				// Set the id because when update config fail the vm is still created
-				d.SetId(resourceId(targetNode, "qemu", vmr.VmId()))
+				d.SetId(id.Guest{
+					ID:   vmr.VmId(),
+					Node: targetNode,
+					Type: id.GuestQemu}.String())
 				return append(diags, diag.FromErr(err)...)
 			}
 
@@ -731,12 +735,18 @@ func resourceVmQemuCreate(ctx context.Context, d *schema.ResourceData, meta inte
 		rebootRequired, err = config.Update(ctx, false, vmr, client)
 		if err != nil {
 			// Set the id because when update config fail the vm is still created
-			d.SetId(resourceId(targetNode, "qemu", vmr.VmId()))
+			d.SetId(id.Guest{
+				ID:   vmr.VmId(),
+				Node: targetNode,
+				Type: id.GuestQemu}.String())
 			return append(diags, diag.FromErr(err)...)
 		}
 
 	}
-	d.SetId(resourceId(vmr.Node(), "qemu", vmr.VmId()))
+	d.SetId(id.Guest{
+		ID:   vmr.VmId(),
+		Node: vmr.Node(),
+		Type: id.GuestQemu}.String())
 	logger.Debug().Int(vmID.Root, int(vmr.VmId())).Msgf("Set this vm (resource Id) to '%v'", d.Id())
 
 	// give sometime to proxmox to catchup
@@ -775,14 +785,15 @@ func resourceVmQemuUpdate(ctx context.Context, d *schema.ResourceData, meta inte
 	logger, _ := CreateSubLogger("resource_vm_update")
 
 	// get vmID
-	_, _, guestID, err := parseResourceId(d.Id())
+	var resourceID id.Guest
+	err := resourceID.Parse(d.Id())
 	if err != nil {
 		return diag.FromErr(err)
 	}
 
-	logger.Info().Int(vmID.Root, int(guestID)).Msg("Starting update of the VM resource")
+	logger.Info().Int(vmID.Root, int(resourceID.ID)).Msg("Starting update of the VM resource")
 
-	vmr := pveSDK.NewVmRef(guestID)
+	vmr := pveSDK.NewVmRef(resourceID.ID)
 	_, err = client.GetVmInfo(ctx, vmr)
 	if err != nil {
 		return diag.FromErr(err)
@@ -851,7 +862,7 @@ func resourceVmQemuUpdate(ctx context.Context, d *schema.ResourceData, meta inte
 		return diags
 	}
 
-	logger.Debug().Int(vmID.Root, int(guestID)).Msgf("Updating VM with the following configuration: %+v", config)
+	logger.Debug().Int(vmID.Root, int(resourceID.ID)).Msgf("Updating VM with the following configuration: %+v", config)
 
 	var rebootRequired bool
 	automaticReboot := reboot.GetAutomatic(d)
@@ -938,11 +949,12 @@ func resourceVmQemuRead(ctx context.Context, d *schema.ResourceData, meta interf
 	var diags diag.Diagnostics
 	logger, _ := CreateSubLogger("resource_vm_read")
 
-	_, _, guestID, err := parseResourceId(d.Id())
+	var resourceID id.Guest
+	err := resourceID.Parse(d.Id())
 	if err != nil {
-		d.SetId("")
 		return diag.FromErr(fmt.Errorf("unexpected error when trying to read and parse the resource: %v", err))
 	}
+	guestID := resourceID.ID
 
 	logger.Info().Int(vmID.Root, int(guestID)).Msg("Reading configuration for vmid")
 	vmr := pveSDK.NewVmRef(guestID)
@@ -1009,7 +1021,11 @@ func resourceVmQemuRead(ctx context.Context, d *schema.ResourceData, meta interf
 
 	logger.Debug().Int(vmID.Root, int(guestID)).Msgf("[READ] Received Config from Proxmox API: %+v", config)
 
-	d.SetId(resourceId(vmr.Node(), "qemu", vmr.VmId()))
+	d.SetId(id.Guest{
+		ID:   vmr.VmId(),
+		Node: vmr.Node(),
+		Type: id.GuestQemu}.String())
+
 	vmID.Terraform(vmr.VmId(), d)
 	name.Terraform_Unsafe(config.Name, d)
 	description.Terraform(config.Description, true, d)

--- a/proxmox/util.go
+++ b/proxmox/util.go
@@ -17,8 +17,6 @@ import (
 
 const defaultDescription = "Managed by Terraform."
 
-var rxRsId = regexp.MustCompile(`([^/]+)/([^/]+)/(\d+)`)
-
 var rxClusterRsId = regexp.MustCompile(`([^/]+)/([^/]+)`)
 
 var machineModelsRegex = regexp.MustCompile(`(^pc|^q35|^virt)`)


### PR DESCRIPTION
Fixes #1395 by using the guestID as main identifier instead of the name (thought we removed all the code that did this already).

Refactored the guest resource ID.