### PR TITLE
fix: reject short network id instead of crashing with slice bounds panic

### DIFF
--- a/proxmox/Internal/validate/validate.go
+++ b/proxmox/Internal/validate/validate.go
@@ -12,18 +12,16 @@ func ID(value, prefix, schemaID string, maxID uint64) diag.Diagnostics {
 			Summary:  schemaID + " cannot be empty",
 			Severity: diag.Error}}
 	}
-	if len(value) > len(prefix) {
-		if value[0:len(prefix)] != prefix {
-			return diag.Diagnostics{{
-				Summary:  schemaID + " must start with '" + prefix + "'",
-				Severity: diag.Error}}
-		}
-		num, err := strconv.ParseUint(value[len(prefix):], 10, 64) // validate that the rest is a number
-		if err != nil || num > maxID {
-			return diag.Diagnostics{{
-				Summary:  "invalid " + schemaID,
-				Severity: diag.Error}}
-		}
+	if len(value) <= len(prefix) || value[0:len(prefix)] != prefix {
+		return diag.Diagnostics{{
+			Summary:  schemaID + " must start with '" + prefix + "'",
+			Severity: diag.Error}}
+	}
+	num, err := strconv.ParseUint(value[len(prefix):], 10, 64) // validate that the rest is a number
+	if err != nil || num > maxID {
+		return diag.Diagnostics{{
+			Summary:  "invalid " + schemaID,
+			Severity: diag.Error}}
 	}
 	return nil
 }

--- a/proxmox/Internal/validate/validate_test.go
+++ b/proxmox/Internal/validate/validate_test.go
@@ -1,0 +1,29 @@
+package validate
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_ID(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		err   bool
+	}{
+		{name: `valid`, input: "net0"},
+		{name: `valid max`, input: "net15"},
+		{name: `empty`, input: "", err: true},
+		{name: `no prefix`, input: "0", err: true},
+		{name: `prefix only`, input: "net", err: true},
+		{name: `wrong prefix`, input: "eth0", err: true},
+		{name: `not a number`, input: "netx", err: true},
+		{name: `above max`, input: "net16", err: true},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			require.Equal(t, test.err, ID(test.input, "net", "id", 15).HasError())
+		})
+	}
+}


### PR DESCRIPTION
Fixes #1531. validate.ID only checked the `net` prefix when the value was longer than the prefix, so `id = 0` (coerced to "0") passed validation and sdkNetwork paniced on `"0"[3:]` with slice bounds out of range [3:1]. Short values now fail validation with the same "must start with 'net'" error, so the user gets a plan-time diagnostic instead of a provider crash.