### PR TITLE
fix: ID not cleared when guest deleted from gui

### DIFF
--- a/proxmox/diag_warnigns.go
+++ b/proxmox/diag_warnigns.go
@@ -1,0 +1,14 @@
+package proxmox
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func resourceDriftDeletionDiagnostic(d *schema.ResourceData) diag.Diagnostic {
+	id := d.Id()
+	d.SetId("")
+	return diag.Diagnostic{
+		Summary:  "State drift detected: Resource (" + id + ") was deleted outside Terraform",
+		Severity: diag.Warning}
+}

--- a/proxmox/resource_lxc.go
+++ b/proxmox/resource_lxc.go
@@ -816,8 +816,7 @@ func resourceLxcReadWithLock(ctx context.Context, d *schema.ResourceData, meta a
 		return append(diags, diag.FromErr(err)...)
 	}
 	if !ok {
-		d.SetId("")
-		return diags
+		return append(diags, resourceDriftDeletionDiagnostic(d))
 	}
 	vmr := pveSDK.NewVmRef(resourceID.ID)
 	if err := client.CheckVmRef(ctx, vmr); err != nil {

--- a/proxmox/resource_lxc_guest.go
+++ b/proxmox/resource_lxc_guest.go
@@ -243,8 +243,7 @@ func resourceLxcGuestReadWithLock(ctx context.Context, d *schema.ResourceData, m
 		return append(diags, diag.FromErr(err)...)
 	}
 	if !ok {
-		d.SetId("")
-		return diags
+		return append(diags, resourceDriftDeletionDiagnostic(d))
 	}
 
 	vmr := pveSDK.NewVmRef(resourceID.ID)

--- a/proxmox/resource_vm_qemu.go
+++ b/proxmox/resource_vm_qemu.go
@@ -967,8 +967,7 @@ func resourceVmQemuReadWithLock(ctx context.Context, d *schema.ResourceData, met
 		return append(diags, diag.FromErr(err)...)
 	}
 	if !ok {
-		d.SetId("")
-		return diags
+		return append(diags, resourceDriftDeletionDiagnostic(d))
 	}
 
 	vmr := pveSDK.NewVmRef(resourceID.ID)


### PR DESCRIPTION
When the guest is removed outside of Terrafrom we get an error when trying to read the deleted guest.
We now clear the ID marking the guest as removed in Terraform.
This way the Guest can automatically be created on the next run.

Resolves #1458
