### PR TITLE
feat: add proxmox_node_status data source

### DIFF
--- a/proxmox/data_node_status.go
+++ b/proxmox/data_node_status.go
@@ -1,0 +1,140 @@
+package proxmox
+
+import (
+	"context"
+	"fmt"
+
+	pveSDK "github.com/Telmate/proxmox-api-go/proxmox"
+	"github.com/hashicorp/go-cty/cty"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func DataNodeStatus() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataReadNodeStatus,
+		Schema: map[string]*schema.Schema{
+			"node": {
+				Type:     schema.TypeString,
+				Required: true,
+				ValidateDiagFunc: func(i interface{}, path cty.Path) diag.Diagnostics {
+					v, ok := i.(string)
+					if !ok {
+						return diag.Diagnostics{diag.Diagnostic{
+							Severity:      diag.Error,
+							Summary:       "Invalid node",
+							Detail:        "node must be a string",
+							AttributePath: path,
+						}}
+					}
+					if err := pveSDK.NodeName(v).Validate(); err != nil {
+						return diag.Diagnostics{diag.Diagnostic{
+							Severity:      diag.Error,
+							Summary:       "Invalid node",
+							Detail:        err.Error(),
+							AttributePath: path,
+						}}
+					}
+					return nil
+				},
+			},
+			"status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"maintenance": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"uptime": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"cpu": {
+				Type:     schema.TypeFloat,
+				Computed: true,
+			},
+			"mem_used": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"mem_total": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataReadNodeStatus(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	pconf := meta.(*providerConfiguration)
+	lock := pmParallelBegin(pconf)
+	defer lock.unlock()
+
+	client := pconf.Client
+	nodeName := data.Get("node").(string)
+
+	nodes, err := client.GetNodeList(ctx)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	nodeData, ok := nodes["data"]
+	if !ok {
+		return diag.Errorf("unexpected response from Proxmox API: missing 'data' key in node list")
+	}
+
+	nodeList, ok := nodeData.([]interface{})
+	if !ok {
+		return diag.Errorf("unexpected response from Proxmox API: 'data' is not a list")
+	}
+
+	var foundNode map[string]interface{}
+	for _, n := range nodeList {
+		entry, ok := n.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		name, ok := entry["node"].(string)
+		if !ok {
+			continue
+		}
+		if name == nodeName {
+			foundNode = entry
+			break
+		}
+	}
+
+	if foundNode == nil {
+		return diag.Errorf("node %q not found in Proxmox cluster", nodeName)
+	}
+
+	status, _ := foundNode["status"].(string)
+
+	// maintenance is absent for normal nodes; Proxmox sends numeric 1 when set.
+	var maintenance bool
+	if rawMaint, exists := foundNode["maintenance"]; exists {
+		switch v := rawMaint.(type) {
+		case bool:
+			maintenance = v
+		case float64:
+			maintenance = v != 0
+		}
+	}
+
+	// JSON numbers decode as float64; cast to int for whole-number fields.
+	uptime, _ := foundNode["uptime"].(float64)
+	cpu, _ := foundNode["cpu"].(float64)
+	memUsed, _ := foundNode["mem"].(float64)
+	memTotal, _ := foundNode["maxmem"].(float64)
+
+	data.SetId(fmt.Sprintf("node/%s", nodeName))
+	_ = data.Set("status", status)
+	_ = data.Set("maintenance", maintenance)
+	_ = data.Set("uptime", int(uptime))
+	_ = data.Set("cpu", cpu)
+	_ = data.Set("mem_used", int(memUsed))
+	_ = data.Set("mem_total", int(memTotal))
+
+	return nil
+}

--- a/proxmox/provider.go
+++ b/proxmox/provider.go
@@ -215,7 +215,8 @@ func Provider() *schema.Provider {
 		},
 
 		DataSourcesMap: map[string]*schema.Resource{
-			"proxmox_ha_groups": DataHAGroup(),
+			"proxmox_ha_groups":   DataHAGroup(),
+			"proxmox_node_status": DataNodeStatus(),
 		},
 
 		ConfigureFunc: providerConfigure,


### PR DESCRIPTION
## Summary

- Adds a new `proxmox_node_status` data source that queries the Proxmox `/nodes` API endpoint
- Exposes whether a node is in HA maintenance mode via the `maintenance` boolean attribute
- Also surfaces `status`, `uptime`, `cpu`, `mem_used`, and `mem_total` for convenience

## Motivation

The primary use case is **excluding nodes in maintenance mode from workload placement**. Without this data source, there is no way to query node-level status from within Terraform, leaving users no option but to manually check the Proxmox UI before running `terraform apply`.

## Usage

**Prevent deploying onto a node in maintenance mode:**

```hcl
data "proxmox_node_status" "pve1" {
  node = "pve1"
}

resource "proxmox_vm_qemu" "app" {
  target_node = "pve1"

  lifecycle {
    precondition {
      condition     = !data.proxmox_node_status.pve1.maintenance
      error_message = "Node pve1 is in maintenance mode — refusing to deploy."
    }
  }
}
```

**Skip resources on a maintenance node:**

```hcl
resource "proxmox_vm_qemu" "app" {
  count       = data.proxmox_node_status.pve1.maintenance ? 0 : 1
  target_node = "pve1"
}
```

## Notes

- No changes to `proxmox-api-go` required — uses the existing `GetNodeList()` method
- The `maintenance` field is absent from the API response for normal nodes and safely defaults to `false`; Proxmox sends a numeric `1` when the HA manager places a node into maintenance mode
- `maintenance` and `status` are kept as separate attributes because they are orthogonal: a node can be `online` and in maintenance simultaneously

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `staticcheck ./...` passes
- [x] `go test -race -vet=off ./...` passes
- [ ] Verify `maintenance = true` when node is in maintenance mode in Proxmox web UI
- [ ] Verify `maintenance = false` for a normal online node