### PR TITLE
feat: add socks proxy support

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -104,7 +104,7 @@ provider "proxmox" {
 ## Enable proxy server support
 
 You can send all api calls from the provider api client to a proxy server rather than directly to proxmox itself. This
-can make debugging easier. A nice proxy server is mitmproxy.
+can make debugging easier. A nice proxy server is mitmproxy. SOCKS proxies are supported via `socks5://`.
 
 ```hcl
 provider "proxmox" {
@@ -131,7 +131,7 @@ The following arguments are supported in the provider block:
 | `pm_log_file`                |                      | `string` | `terraform-plugin-proxmox.log` | The log file the provider will write logs to.|
 | `pm_timeout`                 |                      | `uint`   | `300`                          | Timeout value (seconds) for proxmox API calls.|
 | `pm_debug`                   |                      | `bool`   | `false`                        | Enable verbose output in proxmox-api-go.|
-| `pm_proxy_server`            |                      | `string` |                                | Send provider api call to a proxy server for easy debugging.|
+| `pm_proxy_server`            |                      | `string` |                                | Send provider api call to a proxy server for easy debugging. Supports `http://` and `socks5://`.|
 | `pm_minimum_permission_check`|                      | `bool`   | `true`                         | Enable minimum permission check. This will check if the user has the minimum permissions required to use the provider.|
 | `pm_minimum_permission_list` |                      | `list`   |                                | A list of permissions to check. Allows overwriting of the default permissions.|
 

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.37.0
 	github.com/rs/zerolog v1.34.0
 	github.com/stretchr/testify v1.11.1
+	golang.org/x/net v0.40.0
 )
 
 require (
@@ -61,7 +62,6 @@ require (
 	github.com/zclconf/go-cty v1.16.3 // indirect
 	golang.org/x/crypto v0.39.0 // indirect
 	golang.org/x/mod v0.25.0 // indirect
-	golang.org/x/net v0.40.0 // indirect
 	golang.org/x/sys v0.33.0 // indirect
 	golang.org/x/text v0.26.0 // indirect
 	google.golang.org/appengine v1.6.8 // indirect


### PR DESCRIPTION
  ## Summary
  - Add SOCKS5/SOCKS5H proxy support for `pm_proxy_server`  to enable SSH tunneling workflows by building a custom HTTP client with a SOCKS dialer.
  - Keep HTTP/HTTPS proxy behavior unchanged.
  - Update provider docs to mention `socks5://` usage.
  - Promote `golang.org/x/net` to a direct dependency for SOCKS support.

  ## Notes
  - Proxy URL is validated and unsupported schemes return a clear error.

  ## Testing
  - Tested working in our environment