### PR TITLE
Change node to target_node in LXC guest resource

### DIFF
--- a/docs/resources/lxc_guest.md
+++ b/docs/resources/lxc_guest.md
@@ -8,7 +8,7 @@ To get up and running this is a minimal example:
 resource "proxmox_lxc_guest" "minimal-example" {
     name         = "minimal-example"
     power_state  = "running"
-    node         = "pve-1"
+    target_node  = "pve-1"
     unprivileged = true
     password     = "yourpassword"
     template {


### PR DESCRIPTION
Update to documentation instead of using node to be target_node for lxc_guest resource