### PR TITLE
fix: `rate` network value should be MBps

### DIFF
--- a/proxmox/Internal/resource/guest/qemu/network/sdk.go
+++ b/proxmox/Internal/resource/guest/qemu/network/sdk.go
@@ -56,7 +56,7 @@ func SDK(d *schema.ResourceData) (pveAPI.QemuNetworkInterfaces, diag.Diagnostics
 			NativeVlan:    util.Pointer(pveAPI.Vlan(networkMap[schemaNativeVlan].(int))),
 			Model:         util.Pointer(model),
 			MultiQueue:    util.Pointer(pveAPI.QemuNetworkQueue(networkMap[schemaQueues].(int))),
-			RateLimitKBps: util.Pointer(pveAPI.GuestNetworkRate(rate))}
+			RateLimitKBps: util.Pointer(pveAPI.GuestNetworkRate(rate * 1000))}
 	}
 	return networks, diags
 }

--- a/proxmox/Internal/resource/guest/qemu/network/terraform.go
+++ b/proxmox/Internal/resource/guest/qemu/network/terraform.go
@@ -48,7 +48,7 @@ func Terraform(config pveAPI.QemuNetworkInterfaces, d *schema.ResourceData) {
 			params[schemaQueues] = int(*v.MultiQueue)
 		}
 		if v.RateLimitKBps != nil {
-			params[schemaRate] = int(*v.RateLimitKBps * 1000)
+			params[schemaRate] = int(*v.RateLimitKBps / 1000)
 		}
 		if v.NativeVlan != nil {
 			params[schemaNativeVlan] = int(*v.NativeVlan)


### PR DESCRIPTION
After upgrading from v2 to v3 I noticed that provider reports strange diffs for the rate limit of my VMs, for example:

```
~ rate = 768000000 -> 768
```

Here `768` is the value I configured, and  the `768000000` on the left looks wrong. According to the docs, the `rate` value must be specified in MBps.
