### PR TITLE
fix: read hagroup value from Proxmox

### DIFF
--- a/proxmox/resource_vm_qemu.go
+++ b/proxmox/resource_vm_qemu.go
@@ -1027,6 +1027,9 @@ func resourceVmQemuRead(ctx context.Context, d *schema.ResourceData, vmr *pveSDK
 
 	logger.Debug().Int(vmID.Root, int(vmr.VmId())).Msgf("[READ] Received Config from Proxmox API: %+v", config)
 
+	// NewActiveRawConfigQemuFromApi do not call ReadVMHA() so hagroup is not populated yet
+	client.ReadVMHA(ctx, vmr)
+
 	d.SetId(id.Guest{
 		ID:   vmr.VmId(),
 		Node: vmr.Node(),


### PR DESCRIPTION
In the #1400 the call to `NewConfigQemuFromApi`  was replaced by call to  `NewActiveRawConfigQemuFromApi`, but `ReadVMHA` is never called from  `NewActiveRawConfigQemuFromApi`, so `hagroup` is never populated and the provider always tries to set the HA group to the configured value.

This change restores `ReadVMHA`  call before populating `hagroup` from `vmr`. I'm not sure whether it would be better to add `ReadVMHA` to `NewActiveRawConfigQemuFromApi` itself instead.