### PR TITLE
Feat: LXC `host_managed`

### DIFF
--- a/docs/resources/lxc_guest.md
+++ b/docs/resources/lxc_guest.md
@@ -210,41 +210,43 @@ The `data` field is used to configure a data mount, And is mutually exclusive wi
 
 The `network` field is used to configure the network interfaces. It may be specified multiple times, each instance requires a unique `id` and `name` value. `network` is mutually exclusive with `networks`.
 
-| Argument        | Type    | Default Value | Description |
-|:----------------|---------|---------------|:------------|
-| `bridge`        | `string`|               | **Required**: Bridge the network interface will be connected to.|
-| `connected`     | `bool`  | `true`        | Wheter the network interface will be connected.|
-| `firewall`      | `bool`  | `false`       | Wheter the network interface will be protected by the firewall.|
-| `id`            | `string`|               | **Required**: The unique id of the network interface. Must be prefixed with `net`, example: `net0`. Maximum amount of network interfaces is 16.|
-| `ipv4_address`  | `string`|               | IPv4 address of the network interface.|
-| `ipv4_dhcp`     | `bool`  | `false`       | Wheter IPv4 DHCP is enabled on the network interface.|
-| `ipv4_gateway`  | `string`|               | IPv4 gateway of the network interface.|
-| `ipv6_address`  | `string`|               | IPv6 address of the network interface.|
-| `ipv6_dhcp`     | `bool`  | `false`       | Wheter IPv6 DHCP is enabled on the network interface.|
-| `ipv6_gateway`  | `string`|               | IPv6 gateway of the network interface.|
-| `mac`           | `string`|               | MAC address of the network interface.|
-| `mtu`           | `int`   |               | MTU of the network interface.|
-| `name`          | `string`|               | **Required**: Name of the network interface inside the guest. The name must be unique example: `eth0`.|
-| `rate_limit`    | `int`   |               | Rate limit of the network interface in Kbit/s. `0` means unlimited.|
-| `slaac`         | `bool`  | `false`       | Wheter SLAAC is enabled on the network interface. Conflicts with IPv6 settings.|
-| `vlan_native`   | `int`   |               | Native VLAN of the network interface.|
+| Argument        | Type    | Default Value | Description
+|:----------------|---------|---------------|:-----------
+| `bridge`        | `string`|               | **Required**: Bridge the network interface will be connected to.
+| `connected`     | `bool`  | `true`        | Wheter the network interface will be connected.
+| `firewall`      | `bool`  | `false`       | Wheter the network interface will be protected by the firewall.
+| `host_managed`  | `bool`  | `true`        | Wheter the network interface is managed by proxmox.
+| `id`            | `string`|               | **Required**: The unique id of the network interface. Must be prefixed with `net`, example: `net0`. Maximum amount of network interfaces is 16.
+| `ipv4_address`  | `string`|               | IPv4 address of the network interface.
+| `ipv4_dhcp`     | `bool`  | `false`       | Wheter IPv4 DHCP is enabled on the network interface.
+| `ipv4_gateway`  | `string`|               | IPv4 gateway of the network interface.
+| `ipv6_address`  | `string`|               | IPv6 address of the network interface.
+| `ipv6_dhcp`     | `bool`  | `false`       | Wheter IPv6 DHCP is enabled on the network interface.
+| `ipv6_gateway`  | `string`|               | IPv6 gateway of the network interface.
+| `mac`           | `string`|               | MAC address of the network interface.
+| `mtu`           | `int`   |               | MTU of the network interface.
+| `name`          | `string`|               | **Required**: Name of the network interface inside the guest. The name must be unique example: `eth0`.
+| `rate_limit`    | `int`   |               | Rate limit of the network interface in Kbit/s. `0` means unlimited.
+| `slaac`         | `bool`  | `false`       | Wheter SLAAC is enabled on the network interface. Conflicts with IPv6 settings.
+| `vlan_native`   | `int`   |               | Native VLAN of the network interface.
 
 ### Networks Reference
 
 The `networks` field is used to configure the network interfaces. It may only be specified once. `networks` is mutually exclusive with `network`. `mounts` has 16 sub items, with each sub item representing a unique id, example: `net0`, `net1`, etc. Every slot has the following configuration options:
 
-| Argument     | Type    | Default Value | Description |
-|:-------------|---------|---------------|:------------|
-| `bridge`     | `string`|               | **Required**: Bridge the network interface will be connected to.|
-| `connected`  | `bool`  | `true`        | Wheter the network interface will be connected.|
-| `firewall`   | `bool`  | `false`       | Wheter the network interface will be protected by the firewall.|
-| `ipv4`       | `nested`|               | IPv4 configuration, see [IPv4 Reference](#ipv4-reference).|
-| `ipv6`       | `nested`|               | IPv6 configuration, see [IPv6 Reference](#ipv6-reference).|
-| `mac`        | `string`|               | MAC address of the network interface.|
-| `mtu`        | `int`   |               | MTU of the network interface.|
-| `name`       | `string`|               | **Required**: Name of the network interface inside the guest. The name must be unique example: `eth0`.|
-| `rate_limit` | `int`   |               | Rate limit of the network interface in Kbit/s. `0` means unlimited.|
-| `vlan_native`| `int`   |               | Native VLAN of the network interface.|
+| Argument      | Type    | Default Value | Description
+|:--------------|---------|---------------|:-----------
+| `bridge`      | `string`|               | **Required**: Bridge the network interface will be connected to.
+| `connected`   | `bool`  | `true`        | Wheter the network interface will be connected.
+| `firewall`    | `bool`  | `false`       | Wheter the network interface will be protected by the firewall.
+| `host_managed`| `bool`  | `true`        | Wheter the network interface is managed by proxmox.
+| `ipv4`        | `nested`|               | IPv4 configuration, see [IPv4 Reference](#ipv4-reference).
+| `ipv6`        | `nested`|               | IPv6 configuration, see [IPv6 Reference](#ipv6-reference).
+| `mac`         | `string`|               | MAC address of the network interface.
+| `mtu`         | `int`   |               | MTU of the network interface.
+| `name`        | `string`|               | **Required**: Name of the network interface inside the guest. The name must beunique example: `eth0`.
+| `rate_limit`  | `int`   |               | Rate limit of the network interface in Kbit/s. `0` means unlimited.
+| `vlan_native` | `int`   |               | Native VLAN of the network interface.
 
 #### IPv4 Reference
 

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/Telmate/terraform-provider-proxmox/v2
 go 1.26.2
 
 require (
-	github.com/Telmate/proxmox-api-go v0.0.0-20260730191320-ad30e082d0b2
+	github.com/Telmate/proxmox-api-go v0.0.0-20260811170036-d21834931666
 	github.com/google/uuid v1.6.0
 	github.com/hashicorp/go-cty v1.5.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.40.1

--- a/go.sum
+++ b/go.sum
@@ -4,10 +4,8 @@ github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERo
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/ProtonMail/go-crypto v1.4.1 h1:9RfcZHqEQUvP8RzecWEUafnZVtEvrBVL9BiF67IQOfM=
 github.com/ProtonMail/go-crypto v1.4.1/go.mod h1:e1OaTyu5SYVrO9gKOEhTc+5UcXtTUa+P3uLudwcgPqo=
-github.com/Telmate/proxmox-api-go v0.0.0-20260705170205-4373c9183084 h1:Fbi+cbLbFUPU/YWtP+h7kncX9svAy7kph2PrTE5XNcc=
-github.com/Telmate/proxmox-api-go v0.0.0-20260705170205-4373c9183084/go.mod h1:90hDRcdB9vqdHdtkKje50NGkGbphbGKhtefqezo/Bgc=
-github.com/Telmate/proxmox-api-go v0.0.0-20260730191320-ad30e082d0b2 h1:Bb08DOUAg6T9XpOXbW45fkzmu1t4vaIcpTUIBCbCeM8=
-github.com/Telmate/proxmox-api-go v0.0.0-20260730191320-ad30e082d0b2/go.mod h1:8Ibp7735ao2KgxxdRjqQKktH0RA6TTTfRL7aw1gj324=
+github.com/Telmate/proxmox-api-go v0.0.0-20260811170036-d21834931666 h1:mnnCE8Ws3UClCeOrDTApDHrT6zjGUgEa+LvvCHiieds=
+github.com/Telmate/proxmox-api-go v0.0.0-20260811170036-d21834931666/go.mod h1:8Ibp7735ao2KgxxdRjqQKktH0RA6TTTfRL7aw1gj324=
 github.com/agext/levenshtein v1.2.3 h1:YB2fHEn0UJagG8T1rrWknE3ZQzWM06O8AMAatNn7lmo=
 github.com/agext/levenshtein v1.2.3/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
 github.com/apparentlymart/go-textseg/v12 v12.0.0/go.mod h1:S/4uRK2UtaQttw1GenVJEynmyUenKwP++x/+DdGV/Ec=

--- a/proxmox/Internal/errormsg/error.go
+++ b/proxmox/Internal/errormsg/error.go
@@ -1,6 +1,9 @@
 package errorMSG
 
 import (
+	"errors"
+	"strings"
+
 	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 )
@@ -58,4 +61,74 @@ func (d Diagnostic) Diagnostic() diag.Diagnostic {
 
 func (d Diagnostic) Diagnostics() diag.Diagnostics {
 	return diag.Diagnostics{d.Diagnostic()}
+}
+
+type PathPart struct {
+	Name  string
+	Array bool
+}
+
+func (p PathPart) close() byte {
+	if p.Array {
+		return ']'
+	}
+	return '}'
+}
+
+func (p PathPart) open() byte {
+	if p.Array {
+		return '['
+	}
+	return '{'
+}
+
+type TfProperty struct {
+	Path  []PathPart
+	Value *string
+}
+
+func (p TfProperty) build(b *strings.Builder) {
+	for i := range p.Path {
+		b.WriteString(p.Path[i].Name)
+		if i+1 == len(p.Path) {
+			if p.Value != nil {
+				b.WriteByte('=')
+				b.WriteString(*p.Value)
+			}
+			break
+		}
+		b.WriteByte(p.Path[i].open())
+	}
+	if len(p.Path) > 1 {
+		for i := range len(p.Path) - 1 {
+			b.WriteByte(p.Path[i].close())
+		}
+	}
+}
+
+const (
+	incompatibleConfig = "Incompatible configuration\n\n  "
+	isIncompatible     = ": is incompatible with "
+)
+
+func ConflictsWith(a, b TfProperty) error {
+	var builder strings.Builder
+	builderPTR := &builder
+	builder.WriteString(incompatibleConfig)
+	a.build(builderPTR)
+	builder.WriteString(isIncompatible)
+	b.build(builderPTR)
+	return errors.New(builder.String())
+}
+
+func ConflictsWithWhere(a, b, where TfProperty) error {
+	var builder strings.Builder
+	builderPTR := &builder
+	builder.WriteString(incompatibleConfig)
+	a.build(builderPTR)
+	builder.WriteString(isIncompatible)
+	b.build(builderPTR)
+	builder.WriteString("\n  where ")
+	where.build(builderPTR)
+	return errors.New(builder.String())
 }

--- a/proxmox/Internal/resource/guest/lxc/networks/helper.go
+++ b/proxmox/Internal/resource/guest/lxc/networks/helper.go
@@ -1,0 +1,5 @@
+package networks
+
+import pveSDK "github.com/Telmate/proxmox-api-go/proxmox"
+
+func HostManagedVersion() pveSDK.EncodedVersion { return pveSDK.Version{Major: 9, Minor: 1}.Encode() }

--- a/proxmox/Internal/resource/guest/lxc/networks/schema.go
+++ b/proxmox/Internal/resource/guest/lxc/networks/schema.go
@@ -1,6 +1,7 @@
 package networks
 
 import (
+	"context"
 	"strconv"
 
 	pveSDK "github.com/Telmate/proxmox-api-go/proxmox"
@@ -20,14 +21,15 @@ const (
 
 	schemaID = "id"
 
-	schemaBridge     = "bridge"
-	schemaConnected  = "connected"
-	schemaFirewall   = "firewall"
-	schemaMAC        = mac.Root
-	schemaMTU        = "mtu"
-	schemaName       = "name"
-	schemaNativeVlan = native.Root
-	schemaRateLimit  = "rate_limit"
+	schemaBridge      = "bridge"
+	schemaConnected   = "connected"
+	schemaFirewall    = "firewall"
+	schemaHostManaged = "host_managed"
+	schemaMAC         = mac.Root
+	schemaMTU         = "mtu"
+	schemaName        = "name"
+	schemaNativeVlan  = native.Root
+	schemaRateLimit   = "rate_limit"
 
 	schmemaIPv4 = "ipv4"
 	schmemaIPv6 = "ipv6"
@@ -47,8 +49,9 @@ const (
 	networksAmount = pveSDK.LxcNetworksAmount
 	maximumID      = pveSDK.LxcNetworkIdMaximum
 
-	defaultConnected = true
-	defaultFirewall  = true
+	defaultConnected   = true
+	defaultFirewall    = true
+	defaultHostManaged = true
 )
 
 func subSchemaBridge() *schema.Schema {
@@ -69,6 +72,13 @@ func subSchemaFirewall() *schema.Schema {
 		Type:     schema.TypeBool,
 		Optional: true,
 		Default:  defaultFirewall}
+}
+
+func subSchemaHostManaged() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeBool,
+		Optional: true,
+		Default:  defaultHostManaged}
 }
 
 func subSchemaMAC(useAttributePath bool, path string) *schema.Schema {
@@ -220,4 +230,74 @@ func subSchemaIPv6Gateway(useAttributePath bool, path string, s schema.Schema) *
 		return nil
 	}
 	return &s
+}
+
+func CustomizeDiff() schema.CustomizeDiffFunc {
+	return func(ctx context.Context, d *schema.ResourceDiff, meta any) error {
+		if v, ok := d.GetOk(RootNetwork); ok { // network
+			network := v.([]any)
+			for i := range network {
+				if network[i] != nil {
+					subSchema := network[i].(map[string]any)
+					hostManaged := subSchema[schemaHostManaged].(bool)
+					slaac := subSchema[schemaSLAAC].(bool)
+					id := subSchema[schemaID].(string)
+					if hostManaged && slaac {
+						return errorMSG.ConflictsWithWhere(errorMSG.TfProperty{
+							Path: []errorMSG.PathPart{
+								{Name: RootNetwork, Array: true},
+								{Name: schemaHostManaged}},
+							Value: new("true"),
+						}, errorMSG.TfProperty{
+							Path: []errorMSG.PathPart{
+								{Name: RootNetwork, Array: true},
+								{Name: schemaSLAAC}},
+							Value: new("true"),
+						}, errorMSG.TfProperty{
+							Path: []errorMSG.PathPart{
+								{Name: RootNetwork, Array: true},
+								{Name: schemaID}},
+							Value: &id,
+						})
+					}
+				}
+			}
+		} else if v := d.Get(RootNetworks).([]any); len(v) == 1 { // networks
+			if subSchema, ok := v[0].(map[string]any); ok {
+				for i := range networksAmount {
+					id := prefixSchemaID + strconv.Itoa(i)
+					schemaArray := subSchema[id].([]any)
+					if len(schemaArray) == 0 {
+						continue
+					}
+					schemaMap := schemaArray[0].(map[string]any)
+					hostManaged := schemaMap[schemaHostManaged].(bool)
+					ipv6Schema := schemaMap[schmemaIPv6].([]any)
+					var slaac bool
+					if len(ipv6Schema) == 1 && ipv6Schema[0] != nil {
+						if v := ipv6Schema[0].(map[string]any); v[schemaSLAAC].(bool) {
+							slaac = true
+						}
+					}
+					if hostManaged && slaac {
+						return errorMSG.ConflictsWith(errorMSG.TfProperty{
+							Path: []errorMSG.PathPart{
+								{Name: RootNetworks},
+								{Name: id},
+								{Name: schemaHostManaged}},
+							Value: new("true"),
+						}, errorMSG.TfProperty{
+							Path: []errorMSG.PathPart{
+								{Name: RootNetworks},
+								{Name: id},
+								{Name: schmemaIPv6},
+								{Name: schemaSLAAC}},
+							Value: new("true"),
+						})
+					}
+				}
+			}
+		}
+		return nil
+	}
 }

--- a/proxmox/Internal/resource/guest/lxc/networks/schema_network.go
+++ b/proxmox/Internal/resource/guest/lxc/networks/schema_network.go
@@ -25,6 +25,7 @@ func SchemaNetwork() *schema.Schema {
 				schemaBridge:      subSchemaBridge(),
 				schemaConnected:   subSchemaConnected(),
 				schemaFirewall:    subSchemaFirewall(),
+				schemaHostManaged: subSchemaHostManaged(),
 				schemaIPv4Address: subSchemaIPv4Address(true, schemaIPv4Address, schema.Schema{}),
 				schemaIPv4DHCP:    subSchemaDHCP(schema.Schema{}),
 				schemaIPv4Gateway: subSchemaIPv4Gateway(true, schemaIPv4Gateway, schema.Schema{}),

--- a/proxmox/Internal/resource/guest/lxc/networks/schema_networks.go
+++ b/proxmox/Internal/resource/guest/lxc/networks/schema_networks.go
@@ -36,14 +36,15 @@ func networksSubSchema(slot string) *schema.Schema {
 		MaxItems: 1,
 		Elem: &schema.Resource{
 			Schema: map[string]*schema.Schema{
-				schemaBridge:     subSchemaBridge(),
-				schemaConnected:  subSchemaConnected(),
-				schemaFirewall:   subSchemaFirewall(),
-				schemaMAC:        subSchemaMAC(false, pathSimple+schemaMAC),
-				schemaMTU:        subSchemaMTU(false, pathSimple+schemaMTU),
-				schemaName:       subSchemaName(false, pathSimple+schemaName),
-				schemaNativeVlan: subSchemaNativeVlan(false, pathSimple+schemaNativeVlan),
-				schemaRateLimit:  subSchemaRate(false, pathSimple+schemaRateLimit),
+				schemaBridge:      subSchemaBridge(),
+				schemaConnected:   subSchemaConnected(),
+				schemaFirewall:    subSchemaFirewall(),
+				schemaHostManaged: subSchemaHostManaged(),
+				schemaMAC:         subSchemaMAC(false, pathSimple+schemaMAC),
+				schemaMTU:         subSchemaMTU(false, pathSimple+schemaMTU),
+				schemaName:        subSchemaName(false, pathSimple+schemaName),
+				schemaNativeVlan:  subSchemaNativeVlan(false, pathSimple+schemaNativeVlan),
+				schemaRateLimit:   subSchemaRate(false, pathSimple+schemaRateLimit),
 				schmemaIPv4: {
 					Type:     schema.TypeList,
 					Optional: true,

--- a/proxmox/Internal/resource/guest/lxc/networks/sdk.go
+++ b/proxmox/Internal/resource/guest/lxc/networks/sdk.go
@@ -6,12 +6,12 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
-func SDK(d *schema.ResourceData) (pveSDK.LxcNetworks, diag.Diagnostics) {
+func SDK(version pveSDK.EncodedVersion, d *schema.ResourceData) (pveSDK.LxcNetworks, diag.Diagnostics) {
 	if v, ok := d.GetOk(RootNetwork); ok { // network
-		return sdkNetwork(v.([]any))
+		return sdkNetwork(version, v.([]any))
 	} else if v := d.Get(RootNetworks).([]any); len(v) == 1 { // networks
 		if subSchema, ok := v[0].(map[string]any); ok {
-			return sdkNetworks(subSchema), nil
+			return sdkNetworks(version, subSchema), nil
 		}
 	}
 	// Defaults

--- a/proxmox/Internal/resource/guest/lxc/networks/sdk_network.go
+++ b/proxmox/Internal/resource/guest/lxc/networks/sdk_network.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 )
 
-func sdkNetwork(schema []any) (pveSDK.LxcNetworks, diag.Diagnostics) {
+func sdkNetwork(version pveSDK.EncodedVersion, schema []any) (pveSDK.LxcNetworks, diag.Diagnostics) {
 	config := pveSDK.LxcNetworks{}
 	for _, e := range schema {
 		schemaMap := e.(map[string]any)
@@ -23,10 +23,15 @@ func sdkNetwork(schema []any) (pveSDK.LxcNetworks, diag.Diagnostics) {
 		if v := schemaMap[schemaMAC].(string); v != "" {
 			mac, _ = net.ParseMAC(schemaMap[schemaMAC].(string))
 		}
+		var hostManaged *bool
+		if version >= HostManagedVersion() {
+			hostManaged = new(schemaMap[schemaHostManaged].(bool))
+		}
 		config[id] = pveSDK.LxcNetwork{
 			Bridge:        new(schemaMap[schemaBridge].(string)),
 			Connected:     new(schemaMap[schemaConnected].(bool)),
 			Firewall:      new(schemaMap[schemaFirewall].(bool)),
+			HostManaged:   hostManaged,
 			IPv4:          sdkNetworkIPv4(schemaMap),
 			IPv6:          sdkNetworkIPv6(schemaMap),
 			MAC:           &mac,

--- a/proxmox/Internal/resource/guest/lxc/networks/sdk_network.go
+++ b/proxmox/Internal/resource/guest/lxc/networks/sdk_network.go
@@ -5,7 +5,6 @@ import (
 	"strconv"
 
 	pveSDK "github.com/Telmate/proxmox-api-go/proxmox"
-	"github.com/Telmate/terraform-provider-proxmox/v2/proxmox/Internal/util"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 )
 
@@ -25,16 +24,16 @@ func sdkNetwork(schema []any) (pveSDK.LxcNetworks, diag.Diagnostics) {
 			mac, _ = net.ParseMAC(schemaMap[schemaMAC].(string))
 		}
 		config[id] = pveSDK.LxcNetwork{
-			Bridge:        util.Pointer(schemaMap[schemaBridge].(string)),
-			Connected:     util.Pointer(schemaMap[schemaConnected].(bool)),
-			Firewall:      util.Pointer(schemaMap[schemaFirewall].(bool)),
+			Bridge:        new(schemaMap[schemaBridge].(string)),
+			Connected:     new(schemaMap[schemaConnected].(bool)),
+			Firewall:      new(schemaMap[schemaFirewall].(bool)),
 			IPv4:          sdkNetworkIPv4(schemaMap),
 			IPv6:          sdkNetworkIPv6(schemaMap),
-			MAC:           util.Pointer(mac),
-			Mtu:           util.Pointer(pveSDK.MTU(schemaMap[schemaMTU].(int))),
-			Name:          util.Pointer(pveSDK.LxcNetworkName(schemaMap[schemaName].(string))),
-			NativeVlan:    util.Pointer(pveSDK.Vlan(schemaMap[schemaNativeVlan].(int))),
-			RateLimitKBps: util.Pointer(pveSDK.GuestNetworkRate(schemaMap[schemaRateLimit].(int)))}
+			MAC:           &mac,
+			Mtu:           new(pveSDK.MTU(schemaMap[schemaMTU].(int))),
+			Name:          new(pveSDK.LxcNetworkName(schemaMap[schemaName].(string))),
+			NativeVlan:    new(pveSDK.Vlan(schemaMap[schemaNativeVlan].(int))),
+			RateLimitKBps: new(pveSDK.GuestNetworkRate(schemaMap[schemaRateLimit].(int)))}
 	}
 	for i := range pveSDK.LxcNetworkID(networksAmount) { // ensure all networks are present
 		if _, ok := config[i]; !ok {
@@ -49,8 +48,8 @@ func sdkNetworkIPv4(schema map[string]any) *pveSDK.LxcIPv4 {
 		return &pveSDK.LxcIPv4{DHCP: dhcp}
 	}
 	return &pveSDK.LxcIPv4{
-		Address: util.Pointer(pveSDK.IPv4CIDR(schema[schemaIPv4Address].(string))),
-		Gateway: util.Pointer(pveSDK.IPv4Address(schema[schemaIPv4Gateway].(string)))}
+		Address: new(pveSDK.IPv4CIDR(schema[schemaIPv4Address].(string))),
+		Gateway: new(pveSDK.IPv4Address(schema[schemaIPv4Gateway].(string)))}
 }
 
 func sdkNetworkIPv6(schema map[string]any) *pveSDK.LxcIPv6 {
@@ -61,6 +60,6 @@ func sdkNetworkIPv6(schema map[string]any) *pveSDK.LxcIPv6 {
 		return &pveSDK.LxcIPv6{SLAAC: slaac}
 	}
 	return &pveSDK.LxcIPv6{
-		Address: util.Pointer(pveSDK.IPv6CIDR(schema[schemaIPv6Address].(string))),
-		Gateway: util.Pointer(pveSDK.IPv6Address(schema[schemaIPv6Gateway].(string)))}
+		Address: new(pveSDK.IPv6CIDR(schema[schemaIPv6Address].(string))),
+		Gateway: new(pveSDK.IPv6Address(schema[schemaIPv6Gateway].(string)))}
 }

--- a/proxmox/Internal/resource/guest/lxc/networks/sdk_networks.go
+++ b/proxmox/Internal/resource/guest/lxc/networks/sdk_networks.go
@@ -5,7 +5,6 @@ import (
 	"strconv"
 
 	pveSDK "github.com/Telmate/proxmox-api-go/proxmox"
-	"github.com/Telmate/terraform-provider-proxmox/v2/proxmox/Internal/util"
 )
 
 func sdkNetworks(schema map[string]any) pveSDK.LxcNetworks {
@@ -23,16 +22,16 @@ func sdkNetworks(schema map[string]any) pveSDK.LxcNetworks {
 			mac, _ = net.ParseMAC(schemaMap[schemaMAC].(string))
 		}
 		config[pveSDK.LxcNetworkID(tmpID)] = pveSDK.LxcNetwork{
-			Bridge:        util.Pointer(schemaMap[schemaBridge].(string)),
-			Connected:     util.Pointer(schemaMap[schemaConnected].(bool)),
-			Firewall:      util.Pointer(schemaMap[schemaFirewall].(bool)),
+			Bridge:        new(schemaMap[schemaBridge].(string)),
+			Connected:     new(schemaMap[schemaConnected].(bool)),
+			Firewall:      new(schemaMap[schemaFirewall].(bool)),
 			IPv4:          sdkNetworksIPv4(schemaMap[schmemaIPv4].([]any)),
 			IPv6:          sdkNetworksIPv6(schemaMap[schmemaIPv6].([]any)),
-			MAC:           util.Pointer(mac),
-			Mtu:           util.Pointer(pveSDK.MTU(schemaMap[schemaMTU].(int))),
-			Name:          util.Pointer(pveSDK.LxcNetworkName(schemaMap[schemaName].(string))),
-			NativeVlan:    util.Pointer(pveSDK.Vlan(schemaMap[schemaNativeVlan].(int))),
-			RateLimitKBps: util.Pointer(pveSDK.GuestNetworkRate(schemaMap[schemaRateLimit].(int)))}
+			MAC:           new(mac),
+			Mtu:           new(pveSDK.MTU(schemaMap[schemaMTU].(int))),
+			Name:          new(pveSDK.LxcNetworkName(schemaMap[schemaName].(string))),
+			NativeVlan:    new(pveSDK.Vlan(schemaMap[schemaNativeVlan].(int))),
+			RateLimitKBps: new(pveSDK.GuestNetworkRate(schemaMap[schemaRateLimit].(int)))}
 	}
 	return config
 }

--- a/proxmox/Internal/resource/guest/lxc/networks/sdk_networks.go
+++ b/proxmox/Internal/resource/guest/lxc/networks/sdk_networks.go
@@ -7,7 +7,7 @@ import (
 	pveSDK "github.com/Telmate/proxmox-api-go/proxmox"
 )
 
-func sdkNetworks(schema map[string]any) pveSDK.LxcNetworks {
+func sdkNetworks(version pveSDK.EncodedVersion, schema map[string]any) pveSDK.LxcNetworks {
 	config := make(pveSDK.LxcNetworks, len(schema))
 	for k, v := range schema {
 		tmpID, _ := strconv.ParseUint(k[len(prefixSchemaID):], 10, 64)
@@ -21,10 +21,15 @@ func sdkNetworks(schema map[string]any) pveSDK.LxcNetworks {
 		if v := schemaMap[schemaMAC].(string); v != "" {
 			mac, _ = net.ParseMAC(schemaMap[schemaMAC].(string))
 		}
+		var hostManaged *bool
+		if version >= HostManagedVersion() {
+			hostManaged = new(schemaMap[schemaHostManaged].(bool))
+		}
 		config[pveSDK.LxcNetworkID(tmpID)] = pveSDK.LxcNetwork{
 			Bridge:        new(schemaMap[schemaBridge].(string)),
 			Connected:     new(schemaMap[schemaConnected].(bool)),
 			Firewall:      new(schemaMap[schemaFirewall].(bool)),
+			HostManaged:   hostManaged,
 			IPv4:          sdkNetworksIPv4(schemaMap[schmemaIPv4].([]any)),
 			IPv6:          sdkNetworksIPv6(schemaMap[schmemaIPv6].([]any)),
 			MAC:           new(mac),
@@ -41,7 +46,6 @@ func sdkNetworksIPv4(schema []any) *pveSDK.LxcIPv4 {
 	var gateway pveSDK.IPv4Address
 	if len(schema) == 1 {
 		v := schema[0].(map[string]any)
-		_ = v
 		if v[schemaDHCP].(bool) {
 			return &pveSDK.LxcIPv4{DHCP: true}
 		}
@@ -56,9 +60,8 @@ func sdkNetworksIPv4(schema []any) *pveSDK.LxcIPv4 {
 func sdkNetworksIPv6(schema []any) *pveSDK.LxcIPv6 {
 	var address pveSDK.IPv6CIDR
 	var gateway pveSDK.IPv6Address
-	if len(schema) == 1 {
+	if len(schema) == 1 && schema[0] != nil {
 		v := schema[0].(map[string]any)
-		_ = v
 		if v[schemaDHCP].(bool) {
 			return &pveSDK.LxcIPv6{DHCP: true}
 		}

--- a/proxmox/Internal/resource/guest/lxc/networks/terraform.go
+++ b/proxmox/Internal/resource/guest/lxc/networks/terraform.go
@@ -13,7 +13,7 @@ func Terraform(networks pveSDK.LxcNetworks, d *schema.ResourceData) error {
 		}
 		d.Set(RootNetwork, devices)
 	} else {
-		d.Set(RootNetworks, terraformNetworks(networks))
+		d.Set(RootNetworks, terraformNetworks(networks, d))
 	}
 	return nil
 }

--- a/proxmox/Internal/resource/guest/lxc/networks/terraform_network.go
+++ b/proxmox/Internal/resource/guest/lxc/networks/terraform_network.go
@@ -32,6 +32,17 @@ func terraformNetwork(config pveSDK.LxcNetworks, tfConfig []any) ([]map[string]a
 			schemaID:        prefixSchemaID + strconv.FormatUint(uint64(i), 10),
 			schemaName:      v.Name.String()}
 		mac.Terraform(v.MAC.String(), int(i), tfMap, schemaMAC, params)
+		if v.HostManaged != nil {
+			params[schemaHostManaged] = *v.HostManaged
+		} else {
+			hostManaged := defaultHostManaged
+			if v, ok := tfMap[int(i)].(map[string]any); ok {
+				if vv, ok := v[schemaHostManaged]; ok {
+					hostManaged = vv.(bool)
+				}
+			}
+			params[schemaHostManaged] = hostManaged
+		}
 		if v.Mtu != nil {
 			params[schemaMTU] = int(*v.Mtu)
 		}

--- a/proxmox/Internal/resource/guest/lxc/networks/terraform_networks.go
+++ b/proxmox/Internal/resource/guest/lxc/networks/terraform_networks.go
@@ -4,10 +4,17 @@ import (
 	"strconv"
 
 	pveSDK "github.com/Telmate/proxmox-api-go/proxmox"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
-func terraformNetworks(config pveSDK.LxcNetworks) []any {
+func terraformNetworks(config pveSDK.LxcNetworks, d *schema.ResourceData) []any {
 	mapParams := make(map[string]any, networksAmount)
+	var networkMap map[string]any
+	if tfConfig := d.Get(RootNetworks); tfConfig != nil {
+		if v, ok := tfConfig.([]any); ok && len(v) > 0 {
+			networkMap = v[0].(map[string]any)
+		}
+	}
 	for k, v := range config {
 		settings := map[string]any{
 			schemaBridge:    *v.Bridge,
@@ -15,6 +22,19 @@ func terraformNetworks(config pveSDK.LxcNetworks) []any {
 			schemaFirewall:  *v.Firewall,
 			schemaMAC:       v.MAC.String(),
 			schemaName:      v.Name.String()}
+		if v.HostManaged != nil {
+			settings[schemaHostManaged] = *v.HostManaged
+		} else {
+			hostManaged := defaultHostManaged
+			if v, ok := networkMap[prefixSchemaID+k.String()]; ok {
+				if vv, ok := v.([]any); ok && len(vv) > 0 {
+					if vvv, ok := vv[0].(map[string]any)[schemaHostManaged]; ok {
+						hostManaged = vvv.(bool)
+					}
+				}
+			}
+			settings[schemaHostManaged] = hostManaged
+		}
 		if v.Mtu != nil {
 			settings[schemaMTU] = int(*v.Mtu)
 		}

--- a/proxmox/resource_lxc_guest.go
+++ b/proxmox/resource_lxc_guest.go
@@ -32,6 +32,7 @@ import (
 	"github.com/Telmate/terraform-provider-proxmox/v2/proxmox/Internal/resource/id"
 	"github.com/Telmate/terraform-provider-proxmox/v2/proxmox/Internal/util"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
@@ -46,7 +47,10 @@ func resourceLxcGuest() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
-		CustomizeDiff: reboot.CustomizeDiff(),
+		CustomizeDiff: customdiff.All(
+			networks.CustomizeDiff(),
+			reboot.CustomizeDiff(),
+		),
 
 		Schema: map[string]*schema.Schema{
 			architecture.Root:            architecture.Schema(),
@@ -97,8 +101,13 @@ func resourceLxcGuestCreate(ctx context.Context, d *schema.ResourceData, meta an
 	client := pconf.Client
 	clientNew := pconf.NewClient
 
+	version, err := client.Version(ctx)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
 	privileged := privilege.SDK(d)
-	config, tmpDiags := lxcSDK(privileged, d)
+	config, tmpDiags := lxcSDK(privileged, version, d)
 	diags = append(diags, tmpDiags...)
 	if diags.HasError() {
 		return diags
@@ -107,7 +116,8 @@ func resourceLxcGuestCreate(ctx context.Context, d *schema.ResourceData, meta an
 	config.Privileged = &privileged
 
 	// Set the node for the LXC container
-	targetNode, err := node.SdkCreate(d)
+	var targetNode pveSDK.NodeName
+	targetNode, err = node.SdkCreate(d)
 	if err != nil {
 		return append(diags, diag.Diagnostic{
 			Summary:  err.Error(),
@@ -176,9 +186,14 @@ func resourceLxcGuestUpdate(ctx context.Context, d *schema.ResourceData, meta an
 
 	diags := lxcGuestWarning()
 
+	version, err := client.Version(ctx)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
 	// Get vm reference
 	var resourceID id.Guest
-	err := resourceID.Parse(d.Id())
+	err = resourceID.Parse(d.Id())
 	if err != nil {
 		d.SetId("")
 		return append(diags, diag.Diagnostic{
@@ -194,7 +209,7 @@ func resourceLxcGuestUpdate(ctx context.Context, d *schema.ResourceData, meta an
 	}
 
 	// create a new config from the resource data
-	config, tmpDiags := lxcSDK(privilege.SDK(d), d)
+	config, tmpDiags := lxcSDK(privilege.SDK(d), version, d)
 	diags = append(diags, tmpDiags...)
 	if diags.HasError() {
 		return diags
@@ -315,7 +330,7 @@ func resourceLxcGuestDelete(ctx context.Context, d *schema.ResourceData, meta an
 	return guestDelete(ctx, d, meta, "LXC")
 }
 
-func lxcSDK(privilidged bool, d *schema.ResourceData) (pveSDK.ConfigLXC, diag.Diagnostics) {
+func lxcSDK(privilidged bool, version pveSDK.Version, d *schema.ResourceData) (pveSDK.ConfigLXC, diag.Diagnostics) {
 	var guestName *pveSDK.GuestName
 	if v := name.SDK(d); v != "" {
 		guestName = &v
@@ -335,7 +350,7 @@ func lxcSDK(privilidged bool, d *schema.ResourceData) (pveSDK.ConfigLXC, diag.Di
 		Tags:            tags.SDK(d),
 	}
 	var diags, tmpDiags diag.Diagnostics
-	config.Networks, diags = networks.SDK(d)
+	config.Networks, diags = networks.SDK(version.Encode(), d)
 	if diags.HasError() {
 		return config, diags
 	}

--- a/proxmox/resource_lxc_guest.go
+++ b/proxmox/resource_lxc_guest.go
@@ -279,7 +279,12 @@ func resourceLxcGuestRead(ctx context.Context, d *schema.ResourceData, vmr *pveS
 		Node: vmr.Node(),
 		Type: id.GuestLxc}.String())
 
-	config := raw.Get(*vmr, pveSDK.PowerStateUnknown)
+	var poolPtr *pveSDK.PoolName
+	if v := vmr.Pool(); v != "" {
+		poolPtr = &v
+	}
+
+	config := raw.Get(poolPtr, pveSDK.PowerStateUnknown)
 
 	architecture.Terraform(config.Architecture, d)
 	cpu.Terraform(config.CPU, d)

--- a/proxmox/resource_lxc_guest.go
+++ b/proxmox/resource_lxc_guest.go
@@ -323,7 +323,7 @@ func lxcSDK(privilidged bool, d *schema.ResourceData) (pveSDK.ConfigLXC, diag.Di
 		Features:        features.SDK(privilidged, d),
 		Memory:          memory.SDK(d),
 		Name:            guestName,
-		StartAtNodeBoot: util.Pointer(startatnodeboot.SDK(d)),
+		StartAtNodeBoot: new(startatnodeboot.SDK(d)),
 		StartupShutdown: startupshutdown.SDK(d),
 		State:           powerstate.SDK(powerstate.LegacyFalse, d),
 		Swap:            swap.SDK(d),


### PR DESCRIPTION
Adds support for the `host_managed` property introduced in PVE9.1 for `proxmox_lxc_guest`.

Pre PVE9.1 we will return the value set by the provider instead of clearing it.