### PR TITLE
fix: bump proxmox-api-go so an automatic reboot reboots

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/Telmate/terraform-provider-proxmox/v2
 go 1.26.2
 
 require (
-	github.com/Telmate/proxmox-api-go v0.0.0-20260705170205-4373c9183084
+	github.com/Telmate/proxmox-api-go v0.0.0-20260730191320-ad30e082d0b2
 	github.com/google/uuid v1.6.0
 	github.com/hashicorp/go-cty v1.5.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.40.1

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,8 @@ github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERo
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/ProtonMail/go-crypto v1.4.1 h1:9RfcZHqEQUvP8RzecWEUafnZVtEvrBVL9BiF67IQOfM=
 github.com/ProtonMail/go-crypto v1.4.1/go.mod h1:e1OaTyu5SYVrO9gKOEhTc+5UcXtTUa+P3uLudwcgPqo=
-github.com/Telmate/proxmox-api-go v0.0.0-20260705170205-4373c9183084 h1:Fbi+cbLbFUPU/YWtP+h7kncX9svAy7kph2PrTE5XNcc=
-github.com/Telmate/proxmox-api-go v0.0.0-20260705170205-4373c9183084/go.mod h1:90hDRcdB9vqdHdtkKje50NGkGbphbGKhtefqezo/Bgc=
+github.com/Telmate/proxmox-api-go v0.0.0-20260730191320-ad30e082d0b2 h1:Bb08DOUAg6T9XpOXbW45fkzmu1t4vaIcpTUIBCbCeM8=
+github.com/Telmate/proxmox-api-go v0.0.0-20260730191320-ad30e082d0b2/go.mod h1:8Ibp7735ao2KgxxdRjqQKktH0RA6TTTfRL7aw1gj324=
 github.com/agext/levenshtein v1.2.3 h1:YB2fHEn0UJagG8T1rrWknE3ZQzWM06O8AMAatNn7lmo=
 github.com/agext/levenshtein v1.2.3/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
 github.com/apparentlymart/go-textseg/v12 v12.0.0/go.mod h1:S/4uRK2UtaQttw1GenVJEynmyUenKwP++x/+DdGV/Ec=


### PR DESCRIPTION
Fixes #1526

### What

Moves the `proxmox-api-go` pin from `4373c9183084` (2026-07-05) to `ad30e082d0b2` (2026-07-30), so that `automatic_reboot = true` actually reboots.

`go.mod` and `go.sum` only; no provider code changes.

### Why

`updateNoCheck` in the currently pinned `proxmox-api-go` has the `allowRestart` condition inverted:

```go
if rebootRequired {
    if allowRestart {
        return true, errors.New(ConfigQemu_Error_UnableToUpdateWithoutReboot)
    }
    if err = vmr.reboot_Unsafe(ctx, c); err != nil {
```

That contradicts the interface comment on `Update` ("When allowRestart is false an error is return if the update rewuires a reboot or shutdown") and `shutdownIfRunning` a few lines below, which correctly tests `if !allowRestart`.

`resourceVmQemuUpdate` passes `automatic_reboot` straight into `allowRestart`, and the schema default is `true`. So on any change requiring a reboot — memory, CPU, bios — the apply fails with:

```
Error: the QEMU guest needs to be rebooted and `automatic_reboot = false`.
the QEMU guest needs to be rebooted for the changes to take effect.
Set `automatic_reboot = true` to allow the provider to reboot the guest.
```

The diagnostic advises setting the value that is already in effect. Setting `automatic_reboot = false` makes the guest reboot, which is how the inversion surfaces in practice.

Note the failure is not clean: the config PUT has already succeeded by the time this returns, so the guest is left with the change pending and Terraform state not refreshed.

### Relation to #1526

This addresses the reboot half of #1526, where the reported workaround was exactly `automatic_reboot = false`. That issue also reports post-apply drift on computed attributes (`vm_state`, `ssh_host`, `default_ipv4_address`), which is a separate problem and is untouched here. If that part is still
reproducible once this lands, the issue is worth reopening rather than
treating as resolved by this bump.

### Why the pin moves to master head

The fix is Telmate/proxmox-api-go#572, merged 2026-07-30. `v3.0.2-rc08` predates it, and `master`'s `go.mod` here still carries the same 2026-07-05 pseudo-version — checked against `upstream/master` directly rather than against the release tag, as of 2026-08-09.

Master head rather than the #572 merge commit is deliberate. `1eb61256` (that merge) already has the PCI-validation refactor and the `golang.org/x/crypto` 0.45.0 -> 0.52.0 bump among its ancestors, so there is no earlier point carrying the reboot fix without them. Going to head additionally picks up `3260c52c`, the end-to-end regression test written for this bug. Eleven commits, seven files.

`golang.org/x/crypto` in this repository stays put: `v0.53.0` here already exceeds the `v0.52.0` the dependency now asks for, so MVS selects nothing new. `go mod tidy` produces no diff.

### Verification

Against the five jobs in `.github/workflows/go.yml`, run locally with `GOFLAGS=-mod=readonly`:

- `go mod verify` — ok
- `go build -v ./...` — ok
- `go vet ./...` — ok
- `go test -race -vet=off ./...` — ok
- `staticcheck ./...` — ok

The resolved module in the module cache carries `if !allowRestart` at the call site.

`docs/resources/vm_qemu.md` already documents the intended behaviour, so no documentation change is needed.


