### PR TITLE
Update: pveSDK

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -16,7 +16,7 @@ on:
       - 'examples/**'
 
 env:
-  GO_VERSION: '1.24'
+  GO_VERSION: '1.26'
 
 jobs:
   verify-dependencies:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
         name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.24'
+          go-version: '1.26'
           check-latest: true
       -
         name: Import GPG key

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/Telmate/terraform-provider-proxmox/v2
 go 1.24.9
 
 require (
-	github.com/Telmate/proxmox-api-go v0.0.0-20260423201259-0eeefb930bb2
+	github.com/Telmate/proxmox-api-go v0.0.0-20260705170205-4373c9183084
 	github.com/google/uuid v1.6.0
 	github.com/hashicorp/go-cty v1.5.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.38.2

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Telmate/terraform-provider-proxmox/v2
 
-go 1.24.9
+go 1.26.2
 
 require (
 	github.com/Telmate/proxmox-api-go v0.0.0-20260705170205-4373c9183084

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,8 @@ github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERo
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/ProtonMail/go-crypto v1.2.0 h1:+PhXXn4SPGd+qk76TlEePBfOfivE0zkWFenhGhFLzWs=
 github.com/ProtonMail/go-crypto v1.2.0/go.mod h1:9whxjD8Rbs29b4XWbB8irEcE8KHMqaR2e7GWU1R+/PE=
-github.com/Telmate/proxmox-api-go v0.0.0-20260423201259-0eeefb930bb2 h1:VVMmJjr9NmuekozPo3/XTdcgQZsXgGayA0eVYI1zb8g=
-github.com/Telmate/proxmox-api-go v0.0.0-20260423201259-0eeefb930bb2/go.mod h1:HGPbpwiVsrpYYuQAygnnU04ZdGLYc8fdP9qhJIBw2Bg=
+github.com/Telmate/proxmox-api-go v0.0.0-20260705170205-4373c9183084 h1:Fbi+cbLbFUPU/YWtP+h7kncX9svAy7kph2PrTE5XNcc=
+github.com/Telmate/proxmox-api-go v0.0.0-20260705170205-4373c9183084/go.mod h1:90hDRcdB9vqdHdtkKje50NGkGbphbGKhtefqezo/Bgc=
 github.com/agext/levenshtein v1.2.3 h1:YB2fHEn0UJagG8T1rrWknE3ZQzWM06O8AMAatNn7lmo=
 github.com/agext/levenshtein v1.2.3/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
 github.com/apparentlymart/go-textseg/v12 v12.0.0/go.mod h1:S/4uRK2UtaQttw1GenVJEynmyUenKwP++x/+DdGV/Ec=

--- a/proxmox/Internal/resource/guest/lxc/architecture/terraform.go
+++ b/proxmox/Internal/resource/guest/lxc/architecture/terraform.go
@@ -5,6 +5,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
-func Terraform(architecture pveSDK.CpuArchitecture, d *schema.ResourceData) {
+func Terraform(architecture pveSDK.LxcCpuArchitecture, d *schema.ResourceData) {
 	d.Set(Root, architecture.String())
 }

--- a/proxmox/Internal/resource/guest/qemu/cpu/schema.go
+++ b/proxmox/Internal/resource/guest/qemu/cpu/schema.go
@@ -245,7 +245,7 @@ func subSchemaUnits() *schema.Schema {
 			if !ok {
 				return diag.Errorf(schemaUnits + " must be an integer")
 			}
-			if err := pveSDK.CpuUnits(v).Validate(); err != nil {
+			if err := pveSDK.QemuCpuUnits(v).Validate(); err != nil {
 				return diag.FromErr(err)
 			}
 			return nil

--- a/proxmox/Internal/resource/guest/qemu/cpu/sdk.go
+++ b/proxmox/Internal/resource/guest/qemu/cpu/sdk.go
@@ -36,7 +36,7 @@ func SDK(d *schema.ResourceData) *pveSDK.QemuCPU {
 			Numa:         util.Pointer(settings[schemaNuma].(bool)),
 			Sockets:      util.Pointer(pveSDK.QemuCpuSockets(settings[schemaSockets].(int))),
 			Type:         util.Pointer(pveSDK.CpuType(settings[schemaType].(string))),
-			Units:        util.Pointer(pveSDK.CpuUnits(settings[schemaUnits].(int))),
+			Units:        new(pveSDK.QemuCpuUnits(settings[schemaUnits].(int))),
 			VirtualCores: util.Pointer(pveSDK.CpuVirtualCores(settings[schemaVirtualCores].(int)))}
 	}
 	return defaults()
@@ -140,6 +140,6 @@ func defaults() *pveSDK.QemuCPU {
 		Numa:         util.Pointer(defaultNuma),
 		Sockets:      util.Pointer(pveSDK.QemuCpuSockets(defaultSockets)),
 		Type:         util.Pointer(pveSDK.CpuType(defaultType)),
-		Units:        util.Pointer(pveSDK.CpuUnits(defaultUnits)),
+		Units:        new(pveSDK.QemuCpuUnits(defaultUnits)),
 		VirtualCores: util.Pointer(pveSDK.CpuVirtualCores(defaultVirtualCores))}
 }

--- a/proxmox/Internal/resource/guest/qemu/cpu/terraform.go
+++ b/proxmox/Internal/resource/guest/qemu/cpu/terraform.go
@@ -79,19 +79,20 @@ func terraformAffinity(affinity []uint) string {
 			rangeEnd = affinity[i]
 		} else {
 			// Close the current range and start a new range
-			if rangeStart == rangeEnd {
-				builder.WriteString(strconv.Itoa(int(rangeStart)) + ",")
-			} else {
-				builder.WriteString(strconv.Itoa(int(rangeStart)) + "-" + strconv.Itoa(int(rangeEnd)) + ",")
+			builder.WriteString(strconv.Itoa(int(rangeStart)))
+			if rangeStart != rangeEnd {
+				builder.WriteRune('-')
+				builder.WriteString(strconv.Itoa(int(rangeEnd)))
 			}
+			builder.WriteRune(',')
 			rangeStart, rangeEnd = affinity[i], affinity[i]
 		}
 	}
 	// Append the last range
-	if rangeStart == rangeEnd {
-		builder.WriteString(strconv.Itoa(int(rangeStart)))
-	} else {
-		builder.WriteString(strconv.Itoa(int(rangeStart)) + "-" + strconv.Itoa(int(rangeEnd)))
+	builder.WriteString(strconv.Itoa(int(rangeStart)))
+	if rangeStart != rangeEnd {
+		builder.WriteRune('-')
+		builder.WriteString(strconv.Itoa(int(rangeEnd)))
 	}
 	return builder.String()
 }

--- a/proxmox/Internal/resource/guest/qemu/disk/schema.go
+++ b/proxmox/Internal/resource/guest/qemu/disk/schema.go
@@ -241,7 +241,7 @@ func SchemaDisks() *schema.Schema {
 							schemaVirtIO + "15": subSchemaVirtio(schemaVirtIO + "15")}}}}}}
 }
 
-func subSchemaCdRom(path string, ci bool) *schema.Schema {
+func subSchemaCdRom(path string, ci bool, deprecated string) *schema.Schema {
 	var conflicts []string
 	if ci {
 		conflicts = []string{path + "." + schemaCloudInit, path + "." + schemaDisk, path + "." + schemaIgnore, path + "." + schemaPassthrough}
@@ -252,6 +252,7 @@ func subSchemaCdRom(path string, ci bool) *schema.Schema {
 		Type:          schema.TypeList,
 		Optional:      true,
 		MaxItems:      1,
+		Deprecated:    deprecated,
 		ConflictsWith: conflicts,
 		Elem: &schema.Resource{
 			Schema: map[string]*schema.Schema{
@@ -615,7 +616,7 @@ func subSchemaIde(slot string) *schema.Schema {
 		MaxItems: 1,
 		Elem: &schema.Resource{
 			Schema: map[string]*schema.Schema{
-				schemaCdRom:     subSchemaCdRom(path, true),
+				schemaCdRom:     subSchemaCdRom(path, true, ""),
 				schemaCloudInit: subSchemaCloudInit(path, slot),
 				schemaDisk: {
 					Type:          schema.TypeList,
@@ -701,7 +702,7 @@ func subSchemaSata(slot string) *schema.Schema {
 		MaxItems: 1,
 		Elem: &schema.Resource{
 			Schema: map[string]*schema.Schema{
-				schemaCdRom:     subSchemaCdRom(path, true),
+				schemaCdRom:     subSchemaCdRom(path, true, ""),
 				schemaCloudInit: subSchemaCloudInit(path, slot),
 				schemaDisk: {
 					Type:          schema.TypeList,
@@ -751,7 +752,7 @@ func subSchemaScsi(slot string) *schema.Schema {
 		MaxItems: 1,
 		Elem: &schema.Resource{
 			Schema: map[string]*schema.Schema{
-				schemaCdRom:     subSchemaCdRom(path, true),
+				schemaCdRom:     subSchemaCdRom(path, true, ""),
 				schemaCloudInit: subSchemaCloudInit(path, slot),
 				schemaDisk: {
 					Type:          schema.TypeList,
@@ -805,7 +806,7 @@ func subSchemaVirtio(setting string) *schema.Schema {
 		MaxItems: 1,
 		Elem: &schema.Resource{
 			Schema: map[string]*schema.Schema{
-				schemaCdRom: subSchemaCdRom(path, false),
+				schemaCdRom: subSchemaCdRom(path, false, path+"."+schemaCdRom+" has no effect"),
 				schemaDisk: {
 					Type:          schema.TypeList,
 					Optional:      true,

--- a/proxmox/Internal/resource/guest/qemu/disk/sdk_disk.go
+++ b/proxmox/Internal/resource/guest/qemu/disk/sdk_disk.go
@@ -384,7 +384,9 @@ func sdk_Disk_QemuVirtIOStorage(virtio *pveAPI.QemuVirtIOStorage, schema map[str
 			}
 		}
 	case enumCdRom:
-		virtio.CdRom, diags = sdk_Disk_QemuCdRom(slot, schema)
+		return diag.Diagnostics{{
+			Severity: diag.Error,
+			Summary:  schemaVirtIO + " can't have " + schemaCdRom}}
 	case enumCloudInit:
 		return diag.Diagnostics{{
 			Severity: diag.Error,

--- a/proxmox/Internal/resource/guest/qemu/disk/sdk_disks.go
+++ b/proxmox/Internal/resource/guest/qemu/disk/sdk_disks.go
@@ -461,9 +461,6 @@ func sdk_Disks_QemuVirtIOStorage(key string, schema map[string]any) *pveAPI.Qemu
 		}
 		return &pveAPI.QemuVirtIOStorage{Passthrough: &passthrough}
 	}
-	if v, ok := storageSchema[schemaCdRom].([]any); ok && len(v) == 1 && v[0] != nil {
-		return &pveAPI.QemuVirtIOStorage{CdRom: sdk_Disks_QemuCdRom(v)}
-	}
 	if v, ok := storageSchema[schemaIgnore]; ok {
 		if v.(bool) {
 			return nil // Don't change anything

--- a/proxmox/Internal/resource/guest/qemu/disk/terraform_disk.go
+++ b/proxmox/Internal/resource/guest/qemu/disk/terraform_disk.go
@@ -448,8 +448,6 @@ func terraform_Disk_QemuVirtIOStorage(config *pveAPI.QemuVirtIOStorage, schema m
 		schema[schemaType] = schemaDisk // yes, passthrough is a disk type
 		schema[schemaWorldWideName] = string(config.Passthrough.WorldWideName)
 		terraformQemuDiskBandwidth(schema, config.Passthrough.Bandwidth)
-	} else if config.CdRom != nil {
-		terraform_Disk_QemuCdRom_unsafe(config.CdRom, schema)
 	}
 	return schema
 }

--- a/proxmox/Internal/resource/guest/qemu/disk/terraform_disks.go
+++ b/proxmox/Internal/resource/guest/qemu/disk/terraform_disks.go
@@ -359,5 +359,5 @@ func terraform_Disks_QemuVirtIOStorage(config *pveAPI.QemuVirtIOStorage, schema 
 		return []interface{}{map[string]interface{}{
 			schemaPassthrough: []interface{}{mapParams}}}
 	}
-	return terraform_Disks_QemuCdRom(config.CdRom)
+	return nil
 }

--- a/proxmox/helper_guest.go
+++ b/proxmox/helper_guest.go
@@ -33,52 +33,53 @@ func guestDelete(ctx context.Context, d *schema.ResourceData, meta any, kind str
 
 func guestGetSourceVmr(
 	ctx context.Context,
-	client *pveSDK.Client,
+	client pveSDK.GuestInterface,
 	name pveSDK.GuestName,
 	id pveSDK.GuestID,
 	preferredNode pveSDK.NodeName,
 	guest pveSDK.GuestType,
 	fieldName, fieldID string) (*pveSDK.VmRef, error) {
 	if name != "" {
-		rawGuests, err := pveSDK.ListGuests(ctx, client)
+		rawGuests, err := client.List(ctx)
 		if err != nil {
 			return nil, err
 		}
 		return guestGetSourceVmrByNode(rawGuests, name, preferredNode, guest)
 	} else if id != 0 {
-		rawGuests, err := pveSDK.ListGuests(ctx, client)
+		rawGuests, err := client.List(ctx)
 		if err != nil {
 			return nil, err
 		}
-		rawGuest, ok := rawGuests.SelectID(id)
-		if !ok {
-			return nil, errors.New("guest with ID '" + id.String() + "' does not exist")
+		for e := range rawGuests.Iter() {
+			if localID := e.GetID(); localID == id {
+				if e.GetType() != guest {
+					return nil, errors.New("guest with ID '" + id.String() + "' is not of type '" + string(guest) + "'")
+				}
+				guestRef := pveSDK.NewVmRef(e.GetID())
+				guestRef.SetNode(string(e.GetNode()))
+				guestRef.SetVmType(guest)
+				return guestRef, nil
+			}
 		}
-		if rawGuest.GetType() != guest {
-			return nil, errors.New("guest with ID '" + id.String() + "' is not of type '" + string(guest) + "'")
-		}
-		guestRef := pveSDK.NewVmRef(rawGuest.GetID())
-		guestRef.SetNode(string(rawGuest.GetNode()))
-		guestRef.SetVmType(guest)
-		return guestRef, nil
+		return nil, errors.New("guest with ID '" + id.String() + "' does not exist")
 	}
 	return nil, errors.New("either '" + fieldName + "' or '" + fieldID + "' must be specified")
 }
 
 func guestGetSourceVmrByNode(raw pveSDK.RawGuestResources, name pveSDK.GuestName, preferredNode pveSDK.NodeName, guest pveSDK.GuestType) (*pveSDK.VmRef, error) {
 	var guestRef *pveSDK.VmRef
-	for i := range raw {
-		if raw[i].GetName() == name {
-			if raw[i].GetType() == guest {
-				if node := raw[i].GetNode(); node == preferredNode { // Prefer source VM on the same node
-					guestRef = pveSDK.NewVmRef(raw[i].GetID())
+	for e := range raw.Iter() {
+		if e.GetName() == name {
+			if e.GetType() == guest {
+				if node := e.GetNode(); node == preferredNode { // Prefer source VM on the same node
+					guestRef = pveSDK.NewVmRef(e.GetID())
 					guestRef.SetNode(string(node))
 					guestRef.SetVmType(guest)
 					return guestRef, nil
 				}
 				if guestRef == nil { // remember the first we find
-					guestRef = pveSDK.NewVmRef(raw[i].GetID())
-					guestRef.SetNode(string(raw[i].GetNode()))
+					guestRef = pveSDK.NewVmRef(e.GetID())
+					guestRef.SetNode(string(e.GetNode()))
 					guestRef.SetVmType(guest)
 				}
 			}

--- a/proxmox/helper_guest.go
+++ b/proxmox/helper_guest.go
@@ -16,11 +16,11 @@ func guestDelete(ctx context.Context, d *schema.ResourceData, meta any, kind str
 	lock := pmParallelBegin(pconf)
 	defer lock.unlock()
 
-	client := pconf.Client
+	client := pconf.NewClient
 	rawID, _ := strconv.Atoi(path.Base(d.Id()))
 	guestID := pveSDK.GuestID(rawID)
 
-	if err := pveSDK.NewVmRef(guestID).Delete(ctx, client); err != nil {
+	if _, err := client.Guest.Delete(ctx, *pveSDK.NewVmRef(guestID)); err != nil {
 		if errors.Is(err, pveSDK.Error.GuestDoesNotExist()) {
 			return diag.Diagnostics{{
 				Summary:  "guest of type " + kind + " with ID " + guestID.String() + " already removed",

--- a/proxmox/helper_guest_test.go
+++ b/proxmox/helper_guest_test.go
@@ -2,11 +2,79 @@ package proxmox
 
 import (
 	"errors"
+	"iter"
 	"testing"
+	"time"
 
 	pveSDK "github.com/Telmate/proxmox-api-go/proxmox"
 	"github.com/stretchr/testify/require"
 )
+
+type rawGuestResourceMock struct {
+	GetFunc                   func() pveSDK.GuestResource
+	GetCPUcoresFunc           func() uint
+	GetCPUusageFunc           func() float64
+	GetDiskReadTotalFunc      func() uint
+	GetDiskSizeInBytesFunc    func() uint
+	GetDiskUsedInBytesFunc    func() uint
+	GetDiskWriteTotalFunc     func() uint
+	GetHaStateFunc            func() *string
+	GetIDFunc                 func() pveSDK.GuestID
+	GetLockedFunc             func() bool
+	GetMemoryTotalInBytesFunc func() uint
+	GetMemoryUsedInBytesFunc  func() uint
+	GetNameFunc               func() pveSDK.GuestName
+	GetNetworkInFunc          func() uint
+	GetNetworkOutFunc         func() uint
+	GetNodeFunc               func() pveSDK.NodeName
+	GetPoolFunc               func() pveSDK.PoolName
+	GetStatusFunc             func() pveSDK.PowerState
+	GetTagsFunc               func() pveSDK.Tags
+	GetTemplateFunc           func() bool
+	GetTypeFunc               func() pveSDK.GuestType
+	GetUptimeFunc             func() time.Duration
+}
+
+var _ pveSDK.RawGuestResource = (*rawGuestResourceMock)(nil)
+
+func (r *rawGuestResourceMock) Get() pveSDK.GuestResource    { return r.GetFunc() }
+func (r *rawGuestResourceMock) GetCPUcores() uint            { return r.GetCPUcoresFunc() }
+func (r *rawGuestResourceMock) GetCPUusage() float64         { return r.GetCPUusageFunc() }
+func (r *rawGuestResourceMock) GetDiskReadTotal() uint       { return r.GetDiskReadTotalFunc() }
+func (r *rawGuestResourceMock) GetDiskSizeInBytes() uint     { return r.GetDiskSizeInBytesFunc() }
+func (r *rawGuestResourceMock) GetDiskUsedInBytes() uint     { return r.GetDiskUsedInBytesFunc() }
+func (r *rawGuestResourceMock) GetDiskWriteTotal() uint      { return r.GetDiskWriteTotalFunc() }
+func (r *rawGuestResourceMock) GetHaState() *string          { return r.GetHaStateFunc() }
+func (r *rawGuestResourceMock) GetID() pveSDK.GuestID        { return r.GetIDFunc() }
+func (r *rawGuestResourceMock) GetLocked() bool              { return r.GetLockedFunc() }
+func (r *rawGuestResourceMock) GetMemoryTotalInBytes() uint  { return r.GetMemoryTotalInBytesFunc() }
+func (r *rawGuestResourceMock) GetMemoryUsedInBytes() uint   { return r.GetMemoryUsedInBytesFunc() }
+func (r *rawGuestResourceMock) GetName() pveSDK.GuestName    { return r.GetNameFunc() }
+func (r *rawGuestResourceMock) GetNetworkIn() uint           { return r.GetNetworkInFunc() }
+func (r *rawGuestResourceMock) GetNetworkOut() uint          { return r.GetNetworkOutFunc() }
+func (r *rawGuestResourceMock) GetNode() pveSDK.NodeName     { return r.GetNodeFunc() }
+func (r *rawGuestResourceMock) GetPool() pveSDK.PoolName     { return r.GetPoolFunc() }
+func (r *rawGuestResourceMock) GetStatus() pveSDK.PowerState { return r.GetStatusFunc() }
+func (r *rawGuestResourceMock) GetTags() pveSDK.Tags         { return r.GetTagsFunc() }
+func (r *rawGuestResourceMock) GetTemplate() bool            { return r.GetTemplateFunc() }
+func (r *rawGuestResourceMock) GetType() pveSDK.GuestType    { return r.GetTypeFunc() }
+func (r *rawGuestResourceMock) GetUptime() time.Duration     { return r.GetUptimeFunc() }
+
+type rawGuestResourcesMock struct {
+	AsArrayFunc func() []pveSDK.RawGuestResource
+	AsMapFunc   func() map[pveSDK.GuestID]pveSDK.RawGuestResource
+	IterFunc    func() iter.Seq[pveSDK.RawGuestResource]
+	LenFunc     func() int
+}
+
+var _ pveSDK.RawGuestResources = (*rawGuestResourcesMock)(nil)
+
+func (r *rawGuestResourcesMock) AsArray() []pveSDK.RawGuestResource { return r.AsArrayFunc() }
+func (r *rawGuestResourcesMock) AsMap() map[pveSDK.GuestID]pveSDK.RawGuestResource {
+	return r.AsMapFunc()
+}
+func (r *rawGuestResourcesMock) Iter() iter.Seq[pveSDK.RawGuestResource] { return r.IterFunc() }
+func (r *rawGuestResourcesMock) Len() int                                { return r.LenFunc() }
 
 func Test_UserID_Validate(t *testing.T) {
 	newGuestRef := func(id pveSDK.GuestID, node pveSDK.NodeName, guest pveSDK.GuestType) *pveSDK.VmRef {
@@ -16,29 +84,31 @@ func Test_UserID_Validate(t *testing.T) {
 		return ref
 	}
 	guestBuilder := func(ID pveSDK.GuestID, Name pveSDK.GuestName, Node pveSDK.NodeName, Type pveSDK.GuestType) pveSDK.RawGuestResource {
-		return &pveSDK.RawGuestResourceMock{
-			GetIDFunc: func() pveSDK.GuestID {
-				return ID
-			},
-			GetNameFunc: func() pveSDK.GuestName {
-				return Name
-			},
-			GetNodeFunc: func() pveSDK.NodeName {
-				return Node
-			},
-			GetTypeFunc: func() pveSDK.GuestType {
-				return Type
-			}}
+		return &rawGuestResourceMock{
+			GetIDFunc:   func() pveSDK.GuestID { return ID },
+			GetNameFunc: func() pveSDK.GuestName { return Name },
+			GetNodeFunc: func() pveSDK.NodeName { return Node },
+			GetTypeFunc: func() pveSDK.GuestType { return Type }}
 	}
-	raw := []pveSDK.RawGuestResource{
-		guestBuilder(100, "test", "node1", pveSDK.GuestQemu),
-		guestBuilder(101, "test", "node1", pveSDK.GuestLxc),
-		guestBuilder(102, "test", "node2", pveSDK.GuestQemu),
-		guestBuilder(103, "test", "node2", pveSDK.GuestLxc),
-		guestBuilder(104, "test", "node3", pveSDK.GuestQemu),
-		guestBuilder(105, "test", "node3", pveSDK.GuestLxc),
-		guestBuilder(200, "single-node", "node3", pveSDK.GuestLxc),
-	}
+	raw := &rawGuestResourcesMock{
+		IterFunc: func() iter.Seq[pveSDK.RawGuestResource] {
+			return func(yield func(pveSDK.RawGuestResource) bool) {
+				array := []pveSDK.RawGuestResource{
+					guestBuilder(100, "test", "node1", pveSDK.GuestQemu),
+					guestBuilder(101, "test", "node1", pveSDK.GuestLxc),
+					guestBuilder(102, "test", "node2", pveSDK.GuestQemu),
+					guestBuilder(103, "test", "node2", pveSDK.GuestLxc),
+					guestBuilder(104, "test", "node3", pveSDK.GuestQemu),
+					guestBuilder(105, "test", "node3", pveSDK.GuestLxc),
+					guestBuilder(200, "single-node", "node3", pveSDK.GuestLxc),
+				}
+				for i := range array {
+					if !yield(array[i]) {
+						return
+					}
+				}
+			}
+		}}
 	type testInput struct {
 		guestType     pveSDK.GuestType
 		name          pveSDK.GuestName

--- a/proxmox/provider.go
+++ b/proxmox/provider.go
@@ -381,7 +381,7 @@ func getClient(pm_api_url string,
 			return nil, err
 		}
 		// Unsure how to get an err for this
-		client.SetAPIToken(*tokenID, pveSDK.ApiTokenSecret(pm_api_token_secret))
+		client.SetAPIToken(pveSDK.ApiToken{ID: *tokenID, Secret: pveSDK.ApiTokenSecret(pm_api_token_secret)})
 	}
 
 	if err != nil {

--- a/proxmox/resource_lxc.go
+++ b/proxmox/resource_lxc.go
@@ -440,6 +440,7 @@ func resourceLxcCreate(ctx context.Context, d *schema.ResourceData, meta interfa
 	defer lock.unlock()
 
 	client := pconf.Client
+	clientNew := pconf.NewClient
 
 	config := pveSDK.NewConfigLxc()
 	config.Ostemplate = d.Get("ostemplate").(string)
@@ -520,7 +521,7 @@ func resourceLxcCreate(ctx context.Context, d *schema.ResourceData, meta interfa
 	var vmr *pveSDK.VmRef
 	if d.Get("clone").(string) != "" { // Clone
 		var sourceVmr *pveSDK.VmRef
-		sourceVmr, err = guestGetSourceVmr(ctx, client, pveSDK.GuestName(d.Get("clone").(string)), 0, targetNode, pveSDK.GuestLxc, "clone", "clone_id")
+		sourceVmr, err = guestGetSourceVmr(ctx, clientNew.Guest, pveSDK.GuestName(d.Get("clone").(string)), 0, targetNode, pveSDK.GuestLxc, "clone", "clone_id")
 		if err != nil {
 			return append(diags, diag.FromErr(err)...)
 		}

--- a/proxmox/resource_lxc_guest.go
+++ b/proxmox/resource_lxc_guest.go
@@ -95,6 +95,7 @@ func resourceLxcGuestCreate(ctx context.Context, d *schema.ResourceData, meta an
 	diags := lxcGuestWarning()
 
 	client := pconf.Client
+	clientNew := pconf.NewClient
 
 	privileged := privilege.SDK(d)
 	config, tmpDiags := lxcSDK(privileged, d)
@@ -122,7 +123,7 @@ func resourceLxcGuestCreate(ctx context.Context, d *schema.ResourceData, meta an
 		Pool: config.Pool})
 	if cloneGuest != nil {
 		var cloneRef *pveSDK.VmRef
-		cloneRef, err = guestGetSourceVmr(ctx, client, cloneGuest.Name, cloneGuest.ID, targetNode, pveSDK.GuestLxc, clone.Root+" { "+clone.SchemaName+" }", clone.Root+" { "+clone.SchemaID+" }")
+		cloneRef, err = guestGetSourceVmr(ctx, clientNew.Guest, cloneGuest.Name, cloneGuest.ID, targetNode, pveSDK.GuestLxc, clone.Root+" { "+clone.SchemaName+" }", clone.Root+" { "+clone.SchemaID+" }")
 		if err != nil {
 			return append(diags, diag.Diagnostic{
 				Summary:  err.Error(),

--- a/proxmox/resource_vm_qemu.go
+++ b/proxmox/resource_vm_qemu.go
@@ -564,20 +564,23 @@ func resourceVmQemuCreate(ctx context.Context, d *schema.ResourceData, meta inte
 	var vmr *pveSDK.VmRef
 	if guestID := vmID.Get(d); guestID != 0 { // Manually set vmID
 		log.Print("[DEBUG][QemuVmCreate] checking if vmId: " + guestID.String() + " already exists")
-		guests, err := pveSDK.ListGuests(ctx, client)
+		guests, err := clientNew.Guest.List(ctx)
 		if err != nil {
 			return append(diags, diag.FromErr(err)...)
 		}
-		if rawGuest, ok := guests.SelectID(guestID); ok { // guest already exists
-			forceCreate := d.Get("force_create").(bool)
-			if !forceCreate {
-				return append(diags, diag.Diagnostic{
-					Summary:  "vmId: " + guestID.String() + " already in use. Set force_create=true to recycle",
-					Severity: diag.Error})
+		for e := range guests.Iter() {
+			if e.GetID() == guestID { // guest already exists
+				forceCreate := d.Get("force_create").(bool)
+				if !forceCreate {
+					return append(diags, diag.Diagnostic{
+						Summary:  "vmId: " + guestID.String() + " already in use. Set force_create=true to recycle",
+						Severity: diag.Error})
+				}
+				vmr = pveSDK.NewVmRef(guestID)
+				vmr.SetNode(string(e.GetNode()))
+				vmr.SetVmType(e.GetType())
+				break
 			}
-			vmr = pveSDK.NewVmRef(guestID)
-			vmr.SetNode(string(rawGuest.GetNode()))
-			vmr.SetVmType(rawGuest.GetType())
 		}
 	}
 
@@ -599,7 +602,7 @@ func resourceVmQemuCreate(ctx context.Context, d *schema.ResourceData, meta inte
 		// check if clone, or PXE boot
 		if d.Get("clone").(string) != "" || d.Get("clone_id").(int) != 0 { // Clone
 
-			sourceVmr, err := guestGetSourceVmr(ctx, client, pveSDK.GuestName(d.Get("clone").(string)), pveSDK.GuestID(d.Get("clone_id").(int)), targetNode, pveSDK.GuestQemu, "clone", "clone_id")
+			sourceVmr, err := guestGetSourceVmr(ctx, clientNew.Guest, pveSDK.GuestName(d.Get("clone").(string)), pveSDK.GuestID(d.Get("clone_id").(int)), targetNode, pveSDK.GuestQemu, "clone", "clone_id")
 			if err != nil {
 				return append(diags, diag.FromErr(err)...)
 			}


### PR DESCRIPTION
Use latest version of [pveSDK](https://github.com/Telmate/proxmox-api-go).
Many interfaces we used have been deprecated and we are now using the new ones.
GO has been updated to 1.26.2
`virtio.cdrom` has been marked as deprecated as there is no way to set it in the pveSDK.