### PR TITLE
Feat: Lxc network info

### DIFF
--- a/docs/resources/lxc_guest.md
+++ b/docs/resources/lxc_guest.md
@@ -52,10 +52,13 @@ resource "proxmox_lxc_guest" "minimal-example" {
 | `dns`               | `nested`|                          | DNS configuration, see [DNS Reference](#dns-reference).|
 | `features`          | `nested`|                          | Features configuration, see [Features Reference](#features-reference).|
 | `guest_id`          | `int`   |                          | **Forces Recreation**, **Computed**: The numeric ID of the guest container also known as `vmid`. If not specified, an ID will be automatically assigned.|
+| `ipv4_address`      | `str`   |                          | **Computed** Read-only attribute. Returns the ip of the first configured network interface. The setting `skip_ipv4` has influence on this.|
+| `ipv6_address`      | `str`   |                          | **Computed** Read-only attribute. Returns the ip of the first configured network interface. The setting `skip_ipv6` has influence on this.|
 | `memory`            | `int`   | `512`                    | The amount of memory to allocate to the guest in Megabytes.|
 | `mount`             | `array` |                          | Storage mounts configured as individual array items, see [Mount Reference](#mount-reference).|
 | `mounts`            | `nested`|                          | Storage mounts configured as nested sub items, see [Mounts Reference](#mounts-reference).|
 | `name`              | `string`|                          | **Required**: The name of the container.|
+| `network_timeout`   | `int`   | `90`                     | Timeout in seconds to keep trying to obtain an IP address from the network info onece we have a connection. |
 | `network`           | `array` |                          | Network interfaces configured as individual array items, see [Network Reference](#network-reference).|
 | `networks`          | `nested`|                          | Network interfaces configured as nested sub items, see [Networks Reference](#networks-reference).|
 | `os`                | `string`|                          | **Computed**: The name of the OS inside the guest.|
@@ -64,6 +67,8 @@ resource "proxmox_lxc_guest" "minimal-example" {
 | `power_state`       | `string`| `"running"`              | Power state of the guest, can be `"running"` or `"stopped"`.|
 | `privileged`        | `bool`  |                          | **Forces Recreation**: If the guest is privileged or unprivileged. Can only be `true` or unset. Mutually exclusive with `unprivileged`.|
 | `root_mount`        | `nested`|                          | **Required**: Configuration of the root/boot mount/disk of the guest container. **Note:** Size can only be increased, not decreased.|
+| `skip_ipv4`         | `bool`  | `false`                  | Tells Terraform that acquiring an IPv4 address from the network info isn't required, it will still return an ipv4 address if it could obtain one. Useful for reducing retries in environments without ipv4.|
+| `skip_ipv6`         | `bool`  | `false`                  | Tells Terraform that acquiring an IPv6 address from the network info isn't required, it will still return an ipv6 address if it could obtain one. Useful for reducing retries in environments without ipv6.|
 | `ssh_public_key`    | `string`|                          | **Forces Recreation** SSH public key of the root user inside the guest container.|
 | `start_at_node_boot`| `bool`  | `false`                  | Whether the guest should start automatically when the Proxmox node boots.|
 | `startup_shutdown`  | `nested`|                          | Startup and shutdown configuration of the guest, see [Startup and Shutdown Reference](#startup-and-shutdown-reference).|

--- a/docs/resources/vm_qemu.md
+++ b/docs/resources/vm_qemu.md
@@ -141,9 +141,9 @@ The following arguments are supported in the top level resource block.
 | `ipconfig1` to `ipconfig15`   | `str`    |                      | The second IP address to assign to the guest. Same format as `ipconfig0`. |
 | `automatic_reboot`            | `bool`   | `true`               | Automatically reboot the VM when parameter changes require this. If disabled the provider will emit a warning or error when the VM needs to be rebooted, this can be configured with `automatic_reboot_severity`.|
 | `automatic_reboot_severity`   | `string`  | `error`              | Sets the severity of the error/warning when `automatic_reboot` is `false`. Values can be `error` or `warning`.|
-| `skip_ipv4`                   | `bool`   | `false`              | Tells proxmox that acquiring an IPv4 address from the qemu guest agent isn't required, it will still return an ipv4 address if it could obtain one. Useful for reducing retries in environments without ipv4.|
-| `skip_ipv6`                   | `bool`   | `false`              | Tells proxmox that acquiring an IPv6 address from the qemu guest agent isn't required, it will still return an ipv6 address if it could obtain one. Useful for reducing retries in environments without ipv6.|
-| `agent_timeout`               | `int`    | `90`                 | Timeout in seconds to keep trying to obtain an IP address from the guest agent one we have a connection. |
+| `skip_ipv4`                   | `bool`   | `false`              | Tells Terraform that acquiring an IPv4 address from the qemu guest agent isn't required, it will still return an ipv4 address if it could obtain one. Useful for reducing retries in environments without ipv4.|
+| `skip_ipv6`                   | `bool`   | `false`              | Tells Terraform that acquiring an IPv6 address from the qemu guest agent isn't required, it will still return an ipv6 address if it could obtain one. Useful for reducing retries in environments without ipv6.|
+| `agent_timeout`               | `int`    | `90`                 | Timeout in seconds to keep trying to obtain an IP address from the guest agent onece we have a connection. |
 | `current_node`                | `string` |                      | **Computed** The current node of the Qemu guest is on.|
 
 ### CPU Block

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/Telmate/terraform-provider-proxmox/v2
 go 1.26.2
 
 require (
-	github.com/Telmate/proxmox-api-go v0.0.0-20260811170036-d21834931666
+	github.com/Telmate/proxmox-api-go v0.0.0-20260830211552-9cba66824699
 	github.com/google/uuid v1.6.0
 	github.com/hashicorp/go-cty v1.5.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.40.1

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,8 @@ github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERo
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/ProtonMail/go-crypto v1.4.1 h1:9RfcZHqEQUvP8RzecWEUafnZVtEvrBVL9BiF67IQOfM=
 github.com/ProtonMail/go-crypto v1.4.1/go.mod h1:e1OaTyu5SYVrO9gKOEhTc+5UcXtTUa+P3uLudwcgPqo=
-github.com/Telmate/proxmox-api-go v0.0.0-20260811170036-d21834931666 h1:mnnCE8Ws3UClCeOrDTApDHrT6zjGUgEa+LvvCHiieds=
-github.com/Telmate/proxmox-api-go v0.0.0-20260811170036-d21834931666/go.mod h1:8Ibp7735ao2KgxxdRjqQKktH0RA6TTTfRL7aw1gj324=
+github.com/Telmate/proxmox-api-go v0.0.0-20260830211552-9cba66824699 h1:3MKcKCKU6HlSKBBn7ssTn4UwUINKxRnUtdoBS8hTqi4=
+github.com/Telmate/proxmox-api-go v0.0.0-20260830211552-9cba66824699/go.mod h1:8Ibp7735ao2KgxxdRjqQKktH0RA6TTTfRL7aw1gj324=
 github.com/agext/levenshtein v1.2.3 h1:YB2fHEn0UJagG8T1rrWknE3ZQzWM06O8AMAatNn7lmo=
 github.com/agext/levenshtein v1.2.3/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
 github.com/apparentlymart/go-textseg/v12 v12.0.0/go.mod h1:S/4uRK2UtaQttw1GenVJEynmyUenKwP++x/+DdGV/Ec=

--- a/proxmox/Internal/resource/guest/ip/schema.go
+++ b/proxmox/Internal/resource/guest/ip/schema.go
@@ -7,6 +7,8 @@ const (
 	RootSkipV6 = "skip_ipv6"
 	RootQemuV4 = "default_ipv4_address"
 	RootQemuV6 = "default_ipv6_address"
+	RootLxcV4  = "ipv4_address"
+	RootLxcV6  = "ipv6_address"
 )
 
 func SchemaSkipV4() *schema.Schema {

--- a/proxmox/Internal/resource/guest/ip/schema.go
+++ b/proxmox/Internal/resource/guest/ip/schema.go
@@ -1,0 +1,44 @@
+package ip
+
+import "github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+const (
+	RootSkipV4 = "skip_ipv4"
+	RootSkipV6 = "skip_ipv6"
+	RootQemuV4 = "default_ipv4_address"
+	RootQemuV6 = "default_ipv6_address"
+)
+
+func SchemaSkipV4() *schema.Schema {
+	return &schema.Schema{
+		Type:          schema.TypeBool,
+		Optional:      true,
+		Default:       false,
+		ConflictsWith: []string{RootSkipV6},
+	}
+}
+
+func SchemaSkipV6() *schema.Schema {
+	return &schema.Schema{
+		Type:          schema.TypeBool,
+		Optional:      true,
+		Default:       false,
+		ConflictsWith: []string{RootSkipV4},
+	}
+}
+
+func SchemaV4() *schema.Schema {
+	return &schema.Schema{
+		Type:        schema.TypeString,
+		Computed:    true,
+		Description: "Use to track guest ipv4 address",
+	}
+}
+
+func SchemaV6() *schema.Schema {
+	return &schema.Schema{
+		Type:        schema.TypeString,
+		Computed:    true,
+		Description: "Use to track guest ipv6 address",
+	}
+}

--- a/proxmox/Internal/resource/guest/lxc/networks/schema.go
+++ b/proxmox/Internal/resource/guest/lxc/networks/schema.go
@@ -46,7 +46,7 @@ const (
 	schemaIPv6DHCP    = "ipv6_" + schemaDHCP
 	schemaIPv6Gateway = "ipv6_" + schemaGateway
 
-	networksAmount = pveSDK.LxcNetworksAmount
+	NetworksAmount = pveSDK.LxcNetworksAmount
 	maximumID      = pveSDK.LxcNetworkIdMaximum
 
 	defaultConnected   = true
@@ -264,7 +264,7 @@ func CustomizeDiff() schema.CustomizeDiffFunc {
 			}
 		} else if v := d.Get(RootNetworks).([]any); len(v) == 1 { // networks
 			if subSchema, ok := v[0].(map[string]any); ok {
-				for i := range networksAmount {
+				for i := range NetworksAmount {
 					id := prefixSchemaID + strconv.Itoa(i)
 					schemaArray := subSchema[id].([]any)
 					if len(schemaArray) == 0 {

--- a/proxmox/Internal/resource/guest/lxc/networks/schema_networks.go
+++ b/proxmox/Internal/resource/guest/lxc/networks/schema_networks.go
@@ -7,8 +7,8 @@ import (
 )
 
 func SchemaNetworks() *schema.Schema {
-	schemaItems := make(map[string]*schema.Schema, networksAmount)
-	for i := range networksAmount {
+	schemaItems := make(map[string]*schema.Schema, NetworksAmount)
+	for i := range NetworksAmount {
 		id := strconv.Itoa(i)
 		schemaItems[prefixSchemaID+id] = networksSubSchema(prefixSchemaID + id)
 	}

--- a/proxmox/Internal/resource/guest/lxc/networks/sdk.go
+++ b/proxmox/Internal/resource/guest/lxc/networks/sdk.go
@@ -15,7 +15,7 @@ func SDK(version pveSDK.EncodedVersion, d *schema.ResourceData) (pveSDK.LxcNetwo
 		}
 	}
 	// Defaults
-	config := make(pveSDK.LxcNetworks, networksAmount)
+	config := make(pveSDK.LxcNetworks, NetworksAmount)
 	for i := range pveSDK.LxcNetworkID(maximumID) {
 		config[i] = pveSDK.LxcNetwork{Delete: true}
 	}

--- a/proxmox/Internal/resource/guest/lxc/networks/sdk_network.go
+++ b/proxmox/Internal/resource/guest/lxc/networks/sdk_network.go
@@ -40,7 +40,7 @@ func sdkNetwork(version pveSDK.EncodedVersion, schema []any) (pveSDK.LxcNetworks
 			NativeVlan:    new(pveSDK.Vlan(schemaMap[schemaNativeVlan].(int))),
 			RateLimitKBps: new(pveSDK.GuestNetworkRate(schemaMap[schemaRateLimit].(int)))}
 	}
-	for i := range pveSDK.LxcNetworkID(networksAmount) { // ensure all networks are present
+	for i := range pveSDK.LxcNetworkID(NetworksAmount) { // ensure all networks are present
 		if _, ok := config[i]; !ok {
 			config[i] = pveSDK.LxcNetwork{Delete: true}
 		}

--- a/proxmox/Internal/resource/guest/lxc/networks/terraform_network.go
+++ b/proxmox/Internal/resource/guest/lxc/networks/terraform_network.go
@@ -20,7 +20,7 @@ func terraformNetwork(config pveSDK.LxcNetworks, tfConfig []any) ([]map[string]a
 		tfMap[id] = tfConfig[i]
 	}
 	var index int
-	for i := range pveSDK.LxcNetworkID(networksAmount) {
+	for i := range pveSDK.LxcNetworkID(NetworksAmount) {
 		v, ok := config[i]
 		if !ok {
 			continue

--- a/proxmox/Internal/resource/guest/lxc/networks/terraform_networks.go
+++ b/proxmox/Internal/resource/guest/lxc/networks/terraform_networks.go
@@ -8,7 +8,7 @@ import (
 )
 
 func terraformNetworks(config pveSDK.LxcNetworks, d *schema.ResourceData) []any {
-	mapParams := make(map[string]any, networksAmount)
+	mapParams := make(map[string]any, NetworksAmount)
 	var networkMap map[string]any
 	if tfConfig := d.Get(RootNetworks); tfConfig != nil {
 		if v, ok := tfConfig.([]any); ok && len(v) > 0 {

--- a/proxmox/Internal/resource/guest/wait/schema.go
+++ b/proxmox/Internal/resource/guest/wait/schema.go
@@ -1,0 +1,22 @@
+package wait
+
+import (
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+const Root = "additional_wait"
+
+func Schema() *schema.Schema {
+	return &schema.Schema{
+		Type:        schema.TypeInt,
+		Optional:    true,
+		Default:     5,
+		Description: "Value in second to wait after some operations, useful if system is not fast or during I/O intensive parallel terraform tasks",
+	}
+}
+
+func GetDuration(d *schema.ResourceData) time.Duration {
+	return time.Duration(d.Get(Root).(int)) * time.Second
+}

--- a/proxmox/heper_qemu.go
+++ b/proxmox/heper_qemu.go
@@ -5,13 +5,8 @@ import (
 	"strings"
 
 	pveSDK "github.com/Telmate/proxmox-api-go/proxmox"
+	"github.com/Telmate/terraform-provider-proxmox/v2/proxmox/Internal/resource/guest/ip"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-)
-
-const (
-	errorGuestAgentNoIPSummary   string = "Qemu Guest Agent is enabled but no IP config is found"
-	errorGuestAgentNoIPv4Summary string = "Qemu Guest Agent is enabled but no IPv4 address is found"
-	errorGuestAgentNoIPv6Summary string = "Qemu Guest Agent is enabled but no IPv6 address is found"
 )
 
 func parseCloudInitInterface(ipConfig pveSDK.CloudInitNetworkConfig, ciCustom, skipIPv4, skipIPv6 bool) (conn connectionInfo) {
@@ -47,27 +42,33 @@ type connectionInfo struct {
 	SkipIPv6 bool
 }
 
-func (conn connectionInfo) agentDiagnostics() diag.Diagnostics {
+const (
+	errorNoIPSummary   = "no IP config is found"
+	errorNoIPv4Summary = "no IPv4 address is found"
+	errorNoIPv6Summary = "no IPv6 address is found"
+)
+
+func (conn connectionInfo) agentDiagnostics(key, prefixSummary, prefixDetail string) diag.Diagnostics {
 	if conn.IPs.IPv4 == "" {
 		if conn.IPs.IPv6 == "" {
 			return diag.Diagnostics{diag.Diagnostic{
 				Severity: diag.Warning,
-				Summary:  errorGuestAgentNoIPSummary,
-				Detail:   "Qemu Guest Agent is enabled in your configuration but no IP address was found before the time ran out, increasing '" + schemaAgentTimeout + "' could resolve this issue."}}
+				Summary:  prefixSummary + errorNoIPSummary,
+				Detail:   prefixDetail + "no IP address was found before the time ran out, increasing '" + key + "' could resolve this issue."}}
 		}
 		if !conn.SkipIPv4 {
 			return diag.Diagnostics{diag.Diagnostic{
 				Severity: diag.Warning,
-				Summary:  errorGuestAgentNoIPv4Summary,
-				Detail:   "Qemu Guest Agent is enabled in your configuration but no IPv4 address was found before the time ran out, increasing '" + schemaAgentTimeout + "' could resolve this issue. To suppress this warning set '" + schemaSkipIPv4 + "' to true."}}
+				Summary:  prefixSummary + errorNoIPv4Summary,
+				Detail:   prefixDetail + "no IPv4 address was found before the time ran out, increasing '" + key + "' could resolve this issue. To suppress this warning set '" + ip.RootSkipV4 + "' to true."}}
 		}
 		return diag.Diagnostics{}
 	}
 	if conn.IPs.IPv6 == "" && !conn.SkipIPv6 {
 		return diag.Diagnostics{diag.Diagnostic{
 			Severity: diag.Warning,
-			Summary:  errorGuestAgentNoIPv6Summary,
-			Detail:   "Qemu Guest Agent is enabled in your configuration but no IPv6 address was found before the time ran out, increasing '" + schemaAgentTimeout + "' could resolve this issue. To suppress this warning set '" + schemaSkipIPv6 + "' to true."}}
+			Summary:  prefixSummary + errorNoIPv6Summary,
+			Detail:   prefixDetail + "no IPv6 address was found before the time ran out, increasing '" + key + "' could resolve this issue. To suppress this warning set '" + ip.RootSkipV6 + "' to true."}}
 	}
 	return diag.Diagnostics{}
 }

--- a/proxmox/heper_qemu.go
+++ b/proxmox/heper_qemu.go
@@ -80,7 +80,7 @@ func (conn connectionInfo) hasRequiredIP() bool {
 	return true
 }
 
-func (conn connectionInfo) parsePrimaryIPs(ipAddresses []net.IP) connectionInfo {
+func (conn *connectionInfo) parsePrimaryIPs(ipAddresses []net.IP) {
 	for i := range ipAddresses {
 		if ipAddresses[i].IsGlobalUnicast() {
 			if ipAddresses[i].To4() != nil {
@@ -94,5 +94,4 @@ func (conn connectionInfo) parsePrimaryIPs(ipAddresses []net.IP) connectionInfo 
 			}
 		}
 	}
-	return conn
 }

--- a/proxmox/heper_qemu_test.go
+++ b/proxmox/heper_qemu_test.go
@@ -351,7 +351,8 @@ func Test_ParsePrimaryIPs(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			require.Equal(t, test.output, test.input.conn.parsePrimaryIPs(test.input.nets))
+			test.input.conn.parsePrimaryIPs(test.input.nets)
+			require.Equal(t, test.output, test.input.conn)
 		})
 	}
 }

--- a/proxmox/heper_qemu_test.go
+++ b/proxmox/heper_qemu_test.go
@@ -18,22 +18,22 @@ func Test_connectionInfo_agentDiagnostics(t *testing.T) {
 	}{
 		{name: `empty empty false false`,
 			input:  connectionInfo{primaryIPs{"", ""}, false, false},
-			output: errorGuestAgentNoIPSummary},
+			output: errorNoIPSummary},
 		{name: `empty empty false true`,
 			input:  connectionInfo{primaryIPs{"", ""}, false, true},
-			output: errorGuestAgentNoIPSummary},
+			output: errorNoIPSummary},
 		{name: `empty empty true false`,
 			input:  connectionInfo{primaryIPs{"", ""}, true, false},
-			output: errorGuestAgentNoIPSummary},
+			output: errorNoIPSummary},
 		{name: `empty empty true true`,
 			input:  connectionInfo{primaryIPs{"", ""}, true, true},
-			output: errorGuestAgentNoIPSummary},
+			output: errorNoIPSummary},
 		{name: `empty set false false`,
 			input:  connectionInfo{primaryIPs{"", "set"}, false, false},
-			output: errorGuestAgentNoIPv4Summary},
+			output: errorNoIPv4Summary},
 		{name: `empty set false true`,
 			input:  connectionInfo{primaryIPs{"", "set"}, false, true},
-			output: errorGuestAgentNoIPv4Summary},
+			output: errorNoIPv4Summary},
 		{name: `empty set true false`,
 			input:  connectionInfo{primaryIPs{"", "set"}, true, false},
 			output: ""},
@@ -42,13 +42,13 @@ func Test_connectionInfo_agentDiagnostics(t *testing.T) {
 			output: ""},
 		{name: `set empty false false`,
 			input:  connectionInfo{primaryIPs{"set", ""}, false, false},
-			output: errorGuestAgentNoIPv6Summary},
+			output: errorNoIPv6Summary},
 		{name: `set empty false true`,
 			input:  connectionInfo{primaryIPs{"set", ""}, false, true},
 			output: ""},
 		{name: `set empty true false`,
 			input:  connectionInfo{primaryIPs{"set", ""}, true, false},
-			output: errorGuestAgentNoIPv6Summary},
+			output: errorNoIPv6Summary},
 		{name: `set empty true true`,
 			input:  connectionInfo{primaryIPs{"set", ""}, true, true},
 			output: ""},
@@ -68,11 +68,11 @@ func Test_connectionInfo_agentDiagnostics(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			if test.output != "" {
-				tmpDiag := test.input.agentDiagnostics()
+				tmpDiag := test.input.agentDiagnostics("", "", "")
 				require.Len(t, tmpDiag, 1)
 				require.Equal(t, test.output, tmpDiag[0].Summary)
 			} else {
-				require.Equal(t, diag.Diagnostics{}, test.input.agentDiagnostics())
+				require.Equal(t, diag.Diagnostics{}, test.input.agentDiagnostics("", "", ""))
 			}
 		})
 	}

--- a/proxmox/provider.go
+++ b/proxmox/provider.go
@@ -218,11 +218,11 @@ func Provider() *schema.Provider {
 			"proxmox_ha_groups": DataHAGroup(),
 		},
 
-		ConfigureFunc: providerConfigure,
+		ConfigureContextFunc: providerConfigure,
 	}
 }
 
-func providerConfigure(d *schema.ResourceData) (any, error) {
+func providerConfigure(ctx context.Context, d *schema.ResourceData) (any, diag.Diagnostics) {
 	client, err := getClient(
 		d.Get(schemaPmApiUrl).(string),
 		d.Get(schemaPmUser).(string),
@@ -237,7 +237,7 @@ func providerConfigure(d *schema.ResourceData) (any, error) {
 		d.Get(schemaPmProxyServer).(string),
 	)
 	if err != nil {
-		return nil, err
+		return nil, diag.FromErr(err)
 	}
 
 	minimumPermissions := []string{
@@ -280,17 +280,17 @@ func providerConfigure(d *schema.ResourceData) (any, error) {
 		}
 		var userID pveSDK.UserID
 		if err := userID.Parse(id); err != nil {
-			return nil, err
+			return nil, diag.FromErr(err)
 		}
 		permList, err := client.GetUserPermissions(context.Background(), userID, "/")
 		if err != nil {
-			return nil, err
+			return nil, diag.FromErr(err)
 		}
 		sort.Strings(permList)
 		sort.Strings(minimumPermissions)
 		permDiff := permissions_check(permList, minimumPermissions)
 		if len(permDiff) != 0 {
-			return nil, fmt.Errorf("permissions for user/token "+userID.String()+" are not sufficient, please provide also the following permissions that are missing: %v", permDiff)
+			return nil, diag.Errorf("permissions for user/token "+userID.String()+" are not sufficient, please provide also the following permissions that are missing: %v", permDiff)
 		}
 	}
 
@@ -301,7 +301,7 @@ func providerConfigure(d *schema.ResourceData) (any, error) {
 		if ok {
 			logLevels[logger] = levelAsString
 		} else {
-			return nil, fmt.Errorf("invalid logging level %v for %v. Be sure to use a string", level, logger)
+			return nil, diag.Errorf("invalid logging level %v for %v. Be sure to use a string", level, logger)
 		}
 	}
 

--- a/proxmox/resource_lxc_guest.go
+++ b/proxmox/resource_lxc_guest.go
@@ -2,12 +2,14 @@ package proxmox
 
 import (
 	"context"
+	"time"
 
 	pveSDK "github.com/Telmate/proxmox-api-go/proxmox"
 	"github.com/Telmate/terraform-provider-proxmox/v2/proxmox/Internal/resource/guest/clone"
 	"github.com/Telmate/terraform-provider-proxmox/v2/proxmox/Internal/resource/guest/description"
 	"github.com/Telmate/terraform-provider-proxmox/v2/proxmox/Internal/resource/guest/dns"
 	"github.com/Telmate/terraform-provider-proxmox/v2/proxmox/Internal/resource/guest/guestid"
+	"github.com/Telmate/terraform-provider-proxmox/v2/proxmox/Internal/resource/guest/ip"
 	"github.com/Telmate/terraform-provider-proxmox/v2/proxmox/Internal/resource/guest/lxc/architecture"
 	"github.com/Telmate/terraform-provider-proxmox/v2/proxmox/Internal/resource/guest/lxc/cpu"
 	"github.com/Telmate/terraform-provider-proxmox/v2/proxmox/Internal/resource/guest/lxc/features"
@@ -29,14 +31,20 @@ import (
 	"github.com/Telmate/terraform-provider-proxmox/v2/proxmox/Internal/resource/guest/reboot"
 	"github.com/Telmate/terraform-provider-proxmox/v2/proxmox/Internal/resource/guest/startatnodeboot"
 	"github.com/Telmate/terraform-provider-proxmox/v2/proxmox/Internal/resource/guest/startupshutdown"
+	"github.com/Telmate/terraform-provider-proxmox/v2/proxmox/Internal/resource/guest/wait"
 	"github.com/Telmate/terraform-provider-proxmox/v2/proxmox/Internal/resource/id"
 	"github.com/Telmate/terraform-provider-proxmox/v2/proxmox/Internal/util"
+	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 var lxcNewResourceDef *schema.Resource
+
+const (
+	schemaNetworkTimeout = "network_timeout"
+)
 
 func resourceLxcGuest() *schema.Resource {
 	lxcNewResourceDef = &schema.Resource{
@@ -60,6 +68,10 @@ func resourceLxcGuest() *schema.Resource {
 			dns.Root:                     dns.Schema(),
 			features.Root:                features.Schema(),
 			guestid.Root:                 guestid.Schema(),
+			ip.RootLxcV4:                 ip.SchemaV4(),
+			ip.RootLxcV6:                 ip.SchemaV6(),
+			ip.RootSkipV4:                ip.SchemaSkipV4(),
+			ip.RootSkipV6:                ip.SchemaSkipV6(),
 			memory.Root:                  memory.Schema(),
 			mounts.RootMount:             mounts.SchemaMount(),
 			mounts.RootMounts:            mounts.SchemaMounts(),
@@ -84,7 +96,18 @@ func resourceLxcGuest() *schema.Resource {
 			swap.Root:                    swap.Schema(),
 			tags.Root:                    tags.Schema(),
 			template.Root:                template.Schema(),
-		},
+			wait.Root:                    wait.Schema(),
+			schemaNetworkTimeout: {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Default:     30,
+				Description: "Timeout in seconds to keep trying to obtain an IP address.",
+				ValidateDiagFunc: func(i any, k cty.Path) diag.Diagnostics {
+					if i.(int) > 0 {
+						return nil
+					}
+					return diag.Errorf(schemaNetworkTimeout + " must be greater than 0")
+				}}},
 		Timeouts: resourceTimeouts(),
 	}
 
@@ -113,6 +136,7 @@ func resourceLxcGuestCreate(ctx context.Context, d *schema.ResourceData, meta an
 		return diags
 	}
 	config.ID = guestid.SDK(d)
+	config.Pool = new(pool.SDK(d))
 	config.Privileged = &privileged
 
 	// Set the node for the LXC container
@@ -161,7 +185,6 @@ func resourceLxcGuestCreate(ctx context.Context, d *schema.ResourceData, meta an
 			OsTemplate:    template.SDK(d),
 			PublicSSHkeys: ssh_public_keys.SDK(d),
 			UserPassword:  password.SDK(d)}
-		config.Pool = util.Pointer(pool.SDK(d))
 		vmr, err = config.Create(ctx, client)
 		if err != nil {
 			return append(diags, diag.Diagnostic{
@@ -174,7 +197,7 @@ func resourceLxcGuestCreate(ctx context.Context, d *schema.ResourceData, meta an
 			Type: id.GuestLxc}.String())
 	}
 
-	return append(diags, resourceLxcGuestRead(ctx, d, vmr, client)...)
+	return append(diags, resourceLxcGuestRead(ctx, d, vmr, client, &version, true)...)
 }
 
 func resourceLxcGuestUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
@@ -235,7 +258,7 @@ func resourceLxcGuestUpdate(ctx context.Context, d *schema.ResourceData, meta an
 			Severity: diag.Error})
 	}
 
-	return append(diags, resourceLxcGuestRead(ctx, d, vmr, client)...)
+	return append(diags, resourceLxcGuestRead(ctx, d, vmr, client, &version, true)...)
 }
 
 func resourceLxcGuestReadWithLock(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
@@ -267,25 +290,21 @@ func resourceLxcGuestReadWithLock(ctx context.Context, d *schema.ResourceData, m
 	if err := client.CheckVmRef(ctx, vmr); err != nil {
 		return append(diags, diag.FromErr(err)...)
 	}
-	return append(diags, resourceLxcGuestRead(ctx, d, vmr, client)...)
+	return append(diags, resourceLxcGuestRead(ctx, d, vmr, client, nil, false)...)
 }
 
-func resourceLxcGuestRead(ctx context.Context, d *schema.ResourceData, vmr *pveSDK.VmRef, client *pveSDK.Client) diag.Diagnostics {
+func resourceLxcGuestRead(ctx context.Context, d *schema.ResourceData, vmr *pveSDK.VmRef, client *pveSDK.Client, version *pveSDK.Version, waitForAgent bool) diag.Diagnostics {
+	newClient := client.New()
 	guestStatus, err := vmr.GetRawGuestStatus(ctx, client)
 	if err != nil {
-		return diag.Diagnostics{{
-			Summary:  err.Error(),
-			Severity: diag.Error}}
+		return diag.FromErr(err)
 	}
 
 	var raw pveSDK.RawConfigLXC
 	var pending bool
 	raw, pending, err = pveSDK.NewActiveRawConfigLXCFromApi(ctx, vmr, client)
 	if err != nil {
-		return diag.Diagnostics{
-			diag.Diagnostic{
-				Summary:  err.Error(),
-				Severity: diag.Error}}
+		return diag.FromErr(err)
 	}
 	reboot.SetRequired(pending, d)
 
@@ -313,17 +332,39 @@ func resourceLxcGuestRead(ctx context.Context, d *schema.ResourceData, vmr *pveS
 	if err = networks.Terraform(config.Networks, d); err != nil {
 		return diag.FromErr(err)
 	}
-	node.Terraform(*config.Node, d)
+	node.Terraform(vmr.Node(), d)
 	operatingsystem.Terraform(config.OperatingSystem, d)
 	pool.Terraform(config.Pool, d)
-	powerstate.Terraform(guestStatus.GetState(), false, d)
+	state := guestStatus.GetState()
+	powerstate.Terraform(state, false, d)
 	privilege.Terraform(*config.Privileged, d)
 	rootmount.Terraform(config.BootMount, d)
 	startatnodeboot.Terraform(*config.StartAtNodeBoot, d)
 	startupshutdown.Terraform(config.StartupShutdown, d)
 	swap.Terraform(config.Swap, d)
 	tags.Terraform(config.Tags, d)
-	return nil
+
+	var diags diag.Diagnostics
+	if state == pveSDK.PowerStateRunning {
+		if len(config.Networks) == 0 {
+			return nil
+		}
+		conn := &connectionInfo{
+			SkipIPv4: d.Get(ip.RootSkipV4).(bool),
+			SkipIPv6: d.Get(ip.RootSkipV6).(bool),
+		}
+		var timeout time.Duration
+		if waitForAgent {
+			timeout = time.Duration(d.Get(schemaNetworkTimeout).(int)) * time.Second
+		}
+		tmpDiags := lxcGetIP(ctx, client, newClient, conn, config.Networks, *vmr, timeout, wait.GetDuration(d), version)
+		if len(tmpDiags) > 0 {
+			diags = append(diags, tmpDiags...)
+		}
+		d.Set(ip.RootLxcV4, conn.IPs.IPv4)
+		d.Set(ip.RootLxcV6, conn.IPs.IPv6)
+	}
+	return diags
 }
 
 func resourceLxcGuestDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
@@ -364,4 +405,52 @@ func lxcGuestWarning() diag.Diagnostics {
 		Detail:   "The LXC Guest resource is experimental. The schema and functionality may change in future releases without a major version bump.",
 		Summary:  "LXC Guest resource is experimental",
 		Severity: diag.Warning}}
+}
+
+func lxcGetIP(ctx context.Context, client *pveSDK.Client, newClient pveSDK.ClientNew, conn *connectionInfo, network pveSDK.LxcNetworks, vmr pveSDK.VmRef, retryDuration, retryInterval time.Duration, version *pveSDK.Version) diag.Diagnostics {
+	var name pveSDK.LxcNetworkName
+	for i := range networks.NetworksAmount {
+		if v, ok := network[pveSDK.LxcNetworkID(i)]; ok {
+			if v.IPv4 != nil && v.IPv4.Address != nil {
+				conn.SkipIPv4 = true
+				conn.IPs.IPv4 = v.IPv4.Address.String()
+			}
+			if v.IPv6 != nil && v.IPv6.Address != nil {
+				conn.SkipIPv6 = true
+				conn.IPs.IPv6 = v.IPv6.Address.String()
+			}
+			name = *v.Name
+			break
+		}
+	}
+	if !conn.SkipIPv4 || !conn.SkipIPv6 {
+		if version == nil {
+			tmpVersion, err := client.Version(ctx)
+			if err != nil {
+				return diag.FromErr(err)
+			}
+			version = &tmpVersion
+		}
+		if version.Encode() < (pveSDK.Version{Major: 9, Minor: 1}.Encode()) {
+			return nil
+		}
+		endTime := time.Now().Add(retryDuration)
+		for {
+			info, err := newClient.LxcGuest.ReadNetworkInterfaceInfo(ctx, vmr)
+			if err != nil {
+				return diag.FromErr(err)
+			}
+			if interfaceInfo, ok := info.SelectName(name); ok {
+				conn.parsePrimaryIPs(interfaceInfo.GetIpAddresses())
+				if conn.hasRequiredIP() {
+					return nil
+				}
+			}
+			if !time.Now().Before(endTime) {
+				return conn.agentDiagnostics(schemaNetworkTimeout, "", "")
+			}
+			time.Sleep(retryInterval)
+		}
+	}
+	return nil
 }

--- a/proxmox/resource_vm_qemu.go
+++ b/proxmox/resource_vm_qemu.go
@@ -22,6 +22,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
 	"github.com/Telmate/terraform-provider-proxmox/v2/proxmox/Internal/resource/guest/description"
+	"github.com/Telmate/terraform-provider-proxmox/v2/proxmox/Internal/resource/guest/ip"
 	"github.com/Telmate/terraform-provider-proxmox/v2/proxmox/Internal/resource/guest/name"
 	"github.com/Telmate/terraform-provider-proxmox/v2/proxmox/Internal/resource/guest/node"
 	"github.com/Telmate/terraform-provider-proxmox/v2/proxmox/Internal/resource/guest/pool"
@@ -42,6 +43,7 @@ import (
 	"github.com/Telmate/terraform-provider-proxmox/v2/proxmox/Internal/resource/guest/startupshutdown"
 	"github.com/Telmate/terraform-provider-proxmox/v2/proxmox/Internal/resource/guest/tags"
 	vmID "github.com/Telmate/terraform-provider-proxmox/v2/proxmox/Internal/resource/guest/vmid"
+	"github.com/Telmate/terraform-provider-proxmox/v2/proxmox/Internal/resource/guest/wait"
 	"github.com/Telmate/terraform-provider-proxmox/v2/proxmox/Internal/resource/id"
 	"github.com/Telmate/terraform-provider-proxmox/v2/proxmox/Internal/util"
 )
@@ -52,10 +54,7 @@ import (
 var thisResource *schema.Resource
 
 const (
-	schemaAdditionalWait = "additional_wait"
-	schemaAgentTimeout   = "agent_timeout"
-	schemaSkipIPv4       = "skip_ipv4"
-	schemaSkipIPv6       = "skip_ipv6"
+	schemaAgentTimeout = "agent_timeout"
 )
 
 func resourceVmQemu() *schema.Resource {
@@ -389,12 +388,7 @@ func resourceVmQemu() *schema.Resource {
 				Default:     10,
 				Description: "Value in second to wait after a VM has been cloned, useful if system is not fast or during I/O intensive parallel terraform tasks",
 			},
-			schemaAdditionalWait: {
-				Type:        schema.TypeInt,
-				Optional:    true,
-				Default:     5,
-				Description: "Value in second to wait after some operations, useful if system is not fast or during I/O intensive parallel terraform tasks",
-			},
+			wait.Root: wait.Schema(),
 			"ci_wait": { // how long to wait before provision
 				Type:     schema.TypeInt,
 				Optional: true,
@@ -444,28 +438,10 @@ func resourceVmQemu() *schema.Resource {
 				Optional: true,
 				ForceNew: true,
 			},
-			schemaSkipIPv4: {
-				Type:          schema.TypeBool,
-				Optional:      true,
-				Default:       false,
-				ConflictsWith: []string{schemaSkipIPv6},
-			},
-			schemaSkipIPv6: {
-				Type:          schema.TypeBool,
-				Optional:      true,
-				Default:       false,
-				ConflictsWith: []string{schemaSkipIPv4},
-			},
-			"default_ipv4_address": {
-				Type:        schema.TypeString,
-				Computed:    true,
-				Description: "Use to track vm ipv4 address",
-			},
-			"default_ipv6_address": {
-				Type:        schema.TypeString,
-				Computed:    true,
-				Description: "Use to track vm ipv6 address",
-			},
+			ip.RootSkipV4:    ip.SchemaSkipV4(),
+			ip.RootSkipV6:    ip.SchemaSkipV6(),
+			ip.RootQemuV4: ip.SchemaV4(),
+			ip.RootQemuV6: ip.SchemaV6(),
 			"define_connection_info": { // by default define SSH for provisioner info
 				Type:        schema.TypeBool,
 				Optional:    true,
@@ -712,7 +688,7 @@ func resourceVmQemuCreate(ctx context.Context, d *schema.ResourceData, meta inte
 	logger.Debug().Int(vmID.Root, int(vmr.VmId())).Msgf("Set this vm (resource Id) to '%v'", d.Id())
 
 	// give sometime to proxmox to catchup
-	time.Sleep(time.Duration(d.Get(schemaAdditionalWait).(int)) * time.Second)
+	time.Sleep(wait.GetDuration(d))
 
 	d.Set("reboot_required", rebootRequired)
 	log.Print("[DEBUG][QemuVmCreate] vm creation done!")
@@ -1264,10 +1240,10 @@ func initConnInfo(ctx context.Context, d *schema.ResourceData, client *pveSDK.Cl
 		config.Networks,
 		vmr,
 		agentTimeout,
-		time.Duration(d.Get(schemaAdditionalWait).(int))*time.Second,
+		wait.GetDuration(d),
 		ciAgentEnabled,
-		d.Get(schemaSkipIPv4).(bool),
-		d.Get(schemaSkipIPv6).(bool),
+		d.Get(ip.RootSkipV4).(bool),
+		d.Get(ip.RootSkipV6).(bool),
 		hasCiDisk)
 	if len(agentDiags) > 0 {
 		diags = append(diags, agentDiags...)
@@ -1285,8 +1261,8 @@ func initConnInfo(ctx context.Context, d *schema.ResourceData, client *pveSDK.Cl
 	logger.Debug().Int(vmID.Root, int(vmr.VmId())).Msgf("this is the vm configuration: %s %s", sshHost, sshPort)
 
 	// Optional convenience attributes for provisioners
-	_ = d.Set("default_ipv4_address", IPs.IPv4)
-	_ = d.Set("default_ipv6_address", IPs.IPv6)
+	_ = d.Set(ip.RootQemuV4, IPs.IPv4)
+	_ = d.Set(ip.RootQemuV6, IPs.IPv6)
 	_ = d.Set("ssh_host", sshHost)
 	_ = d.Set("ssh_port", sshPort)
 
@@ -1392,7 +1368,7 @@ func getPrimaryIP(
 			Summary:  "Qemu Guest Agent is enabled but not installed/working inside the Qemu guest",
 			Severity: diag.Warning}}
 	}
-	return conn.IPs, conn.agentDiagnostics()
+	return conn.IPs, conn.agentDiagnostics(schemaAgentTimeout, "Qemu Guest Agent is enabled but ", "Qemu Guest Agent is enabled in your configuration but ")
 }
 
 // Map struct to the terraform schema

--- a/proxmox/resource_vm_qemu.go
+++ b/proxmox/resource_vm_qemu.go
@@ -99,7 +99,7 @@ func resourceVmQemu() *schema.Resource {
 				Type:        schema.TypeInt,
 				Optional:    true,
 				Default:     90,
-				Description: "Timeout in seconds to keep trying to obtain an IP address from the guest agent one we have a connection.",
+				Description: "Timeout in seconds to keep trying to obtain an IP address from the guest agent.",
 				ValidateDiagFunc: func(i interface{}, k cty.Path) diag.Diagnostics {
 					v, ok := i.(int)
 					if !ok {
@@ -1352,7 +1352,7 @@ func getPrimaryIP(
 			if raw, ok := interfaces.SelectMacAddress(primaryMacAddress); ok {
 				log.Printf("[INFO][getPrimaryIP] Qemu Agent found MAC")
 				logger.Debug().Int(vmID.Root, int(vmr.VmId())).Msgf("Qemu Agent found MAC")
-				conn = conn.parsePrimaryIPs(raw.GetIpAddresses())
+				conn.parsePrimaryIPs(raw.GetIpAddresses())
 				if conn.hasRequiredIP() {
 					return conn.IPs, diag.Diagnostics{}
 				}

--- a/proxmox/resource_vm_qemu_test.go
+++ b/proxmox/resource_vm_qemu_test.go
@@ -28,10 +28,11 @@ func testAccPreCheck(t *testing.T) {
 	}
 }
 
-func testAccProxmoxProviderFactory() map[string]*schema.Provider {
-	providers := map[string]*schema.Provider{
-		"proxmox": Provider(),
-	}
+func testAccProxmoxProviderFactory() map[string]func() (*schema.Provider, error) {
+	providers := map[string]func() (*schema.Provider, error){
+		"proxmox": func() (*schema.Provider, error) {
+			return Provider(), nil
+		}}
 	// TODO move this log configuration elsewhere, it doesn't make sense here but
 	// it's a short term solution to test the testing out
 	ConfigureLogger(true, "../../acctest.log", map[string]string{"_default": "debug", "_capturelog": ""})
@@ -207,8 +208,8 @@ func TestAccProxmoxVmQemu_BasicCreate(t *testing.T) {
 	resourcePath := fmt.Sprintf("proxmox_vm_qemu.%s", resourceName)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProxmoxProviderFactory(),
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProxmoxProviderFactory(),
 		//CheckDestroy: testAccCheckExampleResourceDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -228,8 +229,8 @@ func TestAccProxmoxVmQemu_StandardCreate(t *testing.T) {
 	resourcePath := fmt.Sprintf("proxmox_vm_qemu.%s", resourceName)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProxmoxProviderFactory(),
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProxmoxProviderFactory(),
 		//CheckDestroy: testAccCheckExampleResourceDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -274,8 +275,8 @@ func TestAccProxmoxVmQemu_BasicCreateClone(t *testing.T) {
 	clonePath := fmt.Sprintf("proxmox_vm_qemu.%s", cloneName)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProxmoxProviderFactory(),
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProxmoxProviderFactory(),
 		//CheckDestroy: testAccCheckExampleResourceDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -301,8 +302,8 @@ func TestAccProxmoxVmQemu_CreateCloneWithTwoDisks(t *testing.T) {
 	clonePath := fmt.Sprintf("proxmox_vm_qemu.%s", cloneName)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProxmoxProviderFactory(),
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProxmoxProviderFactory(),
 		//CheckDestroy: testAccCheckExampleResourceDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -328,8 +329,8 @@ func TestAccProxmoxVmQemu_PxeCreate(t *testing.T) {
 	resourcePath := fmt.Sprintf("proxmox_vm_qemu.%s", resourceName)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProxmoxProviderFactory(),
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProxmoxProviderFactory(),
 		//CheckDestroy: testAccCheckExampleResourceDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -349,8 +350,8 @@ func TestAccProxmoxVmQemu_UpdateNoReboot(t *testing.T) {
 	resourcePath := fmt.Sprintf("proxmox_vm_qemu.%s", resourceName)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProxmoxProviderFactory(),
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProxmoxProviderFactory(),
 
 		Steps: []resource.TestStep{
 			{
@@ -378,8 +379,8 @@ func TestAccProxmoxVmQemu_UpdateRebootRequired(t *testing.T) {
 	resourcePath := fmt.Sprintf("proxmox_vm_qemu.%s", resourceName)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProxmoxProviderFactory(),
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProxmoxProviderFactory(),
 
 		Steps: []resource.TestStep{
 			{


### PR DESCRIPTION
Added support for getting the Lxc network info.

Fixed and issue where pool wasn't returned correctly.
Fixed an issue where `target_node` wasn't returned correctly.

By updating `proxmox-api-go` resolves #1542