### PR TITLE
docs: use description instead of deprecated desc attribute in proxmox_vm_qemu examples

### DIFF
--- a/docs/examples/cloudinit_example.tf
+++ b/docs/examples/cloudinit_example.tf
@@ -8,7 +8,7 @@ provider "proxmox" {
 
 resource "proxmox_vm_qemu" "cloudinit-test" {
     name = "terraform-test-vm"
-    desc = "A test for using terraform and cloudinit"
+    description = "A test for using terraform and cloudinit"
 
     # Node name has to be the same name as within the cluster
     # this might not include the FQDN

--- a/docs/examples/pxe_example.tf
+++ b/docs/examples/pxe_example.tf
@@ -18,7 +18,7 @@ provider "proxmox" {
 
 resource "proxmox_vm_qemu" "pxe-example" {
     name                      = "pxe-example"
-    desc                      = "A test VM for PXE boot mode."
+    description               = "A test VM for PXE boot mode."
 # PXE option enables the network boot feature
     pxe                       = true
 # unless your PXE installed system includes the Agent in the installed

--- a/docs/examples/vagrant_example.tf
+++ b/docs/examples/vagrant_example.tf
@@ -16,7 +16,7 @@ provider "proxmox" {
 }
 
 resource "proxmox_vm_qemu" "example" {
-    name = "servy-mcserverface"
-    desc = "A test for using terraform and vagrant"
+    name        = "servy-mcserverface"
+    description = "A test for using terraform and vagrant"
     target_node = "pve"
 }

--- a/docs/guides/cloud_init.md
+++ b/docs/guides/cloud_init.md
@@ -57,7 +57,7 @@ main.tf:
 /* Uses Cloud-Init options from Proxmox 5.2 */
 resource "proxmox_vm_qemu" "cloudinit-test" {
   name        = "tftest1.xyz.com"
-  desc        = "tf description"
+  description = "tf description"
   target_node = "proxmox1-xx"
 
   clone = "ci-ubuntu-template"
@@ -124,7 +124,7 @@ resource "proxmox_vm_qemu" "cloudinit-test" {
   ]
 
   name        = "tftest1.xyz.com"
-  desc        = "tf description"
+  description = "tf description"
   target_node = "proxmox1-xx"
 
   clone = "ci-ubuntu-template"
@@ -177,7 +177,7 @@ EOF
 /* Uses custom eth1 user-net SSH portforward */
 resource "proxmox_vm_qemu" "preprovision-test" {
   name        = "tftest1.xyz.com"
-  desc        = "tf description"
+  description = "tf description"
   target_node = "proxmox1-xx"
 
   clone = "terraform-ubuntu1404-template"

--- a/docs/resources/vm_qemu.md
+++ b/docs/resources/vm_qemu.md
@@ -95,7 +95,7 @@ The following arguments are supported in the top level resource block.
 | `target_node`                 | `str`    |                      | The name of the PVE Node on which to place the VM.|
 | `target_nodes`                | `str`    |                      | A list of PVE node names on which to place the VM.|
 | `vmid`                        | `int`    |                      | The ID of the VM in Proxmox. When unset it should use the next available ID in the sequence. |
-| `desc`                        | `str`    |                      | The description of the VM. Shows as the 'Notes' field in the Proxmox GUI. |
+| `description`                 | `str`    |                      | The description of the VM. Shows as the 'Notes' field in the Proxmox GUI. |
 | `define_connection_info`      | `bool`   | `true`               | Whether to let terraform define the (SSH) connection parameters for preprovisioners, see config block below. |
 | `bios`                        | `str`    | `"seabios"`          | The BIOS to use, options are `seabios` or `ovmf` for UEFI. |
 | `onboot`                      | `bool`   | `false`              | Whether to have the VM startup after the PVE node starts. |


### PR DESCRIPTION
Replaces all occurrences of `desc` by `description` in the examples

fixes #1421 
