### PR TITLE
Fix phantom diff. Use power_state and fallback to vm_state if not set

### DIFF
--- a/docs/guides/cloud-init getting started.md
+++ b/docs/guides/cloud-init getting started.md
@@ -75,7 +75,7 @@ resource "proxmox_vm_qemu" "cloudinit-example" {
   boot        = "order=scsi0" # has to be the same as the OS disk of the template
   clone       = "debian12-cloudinit" # The name of the template
   scsihw      = "virtio-scsi-single"
-  vm_state    = "running"
+  power_state = "running"
   automatic_reboot = true
 
   # Cloud-Init configuration

--- a/proxmox/Internal/resource/guest/powerstate/sdk.go
+++ b/proxmox/Internal/resource/guest/powerstate/sdk.go
@@ -16,8 +16,10 @@ type LegacyEnum uint8
 
 func SDK(legacy LegacyEnum, d *schema.ResourceData) *pveSDK.PowerState {
 	v, ok := d.GetOk(Root)
-	if !ok && legacy > LegacyFalse {
-		return sdkLegacy(d)
+	if legacy > LegacyFalse {
+		if _, okLegacy := d.GetOk(LegacyRoot); okLegacy || !ok {
+			return sdkLegacy(d)
+		}
 	}
 	switch v.(string) {
 	case enumRunning:

--- a/proxmox/Internal/resource/guest/powerstate/terraform.go
+++ b/proxmox/Internal/resource/guest/powerstate/terraform.go
@@ -6,18 +6,12 @@ import (
 )
 
 func Terraform(config pveSDK.PowerState, legacy bool, d *schema.ResourceData) {
-	if _, ok := d.GetOk(Root); ok {
-		d.Set(Root, terraform(config))
-		if legacy {
-			terraformLegacyClear(d)
-		}
-		return
-	}
 	if legacy {
 		if _, ok := d.GetOk(LegacyRoot); ok {
 			terraformLegacy(config,d)
 			return
 		}
+		terraformLegacyClear(d)
 	}
 	d.Set(Root, terraform(config))
 }

--- a/proxmox/resource_vm_qemu.go
+++ b/proxmox/resource_vm_qemu.go
@@ -69,21 +69,15 @@ func resourceVmQemu() *schema.Resource {
 		CustomizeDiff: customdiff.All(
 			customdiff.ComputedIf(
 				"ssh_host",
-				func(ctx context.Context, d *schema.ResourceDiff, meta interface{}) bool {
-					return d.HasChange("vm_state")
-				},
+				powerStateChanged,
 			),
 			customdiff.ComputedIf(
 				"default_ipv4_address",
-				func(ctx context.Context, d *schema.ResourceDiff, meta interface{}) bool {
-					return d.HasChange("vm_state")
-				},
+				powerStateChanged,
 			),
 			customdiff.ComputedIf(
 				"ssh_port",
-				func(ctx context.Context, d *schema.ResourceDiff, meta interface{}) bool {
-					return d.HasChange("vm_state")
-				},
+				powerStateChanged,
 			),
 			efi.CustomizeDiff(),
 			reboot.CustomizeDiff(),
@@ -125,7 +119,7 @@ func resourceVmQemu() *schema.Resource {
 				Description:      "The VM bios, it can be seabios or ovmf",
 				ValidateDiagFunc: BIOSValidator(),
 			},
-			powerstate.Root:            powerstate.Schema(schema.Schema{}),
+			powerstate.Root:            powerstate.Schema(schema.Schema{Computed: true}),
 			powerstate.LegacyRoot:      powerstate.SchemaLegacy(),
 			startatnodeboot.LegacyRoot: startatnodeboot.LegacySchema(),
 			startatnodeboot.Root:       startatnodeboot.Schema(),
@@ -459,6 +453,10 @@ func resourceVmQemu() *schema.Resource {
 		Timeouts: resourceTimeouts(),
 	}
 	return thisResource
+}
+
+func powerStateChanged(ctx context.Context, d *schema.ResourceDiff, meta interface{}) bool {
+	return d.HasChange(powerstate.Root) || d.HasChange(powerstate.LegacyRoot)
 }
 
 func resourceVmQemuCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
@@ -896,7 +894,6 @@ func resourceVmQemuRead(ctx context.Context, d *schema.ResourceData, vmr *pveSDK
 	}
 	state := guestStatus.GetState()
 	log.Print("[DEBUG] Getting VM state" + state.String())
-	d.Set("vm_state", state.String())
 	if state == pveSDK.PowerStateRunning {
 		log.Printf("[DEBUG] VM is running, checking the IP")
 		// TODO when network interfaces are reimplemented check if we have an interface before getting the connection info


### PR DESCRIPTION
This is my attempt at fixing the phantom diff.

Root cause was the `d.Set("vm_state", state.String())` always setting the value, no matter if its configured or not.

---

Behaviour on `terraform plan` or `terraform apply`, without any changes

**Current:**
```shell
...
  # proxmox_vm_qemu.vm["vm-10"] will be updated in-place
  ~ resource "proxmox_vm_qemu" "vm" {
      ~ default_ipv4_address      = "10.10.10.10" -> (known after apply)
        id                        = "node1/qemu/10"
        name                      = "vm-10"
      ~ ssh_host                  = "10.10.10.10" -> (known after apply)
      ~ ssh_port                  = "22" -> (known after apply)
        tags                      = "terraform"
      - vm_state                  = "running" -> null
        # (52 unchanged attributes hidden)

        # (7 unchanged blocks hidden)
    }
...
    
Plan: 0 to add, 8 to change, 0 to destroy.
```

**After/expected:**
```shell
No changes. Your infrastructure matches the configuration.
```

